### PR TITLE
CHANGE CI CONFIG TO USE THE NEW CIRCLECI CONFIG

### DIFF
--- a/.circleci/deploy.yml
+++ b/.circleci/deploy.yml
@@ -67,7 +67,16 @@ jobs:
       - checkout
       - run:
           name: Install test runtime deps
-          command: sudo apt-get update && sudo apt-get install -y build-essential python3 xvfb libnss3 libgbm1 libasound2
+          # Electron needs the full GTK/ATK/CUPS/ALSA stack to launch (the smoke test
+          # boots a real Electron process), not just nss/gbm — otherwise it fails with
+          # "libatk-1.0.so.0: cannot open shared object file". Names differ across the
+          # Ubuntu 24.04 t64 transition, so fall back to the t64 variants if needed.
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y build-essential python3 xvfb \
+              libnss3 libdrm2 libgbm1 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libpango-1.0-0 libcairo2
+            sudo apt-get install -y libatk1.0-0 libatk-bridge2.0-0 libcups2 libgtk-3-0 libasound2 \
+              || sudo apt-get install -y libatk1.0-0t64 libatk-bridge2.0-0t64 libcups2t64 libgtk-3-0t64 libasound2t64
       - npm_ci
       - run: xvfb-run -a node ci/scripts/smoke-test.mjs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,17 @@ jobs:
           cache: npm
       - name: Install native build deps (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y build-essential python3 xvfb libnss3 libgbm1 libasound2t64
+        # Electron needs the full GTK/ATK/CUPS/ALSA stack to launch (the smoke test
+        # boots a real Electron process), not just nss/gbm — otherwise it fails with
+        # "libatk-1.0.so.0: cannot open shared object file". The GTK/ATK/CUPS/ALSA
+        # package names changed under Ubuntu 24.04's t64 transition, so try the
+        # standard names first and fall back to the t64 variants.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential python3 xvfb \
+            libnss3 libdrm2 libgbm1 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libpango-1.0-0 libcairo2
+          sudo apt-get install -y libatk1.0-0 libatk-bridge2.0-0 libcups2 libgtk-3-0 libasound2 \
+            || sudo apt-get install -y libatk1.0-0t64 libatk-bridge2.0-0t64 libcups2t64 libgtk-3-0t64 libasound2t64
       - name: Install dependencies
         run: npm ci
       - name: Electron smoke test (Linux)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,7 +78,13 @@ build:
 test:linux:
   stage: test
   before_script:
-    - apt-get update && apt-get install -y build-essential python3 xvfb libnss3 libgbm1 libasound2
+    # Electron needs the full GTK/ATK/CUPS/ALSA stack to launch (the smoke test boots
+    # a real Electron process), not just nss/gbm — otherwise it fails with
+    # "libatk-1.0.so.0: cannot open shared object file". The t64 fallback keeps this
+    # working if the base image moves to an Ubuntu 24.04-style t64 library set.
+    - apt-get update
+    - apt-get install -y build-essential python3 xvfb libnss3 libdrm2 libgbm1 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libpango-1.0-0 libcairo2
+    - apt-get install -y libatk1.0-0 libatk-bridge2.0-0 libcups2 libgtk-3-0 libasound2 || apt-get install -y libatk1.0-0t64 libatk-bridge2.0-0t64 libcups2t64 libgtk-3-0t64 libasound2t64
     - npm ci --cache .npm --prefer-offline
   script:
     - xvfb-run -a node ci/scripts/smoke-test.mjs


### PR DESCRIPTION
<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI `apt-get` install lists for Linux test runners; no application, auth, or release logic is modified.
> 
> **Overview**
> Fixes Linux **Electron smoke test** failures in CI by expanding the apt packages installed before `xvfb-run … smoke-test.mjs` on **CircleCI**, **GitHub Actions**, and **GitLab**.
> 
> The previous minimal set (`libnss3`, `libgbm1`, `libasound2`, etc.) was not enough for a real Electron process; missing **ATK/GTK** triggered errors like `libatk-1.0.so.0: cannot open shared object file`. The install step now pulls in the broader desktop/graphics stack (`libdrm2`, `libxkbcommon0`, X11 composite/damage/fixes/randr, `pango`, `cairo`, `gtk-3`, `cups`, `atk-bridge`, and related libs).
> 
> On **Ubuntu 24.04’s t64 package rename**, the same three pipelines try standard package names first, then **fall back to `*t64` variants** so installs keep working across image transitions. Inline comments document why the extra deps are required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63f9056d942482dffb64417c1b9bf82a84ce620e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux smoke-test setup so Electron can start more reliably in CI.
  * Added broader native runtime library support, including fallback package names for newer Ubuntu releases.
  * Reduced CI failures caused by missing desktop/audio/graphics dependencies during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->