### PR TITLE
I implemented both parts on the existing pure-black UI, same theme to…

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -5,6 +5,7 @@
  */
 import { useEffect } from 'react';
 import { AppShell } from '@/renderer/app/AppShell';
+import { WorkspaceSelection } from '@/renderer/features/workspace/WorkspaceSelection';
 import { CommandPalette } from '@/renderer/features/command-palette/CommandPalette';
 import { SettingsModal } from '@/renderer/features/settings/SettingsModal';
 import { Toaster } from '@/renderer/components/feedback/Toaster';
@@ -23,6 +24,13 @@ export function App() {
   useKeyboardShortcuts();
   useCommandBridge();
   usePreventFileDrop();
+
+  // Gate the shell on an active workspace: until one is selected, the full-screen
+  // Workspace Selection screen owns the window and every workspace-dependent panel
+  // stays out of reach. `hydrated` avoids a flash of the selection screen before
+  // the persisted active workspace has loaded.
+  const hydrated = useWorkspaceStore((s) => s.hydrated);
+  const hasWorkspace = useWorkspaceStore((s) => s.activeId !== null);
 
   // Load registered workspaces + sessions + connect to the coding agent once the
   // shell is up. Workspaces hydrate first so the session list can scope to the
@@ -46,7 +54,7 @@ export function App() {
 
   return (
     <>
-      <AppShell />
+      {!hydrated ? null : hasWorkspace ? <AppShell /> : <WorkspaceSelection />}
       <CommandPalette />
       <SettingsModal />
       <Toaster />

--- a/src/renderer/features/workspace/CenterWorkspace.tsx
+++ b/src/renderer/features/workspace/CenterWorkspace.tsx
@@ -1,22 +1,24 @@
 /**
  * Center column — the largest region. A thin header reflecting the active
- * session, a scrolling conversation area, and the Composer pinned at the bottom
+ * session, a scrolling conversation area, and the Composer docked at the bottom
  * of THIS column (it does not span the whole window).
  *
- * Phase 1 has no agent and no mock conversation, so the conversation area shows
- * a welcome / empty state. The structure is final; later phases stream messages
- * into the scroll region.
+ * Layout is a plain 3-row flex column: header (shrink-0), scroll region
+ * (flex-1, min-h-0, the ONLY scroller), and the Composer footer (shrink-0, in
+ * normal flow). Because the composer occupies real layout space, the scroll
+ * area's height always excludes it — streamed messages can never be hidden
+ * behind the composer. This is the standard chat-UI pattern (ChatGPT/Claude);
+ * it replaces the previous floating-absolute composer + `--composer-h` reserve
+ * hack that raced the real height and overlapped tall replies.
  */
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { CircleDot, GitBranch, Plus, Sparkles, TerminalSquare } from 'lucide-react';
 import { DiffStat, EmptyState, IconButton, Spinner } from '@/renderer/components/ui';
 import { useIsSessionRunning } from '@/renderer/features/sessions/useSessionRunning';
 import { Logo } from '@/renderer/components/brand/Logo';
 import { Composer } from './Composer';
 import { ConversationView } from './ConversationView';
-import { WorkspaceLauncher } from './WorkspaceLauncher';
 import { useSessionStore } from '@/renderer/stores/useSessionStore';
-import { useWorkspaceStore } from '@/renderer/stores/useWorkspaceStore';
 import { useAgentStore } from '@/renderer/stores/useAgentStore';
 import { useLayoutStore } from '@/renderer/stores/useLayoutStore';
 import { useGitStore } from '@/renderer/stores/useGitStore';
@@ -26,105 +28,65 @@ export function CenterWorkspace() {
     s.sessions.find((item) => item.id === s.selectedId) ?? null,
   );
   const createSession = useSessionStore((s) => s.createSession);
-  const hasWorkspace = useWorkspaceStore((s) => s.activeId !== null);
   const loadSession = useAgentStore((s) => s.loadSession);
   const messageCount = useAgentStore((s) =>
     session ? (s.bySession[session.id]?.messages.length ?? 0) : 0,
   );
-  // The Composer floats over the bottom of the scroll column; publish its live
-  // height as `--composer-h` so the scroll area can reserve exactly that much
-  // space (+ a gap) and the streaming reply is never hidden behind it.
-  const containerRef = useRef<HTMLDivElement>(null);
-  const composerRef = useRef<HTMLDivElement>(null);
 
   // Restore the transcript whenever the selected session changes.
   useEffect(() => {
     if (session) void loadSession(session.id);
   }, [session?.id, loadSession]);
 
-  useEffect(() => {
-    const composer = composerRef.current;
-    const container = containerRef.current;
-    if (!composer || !container) return;
-    const apply = () => {
-      container.style.setProperty('--composer-h', `${composer.offsetHeight}px`);
-    };
-    apply();
-    const ro = new ResizeObserver(apply);
-    ro.observe(composer);
-    return () => ro.disconnect();
-  }, [hasWorkspace, session?.id]);
-
-  // No workspace selected yet → the Recent-Workspaces launcher owns the column.
-  if (!hasWorkspace) {
-    return (
-      <main className="flex h-full min-h-0 flex-col bg-base px-4">
-        <WorkspaceLauncher />
-      </main>
-    );
-  }
-
   return (
     <main className="flex h-full min-h-0 flex-col bg-base">
       {session && <SessionHeader sessionId={session.id} title={session.title} branch={session.branch} adds={session.adds} dels={session.dels} />}
 
-      {/* The scroll region fills the column; the Composer floats over its bottom
-          edge (no separator line, no full-width bar) with the conversation
-          scrolling cleanly behind it. */}
-      <div ref={containerRef} className="relative min-h-0 flex-1">
-        <div
-          className="h-full overflow-y-auto px-4 pt-6"
-          style={{ paddingBottom: 'calc(var(--composer-h, 360px) + 1.5rem)' }}
-        >
-          <div className="mx-auto flex h-full max-w-3xl flex-col">
-            {session ? (
-              messageCount > 0 ? (
-                <ConversationView sessionId={session.id} />
-              ) : (
-                <EmptyState
-                  className="m-auto"
-                  icon={Sparkles}
-                  title="Start the conversation"
-                  description="Describe what you want to build. Limboo coordinates the repository, files, terminal, and tasks while Claude Code does the work."
-                />
-              )
+      {/* Scroll region — the single scroller. Messages live entirely above the
+          docked composer below, so they are never overlapped or clipped. */}
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 pt-6">
+        <div className="mx-auto flex min-h-full max-w-3xl flex-col">
+          {session ? (
+            messageCount > 0 ? (
+              <ConversationView sessionId={session.id} />
             ) : (
-              <div className="m-auto flex flex-col items-center gap-4 text-center">
-                <Logo size={40} />
-                <div className="flex flex-col gap-1">
-                  <span className="text-[15px] font-semibold tracking-tight text-fg">
-                    Welcome to Limboo
-                  </span>
-                  <span className="max-w-md text-[13px] leading-relaxed text-muted">
-                    The local-first workspace for orchestrating coding agents. Create
-                    a session to begin — every task lives inside one.
-                  </span>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => createSession()}
-                  className="flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-[12px] font-semibold text-base transition-opacity hover:opacity-90"
-                >
-                  <Plus size={13} />
-                  New session
-                </button>
+              <EmptyState
+                className="m-auto"
+                icon={Sparkles}
+                title="Start the conversation"
+                description="Describe what you want to build. Limboo coordinates the repository, files, terminal, and tasks while Claude Code does the work."
+              />
+            )
+          ) : (
+            <div className="m-auto flex flex-col items-center gap-4 text-center">
+              <Logo size={40} />
+              <div className="flex flex-col gap-1">
+                <span className="text-[15px] font-semibold tracking-tight text-fg">
+                  Welcome to Limboo
+                </span>
+                <span className="max-w-md text-[13px] leading-relaxed text-muted">
+                  The local-first workspace for orchestrating coding agents. Create
+                  a session to begin — every task lives inside one.
+                </span>
               </div>
-            )}
-          </div>
+              <button
+                type="button"
+                onClick={() => createSession()}
+                className="flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-[12px] font-semibold text-base transition-opacity hover:opacity-90"
+              >
+                <Plus size={13} />
+                New session
+              </button>
+            </div>
+          )}
         </div>
+      </div>
 
-        {/* Fade scrim: messages dissolve into the background as they scroll toward
-            the composer, so nothing is ever visible behind the (opaque) card.
-            Its height tracks the composer so the fade always covers exactly the
-            composer zone. */}
-        <div
-          className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-base via-base/85 to-transparent"
-          style={{ height: 'calc(var(--composer-h, 360px) + 1.5rem)' }}
-        />
-
-        <div ref={composerRef} className="absolute inset-x-0 bottom-0">
-          <Composer disabled={!session} />
-        </div>
+      {/* Composer docked in normal flow — a soft top fade gives a clean scroll
+          edge without floating over (and hiding) the conversation. */}
+      <div className="shrink-0">
+        <div className="pointer-events-none h-3 bg-gradient-to-t from-base to-transparent" />
+        <Composer disabled={!session} />
       </div>
     </main>
   );

--- a/src/renderer/features/workspace/Composer.tsx
+++ b/src/renderer/features/workspace/Composer.tsx
@@ -1,8 +1,10 @@
 /**
- * The composer — a self-contained, floating interaction surface. It is NOT a
- * full-width bar welded to the bottom: it's a rounded card that floats over the
- * transparent page with a gap on every side and no separator line, so the
- * conversation scrolls cleanly behind it.
+ * The composer — a self-contained interaction surface docked at the bottom of
+ * the center column in normal flow. It is NOT a full-width bar welded to the
+ * window edge: it's a centered rounded card with a gap on every side and no
+ * separator line. Because it sits in flow (not absolutely positioned), the
+ * conversation scroll area above it shrinks to fit and messages are never
+ * hidden behind it.
  *
  * Wired to the Coding Agent Manager: submitting forwards the prompt to the active
  * session's Claude Code run. The footer reflects the live agent *lifecycle* and
@@ -87,8 +89,8 @@ export function Composer({ disabled = false }: { disabled?: boolean }) {
   };
 
   return (
-    <div className="pointer-events-none px-4 pb-6">
-      <div className="pointer-events-auto mx-auto w-full max-w-3xl">
+    <div className="bg-base px-4 pb-6 pt-1">
+      <div className="mx-auto w-full max-w-3xl">
         <ComposerBanner />
         <div className="flex flex-col gap-1.5 rounded-md border border-line bg-surface-2 px-3 py-2.5 shadow-[0_8px_30px_rgba(0,0,0,0.6)] transition-colors focus-within:border-line-strong">
           <div className="flex items-end gap-2">

--- a/src/renderer/features/workspace/ConversationView.tsx
+++ b/src/renderer/features/workspace/ConversationView.tsx
@@ -80,9 +80,8 @@ export function ConversationView({ sessionId }: { sessionId: string }) {
     const el = findScrollParent(bottomRef.current);
     if (!el) return;
     const onScroll = () => {
-      // The scroll area reserves the composer's height as bottom padding, so the
-      // resting "at bottom" position is only ~16px from the true scroll bottom;
-      // a modest threshold keeps auto-follow sticky through fast streaming.
+      // A modest threshold keeps auto-follow sticky through fast streaming while
+      // still releasing it the moment the user scrolls up to read.
       stick.current = el.scrollHeight - el.scrollTop - el.clientHeight < 120;
     };
     el.addEventListener('scroll', onScroll, { passive: true });
@@ -114,9 +113,10 @@ export function ConversationView({ sessionId }: { sessionId: string }) {
         ),
       )}
       {approval && <InlineApproval request={approval} />}
-      {/* Scroll anchor — its scroll-margin keeps the last line above the floating
-          composer when auto-scrolling (honored by scrollIntoView). */}
-      <div ref={bottomRef} style={{ scrollMarginBottom: 'calc(var(--composer-h, 360px) + 1.5rem)' }} />
+      {/* Scroll anchor — a small bottom margin keeps the last line off the very
+          edge when auto-scrolling (honored by scrollIntoView). The composer is
+          docked in flow below the scroller, so no large reserve is needed. */}
+      <div ref={bottomRef} style={{ scrollMarginBottom: '1rem' }} />
     </div>
   );
 }

--- a/src/renderer/features/workspace/WorkspaceLauncher.tsx
+++ b/src/renderer/features/workspace/WorkspaceLauncher.tsx
@@ -1,26 +1,29 @@
 /**
- * Recent-Workspaces launcher, shown in the center column when no workspace is
- * active. Rich cards (project icon, name, path, language/framework badges, git
- * branch, last-opened time, favorite pin, rescan) with search and favorites-first
- * sort. Workspaces are added via the native directory picker OR by dropping a
- * folder onto the drop zone (which doubles as the modern empty state).
+ * Recent-Workspaces launcher body. Rich cards (project icon, name, path,
+ * language/framework badges, git branch, last-opened time, live statistics,
+ * favorite pin, rescan) with search and favorites-first sort. Workspaces are
+ * added via the native directory picker OR by dropping a folder onto the drop
+ * zone (which doubles as the modern empty state).
+ *
+ * Rendered full-screen by `WorkspaceSelection` when no workspace is active, so
+ * it owns the project-launcher experience that gates the rest of the shell.
  */
-import { useMemo, useState } from 'react';
-import { GitBranch, Pin, RefreshCw, Search, Trash2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { FileText, GitBranch, GitCommitHorizontal, HardDrive, Pin, RefreshCw, Search, Trash2 } from 'lucide-react';
+import type { Workspace } from '@shared/types';
 import { Badge, EmptyState, IconButton } from '@/renderer/components/ui';
-import { relativeTime } from '@/renderer/lib/format';
+import { formatBytes, formatCount, relativeTime } from '@/renderer/lib/format';
 import { useWorkspaceStore } from '@/renderer/stores/useWorkspaceStore';
 import { WorkspaceIconBadge } from './WorkspaceIconBadge';
 import { WorkspaceDropZone } from './WorkspaceDropZone';
+import { WorkspaceRemoveDialog } from './WorkspaceRemoveDialog';
 
 export function WorkspaceLauncher() {
   const workspaces = useWorkspaceStore((s) => s.workspaces);
-  const switchTo = useWorkspaceStore((s) => s.switchTo);
-  const toggleFavorite = useWorkspaceStore((s) => s.toggleFavorite);
-  const remove = useWorkspaceStore((s) => s.remove);
-  const rescan = useWorkspaceStore((s) => s.rescan);
 
   const [query, setQuery] = useState('');
+  // Workspace pending safe-delete confirmation (null = dialog closed).
+  const [pendingRemove, setPendingRemove] = useState<Workspace | null>(null);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -77,71 +80,113 @@ export function WorkspaceLauncher() {
             ) : (
               <ul className="flex flex-col gap-2">
                 {filtered.map((ws) => (
-                  <li key={ws.id}>
-                    <div className="group flex items-center gap-3 rounded-lg border border-line bg-surface-2 px-3 py-2.5 transition-colors hover:border-line-strong">
-                      <button
-                        type="button"
-                        onClick={() => switchTo(ws.id)}
-                        className="flex min-w-0 flex-1 items-center gap-3 text-left"
-                      >
-                        <WorkspaceIconBadge icon={ws.icon} size={36} />
-                        <div className="flex min-w-0 flex-col gap-1">
-                          <div className="flex items-center gap-2">
-                            <span className="truncate text-[13px] font-medium text-fg">
-                              {ws.name}
-                            </span>
-                            {ws.metadata.languages.slice(0, 2).map((lang) => (
-                              <Badge key={lang} tone="neutral">
-                                {lang}
-                              </Badge>
-                            ))}
-                          </div>
-                          <div className="flex items-center gap-2 text-[11px] text-faint">
-                            <span className="truncate">{ws.path}</span>
-                            {ws.metadata.hasGit && ws.metadata.branch && (
-                              <span className="flex shrink-0 items-center gap-1">
-                                <GitBranch size={10} />
-                                {ws.metadata.branch}
-                              </span>
-                            )}
-                            <span className="shrink-0">· {relativeTime(ws.lastOpenedAt)}</span>
-                          </div>
-                        </div>
-                      </button>
-                      <div className="flex shrink-0 items-center gap-0.5">
-                        <IconButton
-                          size="sm"
-                          label="Rescan workspace"
-                          className="opacity-0 transition-opacity group-hover:opacity-100"
-                          onClick={() => rescan(ws.id)}
-                        >
-                          <RefreshCw size={13} />
-                        </IconButton>
-                        <IconButton
-                          size="sm"
-                          label={ws.favorite ? 'Unpin' : 'Pin to top'}
-                          active={ws.favorite}
-                          onClick={() => toggleFavorite(ws.id)}
-                        >
-                          <Pin size={13} className={ws.favorite ? 'fill-current' : undefined} />
-                        </IconButton>
-                        <IconButton
-                          size="sm"
-                          label="Remove from list"
-                          className="opacity-0 transition-opacity group-hover:opacity-100"
-                          onClick={() => remove(ws.id)}
-                        >
-                          <Trash2 size={13} />
-                        </IconButton>
-                      </div>
-                    </div>
-                  </li>
+                  <WorkspaceCard key={ws.id} ws={ws} onRequestRemove={() => setPendingRemove(ws)} />
                 ))}
               </ul>
             )}
           </div>
         </>
       )}
+
+      {pendingRemove && (
+        <WorkspaceRemoveDialog
+          workspace={pendingRemove}
+          onClose={() => setPendingRemove(null)}
+        />
+      )}
     </div>
+  );
+}
+
+/** One workspace row. Lazily loads + shows project statistics on mount. */
+function WorkspaceCard({ ws, onRequestRemove }: { ws: Workspace; onRequestRemove: () => void }) {
+  const switchTo = useWorkspaceStore((s) => s.switchTo);
+  const toggleFavorite = useWorkspaceStore((s) => s.toggleFavorite);
+  const rescan = useWorkspaceStore((s) => s.rescan);
+  const loadStats = useWorkspaceStore((s) => s.loadStats);
+  const stats = useWorkspaceStore((s) => s.statsById[ws.id]);
+
+  // Fetch stats once when the card appears (the store memoizes per id).
+  useEffect(() => {
+    void loadStats(ws.id);
+  }, [ws.id, loadStats]);
+
+  return (
+    <li>
+      <div className="group flex items-center gap-3 rounded-lg border border-line bg-surface-2 px-3 py-2.5 transition-colors hover:border-line-strong">
+        <button
+          type="button"
+          onClick={() => switchTo(ws.id)}
+          className="flex min-w-0 flex-1 items-center gap-3 text-left"
+        >
+          <WorkspaceIconBadge icon={ws.icon} size={36} />
+          <div className="flex min-w-0 flex-col gap-1">
+            <div className="flex items-center gap-2">
+              <span className="truncate text-[13px] font-medium text-fg">{ws.name}</span>
+              {ws.metadata.languages.slice(0, 2).map((lang) => (
+                <Badge key={lang} tone="neutral">
+                  {lang}
+                </Badge>
+              ))}
+            </div>
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-faint">
+              <span className="truncate">{ws.path}</span>
+              {ws.metadata.hasGit && ws.metadata.branch && (
+                <span className="flex shrink-0 items-center gap-1">
+                  <GitBranch size={10} />
+                  {ws.metadata.branch}
+                </span>
+              )}
+              <span className="shrink-0">· {relativeTime(ws.lastOpenedAt)}</span>
+              {stats && (
+                <span className="flex shrink-0 items-center gap-2 font-mono text-faint">
+                  <span className="text-line-strong">·</span>
+                  <span className="flex items-center gap-1" title="Files">
+                    <FileText size={10} />
+                    {formatCount(stats.fileCount)}
+                  </span>
+                  <span className="flex items-center gap-1" title="Size on disk">
+                    <HardDrive size={10} />
+                    {formatBytes(stats.sizeBytes)}
+                  </span>
+                  {stats.commitCount != null && (
+                    <span className="flex items-center gap-1" title="Commits">
+                      <GitCommitHorizontal size={10} />
+                      {formatCount(stats.commitCount)}
+                    </span>
+                  )}
+                </span>
+              )}
+            </div>
+          </div>
+        </button>
+        <div className="flex shrink-0 items-center gap-0.5">
+          <IconButton
+            size="sm"
+            label="Rescan workspace"
+            className="opacity-0 transition-opacity group-hover:opacity-100"
+            onClick={() => rescan(ws.id)}
+          >
+            <RefreshCw size={13} />
+          </IconButton>
+          <IconButton
+            size="sm"
+            label={ws.favorite ? 'Unpin' : 'Pin to top'}
+            active={ws.favorite}
+            onClick={() => toggleFavorite(ws.id)}
+          >
+            <Pin size={13} className={ws.favorite ? 'fill-current' : undefined} />
+          </IconButton>
+          <IconButton
+            size="sm"
+            label="Remove from list"
+            className="opacity-0 transition-opacity group-hover:opacity-100"
+            onClick={onRequestRemove}
+          >
+            <Trash2 size={13} />
+          </IconButton>
+        </div>
+      </div>
+    </li>
   );
 }

--- a/src/renderer/features/workspace/WorkspaceRemoveDialog.tsx
+++ b/src/renderer/features/workspace/WorkspaceRemoveDialog.tsx
@@ -1,0 +1,102 @@
+/**
+ * Safe-delete confirmation for removing a workspace from Limboo. Removing a
+ * workspace only detaches it from the app (registration + cached metadata,
+ * statistics, index, and workspace-scoped sessions/memories/checkpoints). The
+ * project directory on disk is NEVER touched — permanently deleting project
+ * files is a deliberate, separate action and is intentionally not offered here.
+ *
+ * Matches the app modal idiom (centered overlay, `bg-elevated`, pop-in). Dark
+ * only — no theme toggle, no gradients.
+ */
+import { useEffect } from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+import type { Workspace } from '@shared/types';
+import { WorkspaceIconBadge } from './WorkspaceIconBadge';
+import { useWorkspaceStore } from '@/renderer/stores/useWorkspaceStore';
+
+export function WorkspaceRemoveDialog({
+  workspace,
+  onClose,
+}: {
+  workspace: Workspace;
+  onClose: () => void;
+}) {
+  const remove = useWorkspaceStore((s) => s.remove);
+
+  // Close on Escape for keyboard parity with the rest of the app.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const confirm = async () => {
+    await remove(workspace.id);
+    onClose();
+  };
+
+  return (
+    <div
+      className="animate-fade-in fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-6"
+      onMouseDown={onClose}
+    >
+      <div
+        className="animate-pop-in flex w-full max-w-md flex-col overflow-hidden rounded-md border border-line-strong bg-elevated shadow-2xl"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-line px-4 py-3">
+          <span className="flex items-center gap-2 text-[13px] font-semibold text-fg">
+            <AlertTriangle size={14} className="text-warning" />
+            Remove workspace
+          </span>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            className="flex h-7 w-7 items-center justify-center rounded-md text-muted transition-colors hover:bg-surface-2 hover:text-fg"
+          >
+            <X size={15} />
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-3 p-4">
+          <div className="flex items-center gap-3 rounded-md border border-line bg-surface-2 px-3 py-2.5">
+            <WorkspaceIconBadge icon={workspace.icon} size={32} />
+            <div className="flex min-w-0 flex-col">
+              <span className="truncate text-[13px] font-medium text-fg">{workspace.name}</span>
+              <span className="truncate text-[11px] text-faint">{workspace.path}</span>
+            </div>
+          </div>
+
+          <p className="text-[12px] leading-relaxed text-muted">
+            This removes the workspace from Limboo only — its registration, cached metadata,
+            statistics, index, and any sessions, memories, and checkpoints scoped to it.
+          </p>
+          <p className="rounded-md border border-line bg-surface-2 px-3 py-2 text-[12px] leading-relaxed text-fg">
+            Your files are safe. The project folder on disk is <span className="font-semibold">not</span> deleted —
+            you can re-open it any time.
+          </p>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t border-line px-4 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-line bg-surface-2 px-3 py-1.5 text-[12px] font-medium text-fg transition-colors hover:border-line-strong"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={confirm}
+            className="rounded-md bg-danger px-3 py-1.5 text-[12px] font-semibold text-base transition-opacity hover:opacity-90"
+          >
+            Remove from Limboo
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/features/workspace/WorkspaceSelection.tsx
+++ b/src/renderer/features/workspace/WorkspaceSelection.tsx
@@ -1,0 +1,26 @@
+/**
+ * Full-screen Workspace Selection experience, shown by `App` whenever no
+ * workspace is active. It replaces the entire shell: every workspace-dependent
+ * surface (sessions, conversation, git, files, tasks, memory) is unavailable
+ * until a project is opened, reinforcing that the workspace is the single source
+ * of truth every subsystem depends on.
+ *
+ * Structure: the frameless TitleBar on top (window controls + drag preserved),
+ * then the recent-workspaces launcher centered in the body. Pure-black, dark
+ * only — reuses existing primitives so it matches the rest of the app exactly.
+ */
+import { TitleBar } from '@/renderer/components/layout/TitleBar';
+import { WorkspaceLauncher } from './WorkspaceLauncher';
+
+export function WorkspaceSelection() {
+  return (
+    <div className="flex h-full w-full flex-col bg-base text-fg">
+      <TitleBar />
+      {/* The launcher owns its own internal scroll for the workspace list, so
+          give it the full remaining height rather than a second scroller. */}
+      <div className="min-h-0 flex-1 px-4">
+        <WorkspaceLauncher />
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/lib/format.ts
+++ b/src/renderer/lib/format.ts
@@ -1,3 +1,21 @@
+/** Formats a byte count as a short human label (e.g. "0 B", "12 KB", "3.4 MB"). */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const exp = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
+  const value = bytes / 1024 ** exp;
+  // Whole numbers for bytes/KB; one decimal once we reach MB+.
+  const rounded = exp >= 2 ? Math.round(value * 10) / 10 : Math.round(value);
+  return `${rounded} ${units[exp]}`;
+}
+
+/** Compact integer label (e.g. 1234 → "1.2k") for file/commit counts. */
+export function formatCount(n: number): string {
+  if (!Number.isFinite(n) || n < 1000) return String(Math.max(0, Math.floor(n)));
+  if (n < 1_000_000) return `${Math.round(n / 100) / 10}k`;
+  return `${Math.round(n / 100_000) / 10}M`;
+}
+
 /** Formats an epoch-ms timestamp as a short relative label (e.g. "now", "12m"). */
 export function relativeTime(epochMs: number, now: number = Date.now()): string {
   const diff = Math.max(0, now - epochMs);

--- a/src/renderer/stores/useWorkspaceStore.ts
+++ b/src/renderer/stores/useWorkspaceStore.ts
@@ -8,7 +8,7 @@
  * the UI still renders.
  */
 import { create } from 'zustand';
-import type { Workspace, WorkspaceConfig, DeepPartial } from '@shared/types';
+import type { Workspace, WorkspaceConfig, WorkspaceStats, DeepPartial } from '@shared/types';
 
 interface WorkspaceState {
   workspaces: Workspace[];
@@ -16,6 +16,9 @@ interface WorkspaceState {
   hydrated: boolean;
   /** True while a native directory picker is open (mirrors the main-process guard). */
   picking: boolean;
+  /** Lazily-loaded per-workspace statistics, memoized by id (each entry is one
+   *  bounded filesystem walk, so we fetch on demand — not eagerly for every card). */
+  statsById: Record<string, WorkspaceStats>;
   hydrate: () => Promise<void>;
   pickDirectory: () => Promise<string | null>;
   open: (path: string) => Promise<Workspace | null>;
@@ -26,6 +29,8 @@ interface WorkspaceState {
   toggleFavorite: (id: string) => Promise<void>;
   updateConfig: (id: string, patch: DeepPartial<WorkspaceConfig>) => Promise<void>;
   rescan: (id: string) => Promise<void>;
+  /** Fetch + cache stats for one workspace (no-op if already loaded). */
+  loadStats: (id: string) => Promise<void>;
 }
 
 /** Resolve the workspace bridge, warning (dev) when it is unexpectedly absent so a
@@ -49,6 +54,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   activeId: null,
   hydrated: false,
   picking: false,
+  statsById: {},
 
   hydrate: async () => {
     if (get().hydrated) return;
@@ -123,7 +129,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     await api.remove(id);
     set((s) => {
       const workspaces = s.workspaces.filter((w) => w.id !== id);
-      return { workspaces, activeId: s.activeId === id ? null : s.activeId };
+      const statsById = { ...s.statsById };
+      delete statsById[id];
+      return { workspaces, statsById, activeId: s.activeId === id ? null : s.activeId };
     });
   },
 
@@ -145,6 +153,21 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     const api = workspaceApi();
     if (!api) return;
     const ws = await api.rescan(id);
-    set((s) => ({ workspaces: mergeWorkspace(s.workspaces, ws) }));
+    // A rescan re-walks the project, so drop the cached stats and let the next
+    // view re-request fresh numbers.
+    set((s) => {
+      const statsById = { ...s.statsById };
+      delete statsById[id];
+      return { workspaces: mergeWorkspace(s.workspaces, ws), statsById };
+    });
+  },
+
+  loadStats: async (id) => {
+    if (get().statsById[id]) return;
+    const api = workspaceApi();
+    if (!api) return;
+    const stats = await api.getStats(id);
+    if (!stats) return;
+    set((s) => ({ statsById: { ...s.statsById, [id]: stats } }));
   },
 }));


### PR DESCRIPTION
…kens, and same security boundary (no new IPC, all data through the existing validated `window.limboo.workspace.*` bridge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full workspace selection screen when no workspace is active.
  * Workspaces now show extra at-a-glance details like file count, disk usage, and commit count.
  * Added clearer byte and count formatting for compact displays.

* **Bug Fixes**
  * Main app now waits for workspace data to load before showing the interface.
  * The workspace composer is now docked in the normal layout flow for smoother scrolling.
  * Removing a workspace now requires confirmation before deletion from the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->