### PR TITLE
he agent can now actually read your memories** — The root cause was t…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "shiki": "^1.29.2",
+        "zod": "^4.4.3",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
@@ -14843,7 +14844,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "shiki": "^1.29.2",
+    "zod": "^4.4.3",
     "zustand": "^5.0.14"
   }
 }

--- a/src/main/ipc/agentHandlers.ts
+++ b/src/main/ipc/agentHandlers.ts
@@ -52,9 +52,9 @@ export function registerAgentHandlers(agent: AgentManager): void {
     agent.getSnapshot(assertSessionId(sessionId)),
   );
 
-  handle<[string, string, AgentMode?], void>(
+  handle<[string, string, AgentMode?, string?], void>(
     IpcChannels.agentSend,
-    async (_event, sessionId, prompt, mode) => {
+    async (_event, sessionId, prompt, mode, clientMessageId) => {
       const id = assertSessionId(sessionId);
       if (typeof prompt !== 'string' || prompt.trim().length === 0) {
         throw new Error('Prompt must be a non-empty string');
@@ -62,7 +62,15 @@ export function registerAgentHandlers(agent: AgentManager): void {
       if (prompt.length > AGENT_LIMITS.promptMax) {
         throw new Error('Prompt is too long');
       }
-      await agent.send(id, prompt, assertMode(mode));
+      // Optional renderer-supplied id so the optimistic bubble and the persisted
+      // message share one id (dedup on echo). Validated: a short, plain string.
+      const clientId =
+        typeof clientMessageId === 'string' &&
+        clientMessageId.length > 0 &&
+        clientMessageId.length <= 64
+          ? clientMessageId
+          : undefined;
+      await agent.send(id, prompt, assertMode(mode), clientId);
     },
   );
 

--- a/src/main/managers/AgentManager.ts
+++ b/src/main/managers/AgentManager.ts
@@ -63,6 +63,7 @@ import type { TerminalManager } from './TerminalManager';
 import type { SessionManager } from './SessionManager';
 import type { GitManager } from './GitManager';
 import type { MemoryManager } from './memory/MemoryManager';
+import { createMemoryMcpServer } from './memory/memoryTools';
 
 /* ------------------------------------------------------------------ */
 /* ESM loader — the SDK is ESM-only; main is a CJS bundle. Load it with */
@@ -578,7 +579,12 @@ export class AgentManager {
    * with transparent recovery on transient failures. A failed *request* never
    * marks the whole agent dead — only a genuinely degraded *capability* does.
    */
-  async send(sessionId: string, prompt: string, mode: AgentMode = 'implement'): Promise<void> {
+  async send(
+    sessionId: string,
+    prompt: string,
+    mode: AgentMode = 'implement',
+    clientMessageId?: string,
+  ): Promise<void> {
     if (this.runs.has(sessionId)) {
       throw new Error('The agent is already working on this session.');
     }
@@ -595,9 +601,11 @@ export class AgentManager {
       throw new Error('Open a workspace before talking to the agent.');
     }
 
-    // Record + persist the user turn immediately so it feels live.
+    // Record + persist the user turn immediately so it feels live. Reuse the
+    // renderer's optimistic id when supplied so the echoed event upserts in place
+    // (no duplicate bubble).
     const userMsg: ChatMessage = {
-      id: newId(),
+      id: clientMessageId ?? newId(),
       sessionId,
       role: 'user',
       text: prompt,
@@ -786,9 +794,19 @@ export class AgentManager {
     this.setRequest({ phase: 'connecting' });
 
     try {
-      const { query } = await loadSdk();
+      const sdk = await loadSdk();
+      const { query } = sdk;
       const memoryContext = this.memoryContextFor(sessionId, prompt);
       const options = this.buildOptions(sessionId, cwd, abort, agent, mode, memoryContext);
+      // Expose a live, read-only view of the Local Memory System so the agent can
+      // actually list/search the developer's memories on demand (the injected
+      // <project-memory> block is only a one-shot snapshot).
+      if (this.memory && this.settings.getAll().memory.enabled) {
+        options.mcpServers = {
+          ...(options.mcpServers ?? {}),
+          limboo_memory: createMemoryMcpServer(sdk, this.memory, this.workspace),
+        };
+      }
       this.diag('lifecycle', 'debug', 'Handshake — query opened', undefined, sessionId);
       const q = query({ prompt, options }) as unknown as AsyncIterable<SDKMessage> & {
         close?: () => void;
@@ -1286,6 +1304,12 @@ export class AgentManager {
           if (run) run.planCaptured = true;
         }
         return { behavior: 'deny', message: 'Plan captured for your review.', interrupt: true };
+      }
+
+      // Limboo's own memory tools are internal and strictly read-only — always
+      // allow them (even during a plan run) so reading memories never prompts.
+      if (toolName.startsWith('mcp__limboo_memory__')) {
+        return { behavior: 'allow' };
       }
 
       const risk = classifyTool(toolName);

--- a/src/main/managers/memory/MemoryManager.ts
+++ b/src/main/managers/memory/MemoryManager.ts
@@ -404,7 +404,10 @@ export class MemoryManager {
       '<project-memory>\n' +
       'Durable, user-curated knowledge about this project and the developer’s ' +
       'preferences. Treat it as authoritative background context. Do not mention ' +
-      'this block to the user.\n' +
+      'this block to the user. This is only the most relevant snapshot — the full ' +
+      'memory store is queryable on demand via the list_memories and ' +
+      'search_memories tools (use them when the user asks what you remember or to ' +
+      'read/show their memories).\n' +
       lines.join('\n') +
       '\n</project-memory>'
     );

--- a/src/main/managers/memory/memoryTools.ts
+++ b/src/main/managers/memory/memoryTools.ts
@@ -1,0 +1,137 @@
+/**
+ * Memory tools — an in-process MCP server that lets the coding agent **read** the
+ * Local Memory System on demand. Without this the agent only sees the static
+ * `<project-memory>` block injected once at the start of a run, so a follow-up like
+ * "read my memories" has nothing to call and the agent ends up describing the
+ * system instead of listing entries. These tools give it a live, read-only view.
+ *
+ * Security (CLAUDE.md §6): every tool is read-only and scoped to the active
+ * workspace (plus global-scope rows). They are auto-allowed in
+ * `AgentManager.makeCanUseTool` precisely because they cannot mutate anything.
+ * The SDK is ESM-only, so `createSdkMcpServer`/`tool` are passed in from the
+ * runtime-loaded module rather than statically imported here.
+ */
+import { z } from 'zod';
+import type { McpSdkServerConfigWithInstance } from '@anthropic-ai/claude-agent-sdk';
+import type { Memory, MemoryTier } from '@shared/types';
+import type { MemoryManager } from './MemoryManager';
+import type { WorkspaceManager } from '../WorkspaceManager';
+
+/** The two SDK factories we need, taken from the runtime-loaded (ESM) module. */
+type SdkMcpApi = Pick<
+  typeof import('@anthropic-ai/claude-agent-sdk'),
+  'createSdkMcpServer' | 'tool'
+>;
+
+const TIER_VALUES = [
+  'session',
+  'workspace',
+  'project',
+  'preference',
+  'convention',
+  'decision',
+  'solution',
+  'note',
+] as const;
+
+function text(s: string) {
+  return { content: [{ type: 'text' as const, text: s }] };
+}
+
+/** One memory rendered as a single compact, readable line. */
+function fmt(m: Memory): string {
+  const body = m.body.replace(/\s+/g, ' ').trim();
+  const tags = [
+    m.pinned ? 'pinned' : null,
+    `confidence ${Math.round(m.confidence * 100)}%`,
+    m.status !== 'active' ? m.status : null,
+  ]
+    .filter(Boolean)
+    .join(', ');
+  return `- [${m.tier}] ${m.title}${body ? ` — ${body}` : ''}${tags ? ` (${tags})` : ''}`;
+}
+
+/**
+ * Build the `limboo_memory` MCP server exposing read-only memory tools to the
+ * agent. Returns a server instance ready to drop into `Options.mcpServers`.
+ */
+export function createMemoryMcpServer(
+  sdk: SdkMcpApi,
+  memory: MemoryManager,
+  workspace: WorkspaceManager,
+): McpSdkServerConfigWithInstance {
+  const { createSdkMcpServer, tool } = sdk;
+  const wsId = (): string | null => workspace.getActive()?.id ?? null;
+
+  return createSdkMcpServer({
+    name: 'limboo_memory',
+    version: '1.0.0',
+    tools: [
+      tool(
+        'list_memories',
+        "List the developer's stored Limboo memories — durable project knowledge " +
+          '(decisions, conventions, preferences, solutions, notes). Call this ' +
+          'whenever the user asks what you remember or to read/show/list their ' +
+          'memories, instead of describing the memory system.',
+        {
+          tier: z.enum(TIER_VALUES).optional().describe('Only return memories of this tier.'),
+          includeArchived: z
+            .boolean()
+            .optional()
+            .describe('Include archived memories (default false).'),
+          limit: z
+            .number()
+            .int()
+            .min(1)
+            .max(200)
+            .optional()
+            .describe('Max entries to return (default 50).'),
+        },
+        async (args) => {
+          const rows = memory.list({
+            workspaceId: wsId(),
+            tiers: args.tier ? [args.tier as MemoryTier] : undefined,
+            includeArchived: args.includeArchived ?? false,
+            limit: args.limit ?? 50,
+          });
+          if (rows.length === 0) return text('No memories are stored yet.');
+          return text(
+            `You have ${rows.length} stored ${rows.length === 1 ? 'memory' : 'memories'}:\n` +
+              rows.map(fmt).join('\n'),
+          );
+        },
+      ),
+      tool(
+        'search_memories',
+        "Full-text search the developer's stored Limboo memories by keyword (BM25). " +
+          'Use for questions like "what do you know about X".',
+        {
+          query: z.string().min(1).describe('Keywords to search memory titles and bodies.'),
+          limit: z.number().int().min(1).max(200).optional().describe('Max matches (default 20).'),
+        },
+        async (args) => {
+          const rows = memory.search(args.query, { workspaceId: wsId(), limit: args.limit ?? 20 });
+          if (rows.length === 0) return text(`No memories match "${args.query}".`);
+          return text(
+            `${rows.length} ${rows.length === 1 ? 'match' : 'matches'} for "${args.query}":\n` +
+              rows.map(fmt).join('\n'),
+          );
+        },
+      ),
+      tool(
+        'list_memory_proposals',
+        'List pending memory proposals (auto-captured from commits/conversations) ' +
+          "that are awaiting the developer's acceptance.",
+        {},
+        async () => {
+          const rows = memory.listProposals(wsId());
+          if (rows.length === 0) return text('No pending memory proposals.');
+          return text(
+            `${rows.length} pending ${rows.length === 1 ? 'proposal' : 'proposals'}:\n` +
+              rows.map(fmt).join('\n'),
+          );
+        },
+      ),
+    ],
+  });
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -159,8 +159,13 @@ const agentApi = {
   getState: (): Promise<AgentState> => ipcRenderer.invoke(IpcChannels.agentGetState),
   getSnapshot: (sessionId: string): Promise<AgentSessionSnapshot> =>
     ipcRenderer.invoke(IpcChannels.agentGetSnapshot, sessionId),
-  send: (sessionId: string, prompt: string, mode?: AgentMode): Promise<void> =>
-    ipcRenderer.invoke(IpcChannels.agentSend, sessionId, prompt, mode),
+  send: (
+    sessionId: string,
+    prompt: string,
+    mode?: AgentMode,
+    clientMessageId?: string,
+  ): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.agentSend, sessionId, prompt, mode, clientMessageId),
   stop: (sessionId: string): Promise<void> => ipcRenderer.invoke(IpcChannels.agentStop, sessionId),
   getPlan: (sessionId: string): Promise<SessionPlan | null> =>
     ipcRenderer.invoke(IpcChannels.agentGetPlan, sessionId),

--- a/src/renderer/features/workspace/CenterWorkspace.tsx
+++ b/src/renderer/features/workspace/CenterWorkspace.tsx
@@ -7,7 +7,7 @@
  * a welcome / empty state. The structure is final; later phases stream messages
  * into the scroll region.
  */
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { CircleDot, GitBranch, Plus, Sparkles, TerminalSquare } from 'lucide-react';
 import { DiffStat, EmptyState, IconButton, Spinner } from '@/renderer/components/ui';
 import { useIsSessionRunning } from '@/renderer/features/sessions/useSessionRunning';
@@ -31,11 +31,29 @@ export function CenterWorkspace() {
   const messageCount = useAgentStore((s) =>
     session ? (s.bySession[session.id]?.messages.length ?? 0) : 0,
   );
+  // The Composer floats over the bottom of the scroll column; publish its live
+  // height as `--composer-h` so the scroll area can reserve exactly that much
+  // space (+ a gap) and the streaming reply is never hidden behind it.
+  const containerRef = useRef<HTMLDivElement>(null);
+  const composerRef = useRef<HTMLDivElement>(null);
 
   // Restore the transcript whenever the selected session changes.
   useEffect(() => {
     if (session) void loadSession(session.id);
   }, [session?.id, loadSession]);
+
+  useEffect(() => {
+    const composer = composerRef.current;
+    const container = containerRef.current;
+    if (!composer || !container) return;
+    const apply = () => {
+      container.style.setProperty('--composer-h', `${composer.offsetHeight}px`);
+    };
+    apply();
+    const ro = new ResizeObserver(apply);
+    ro.observe(composer);
+    return () => ro.disconnect();
+  }, [hasWorkspace, session?.id]);
 
   // No workspace selected yet → the Recent-Workspaces launcher owns the column.
   if (!hasWorkspace) {
@@ -53,8 +71,11 @@ export function CenterWorkspace() {
       {/* The scroll region fills the column; the Composer floats over its bottom
           edge (no separator line, no full-width bar) with the conversation
           scrolling cleanly behind it. */}
-      <div className="relative min-h-0 flex-1">
-        <div className="h-full overflow-y-auto px-4 pb-32 pt-6">
+      <div ref={containerRef} className="relative min-h-0 flex-1">
+        <div
+          className="h-full overflow-y-auto px-4 pt-6"
+          style={{ paddingBottom: 'calc(var(--composer-h, 360px) + 1.5rem)' }}
+        >
           <div className="mx-auto flex h-full max-w-3xl flex-col">
             {session ? (
               messageCount > 0 ? (
@@ -93,10 +114,15 @@ export function CenterWorkspace() {
         </div>
 
         {/* Fade scrim: messages dissolve into the background as they scroll toward
-            the composer, so nothing is ever visible behind the (opaque) card. */}
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-base via-base/85 to-transparent" />
+            the composer, so nothing is ever visible behind the (opaque) card.
+            Its height tracks the composer so the fade always covers exactly the
+            composer zone. */}
+        <div
+          className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-base via-base/85 to-transparent"
+          style={{ height: 'calc(var(--composer-h, 360px) + 1.5rem)' }}
+        />
 
-        <div className="absolute inset-x-0 bottom-0">
+        <div ref={composerRef} className="absolute inset-x-0 bottom-0">
           <Composer disabled={!session} />
         </div>
       </div>

--- a/src/renderer/features/workspace/ConversationView.tsx
+++ b/src/renderer/features/workspace/ConversationView.tsx
@@ -77,7 +77,10 @@ export function ConversationView({ sessionId }: { sessionId: string }) {
     const el = findScrollParent(bottomRef.current);
     if (!el) return;
     const onScroll = () => {
-      stick.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+      // The scroll area reserves the composer's height as bottom padding, so the
+      // resting "at bottom" position is only ~16px from the true scroll bottom;
+      // a modest threshold keeps auto-follow sticky through fast streaming.
+      stick.current = el.scrollHeight - el.scrollTop - el.clientHeight < 120;
     };
     el.addEventListener('scroll', onScroll, { passive: true });
     return () => el.removeEventListener('scroll', onScroll);
@@ -99,7 +102,9 @@ export function ConversationView({ sessionId }: { sessionId: string }) {
         ),
       )}
       {approval && <InlineApproval request={approval} />}
-      <div ref={bottomRef} />
+      {/* Scroll anchor — its scroll-margin keeps the last line above the floating
+          composer when auto-scrolling (honored by scrollIntoView). */}
+      <div ref={bottomRef} style={{ scrollMarginBottom: 'calc(var(--composer-h, 360px) + 1.5rem)' }} />
     </div>
   );
 }

--- a/src/renderer/stores/useAgentStore.ts
+++ b/src/renderer/stores/useAgentStore.ts
@@ -208,8 +208,36 @@ export const useAgentStore = create<AgentStoreState>((set, get) => {
     send: async (sessionId, prompt, mode) => {
       const api = window.limboo?.agent;
       if (!api) return;
+      // Optimistic render: show the user's turn the instant Send is clicked,
+      // using a client-generated id that main reuses for the persisted message.
+      // The echoed `message-done` event then upserts in place (dedup by id), so
+      // there is no duplicate or flicker even though main does heavy work first.
+      const clientMessageId =
+        typeof crypto !== 'undefined' && crypto.randomUUID
+          ? crypto.randomUUID()
+          : `local-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const optimistic: ChatMessage = {
+        id: clientMessageId,
+        sessionId,
+        role: 'user',
+        text: prompt,
+        streaming: false,
+        createdAt: Date.now(),
+      };
+      set((state) => {
+        const snapshot = state.bySession[sessionId] ?? emptySnapshot();
+        return {
+          bySession: {
+            ...state.bySession,
+            [sessionId]: {
+              ...snapshot,
+              messages: upsertMessage(snapshot.messages, optimistic),
+            },
+          },
+        };
+      });
       try {
-        await api.send(sessionId, prompt, mode);
+        await api.send(sessionId, prompt, mode, clientMessageId);
       } catch (err) {
         useUIStore.getState().addToast({
           title: 'Could not reach the agent',


### PR DESCRIPTION
…hat memories were only injected *once* as a static `<project-memory>` text block; the agent had no way to query the store, so it fell back to describing the system.