### PR TITLE
Fix packaged app missing node_modules and assets in asar

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -14,6 +14,52 @@ const config: ForgeConfig = {
     },
     name: 'Limboo',
     icon: 'assets/icon',
+    // @electron-forge/plugin-vite installs a default `packagerConfig.ignore` that
+    // keeps ONLY the `.vite` build output and excludes everything else —
+    // including `node_modules` and `assets/`. That assumes the entire app is
+    // bundled by Vite, which isn't true here: vite.main.config.ts intentionally
+    // keeps native/runtime-only deps (better-sqlite3, bindings, node-pty,
+    // electron-updater, @anthropic-ai/claude-agent-sdk) external as plain
+    // `require()` calls that must resolve from `node_modules` at runtime, and
+    // `assetPath()` (src/main/paths.ts) reads icons from `assets/` at runtime via
+    // `app.getAppPath()`. Without this override, the packaged app has no
+    // node_modules at all and crashes on the first externalized `require()`
+    // before any logging happens.
+    //
+    // Supplying our own `ignore` function here makes the Vite plugin skip its
+    // default (it only warns that the app may be larger than expected — expected,
+    // since we now intentionally keep node_modules). Production dependencies are
+    // still pruned down from the full node_modules by the packager's default
+    // `prune: true` behavior, which walks the real dependency graph and drops
+    // devDependencies (so transitive deps like `bindings` are kept automatically
+    // without needing to be listed here).
+    ignore: (file) => {
+      if (!file) return false;
+      // `file` always starts with `/`. Replicate electron-packager's
+      // DEFAULT_IGNORES (lockfiles, .git, node_modules/.bin, native build
+      // artifacts) — these are skipped entirely once a custom `ignore` function
+      // is supplied.
+      if (
+        /\/package-lock\.json$/.test(file) ||
+        /\/yarn\.lock$/.test(file) ||
+        /\/pnpm-lock\.yaml$/.test(file) ||
+        /\/\.git($|\/)/.test(file) ||
+        /\/node_modules\/\.bin($|\/)/.test(file) ||
+        /\.o(bj)?$/.test(file) ||
+        /\/node_gyp_bins($|\/)/.test(file)
+      ) {
+        return true;
+      }
+      // Keep: Vite's build output, the root package.json (required by the Vite
+      // plugin), bundled static assets, and node_modules (pruned to production
+      // deps above). Ignore everything else (source, configs, dev-only files).
+      const keep =
+        file.startsWith('/.vite') ||
+        file === '/package.json' ||
+        file.startsWith('/assets') ||
+        file.startsWith('/node_modules');
+      return !keep;
+    },
   },
   rebuildConfig: {},
   // No Forge makers: distributables are produced by electron-builder over the


### PR DESCRIPTION
@electron-forge/plugin-vite's default packagerConfig.ignore keeps only the .vite build output and drops everything else, including node_modules and assets/. Since vite.main.config.ts intentionally keeps native/runtime-only deps (better-sqlite3, bindings, node-pty, electron-updater, @anthropic-ai/claude-agent-sdk) external as plain require() calls, the packaged app shipped with zero node_modules and crashed on the very first externalized require() before any logging happened. assetPath() also silently lost assets/icon.png and tray.png since they were dropped the same way.

Override packagerConfig.ignore to allowlist .vite, package.json, assets/, and node_modules (still pruned to production deps by the packager's default prune: true), while replicating electron-packager's DEFAULT_IGNORES that get skipped once a custom ignore function is supplied.

<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Packaging behavior changes what ships in the app bundle (larger artifacts, different file layout); incorrect ignore rules could omit needed files or include too much, but the change is scoped to build tooling rather than runtime security logic.
> 
> **Overview**
> Fixes packaged builds that crashed immediately because **@electron-forge/plugin-vite**’s default `packagerConfig.ignore` shipped only `/.vite` output and stripped **`node_modules`** and **`assets/`**.
> 
> Adds a custom **`packagerConfig.ignore`** in `forge.config.ts` that **allowlists** `/.vite`, `/package.json`, `/assets`, and `/node_modules` (still subject to the packager’s production **`prune`**) while **replicating electron-packager’s default ignores** (lockfiles, `.git`, `node_modules/.bin`, native build junk) that no longer apply automatically once a custom ignore is set.
> 
> This aligns packaging with how the main bundle is built: **externalized** native/runtime deps (`better-sqlite3`, `bindings`, `node-pty`, `electron-updater`, `@anthropic-ai/claude-agent-sdk`) must resolve from **`node_modules` at runtime**, and **`assetPath()`** must find icons under **`assets/`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e28c18b275afa4f0464a1a6e882489cfce09eda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application packaging so runtime dependencies are retained while unnecessary build and development files are excluded.
  * This helps packaged builds run more reliably and reduces the chance of missing required resources at startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->