### PR TITLE
AgentManager` supports true concurrent multi-session runs internally …

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "limboo",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["start"],
+      "port": 5173
+    }
+  ]
+}

--- a/src/main/managers/AgentManager.ts
+++ b/src/main/managers/AgentManager.ts
@@ -97,6 +97,15 @@ const TODO_TOOL = 'TodoWrite';
 /** The SDK tool the agent uses to ask the user clarifying questions. */
 const ASK_USER_QUESTION_TOOL = 'AskUserQuestion';
 
+/** Default per-session request state before a session has ever run. */
+const IDLE_REQUEST: RequestState = {
+  sessionId: null,
+  phase: 'idle',
+  outcome: null,
+  attempt: 0,
+  maxAttempts: 0,
+};
+
 /**
  * Streamed text is coalesced before it crosses IPC: rather than one
  * `message-delta` per token (which floods IPC and forces a React render +
@@ -264,8 +273,11 @@ export class AgentManager {
   private state: AgentState = {
     lifecycle: 'starting',
     install: { installed: false },
-    request: { sessionId: null, phase: 'idle', outcome: null, attempt: 0, maxAttempts: 0 },
+    request: IDLE_REQUEST,
     activeSessionId: null,
+    requestsBySession: {},
+    pendingPermissions: [],
+    pendingClarifications: [],
     heartbeat: { lastOkAt: null, consecutiveFailures: 0 },
   };
 
@@ -275,10 +287,24 @@ export class AgentManager {
   private idleTimer: NodeJS.Timeout | null = null;
   private readonly runtimes = new Map<string, SessionRuntime>();
   private readonly runs = new Map<string, ActiveRun>();
-  /** Pending permission prompts awaiting a renderer decision. */
+  /**
+   * Per-session run phase. Sessions can run concurrently (see {@link runs}), so
+   * this MUST be keyed by sessionId rather than a single shared value — a
+   * single global field would let one session's phase transition silently
+   * overwrite another's, hiding e.g. an `awaiting-permission` pause behind
+   * whichever session most recently touched the state.
+   */
+  private readonly requests = new Map<string, RequestState>();
+  /** Pending permission prompts awaiting a renderer decision, keyed by request id. */
   private readonly pending = new Map<
     string,
-    { resolve: (r: PermissionResult) => void; sessionId: string; input: Record<string, unknown> }
+    {
+      resolve: (r: PermissionResult) => void;
+      sessionId: string;
+      input: Record<string, unknown>;
+      /** The full request, kept so a fresh renderer hydration can replay it via {@link getState}. */
+      request: PermissionRequest;
+    }
   >();
   /**
    * Pending AskUserQuestion clarifications awaiting renderer answers. Kept apart
@@ -294,6 +320,8 @@ export class AgentManager {
       input: Record<string, unknown>;
       /** The normalized questions, used to key answers and summarize the result. */
       questions: ClarificationQuestion[];
+      /** The full request, kept so a fresh renderer hydration can replay it via {@link getState}. */
+      request: ClarificationRequest;
     }
   >();
   /** Remembered "always allow" choices, keyed `sessionId:risk`. */
@@ -405,8 +433,19 @@ export class AgentManager {
   /* Public API (reached via IPC)                                     */
   /* ---------------------------------------------------------------- */
 
+  /**
+   * A fresh snapshot including live per-session data, so a renderer hydrating
+   * after a reload (or a second window opening) can rebuild every session's
+   * pending request/clarification/phase — not just whatever `agentStateChanged`
+   * last broadcast, which only carries the fields in {@link setState} patches.
+   */
   getState(): AgentState {
-    return this.state;
+    return {
+      ...this.state,
+      requestsBySession: Object.fromEntries(this.requests),
+      pendingPermissions: [...this.pending.values()].map((p) => p.request),
+      pendingClarifications: [...this.pendingClarifications.values()].map((p) => p.request),
+    };
   }
 
   /**
@@ -567,7 +606,7 @@ export class AgentManager {
       this.runs.has(entry.sessionId)
     ) {
       this.setLifecycle('streaming');
-      this.setRequest({ phase: 'streaming' });
+      this.setRequest(entry.sessionId, { phase: 'streaming' });
     }
   }
 
@@ -602,7 +641,7 @@ export class AgentManager {
     // resolving records the answered summary. This avoids a duplicate marker.
     this.diag('tool', 'info', 'Clarification requested', headers, sessionId);
     this.setLifecycle('awaiting-permission');
-    this.setRequest({ phase: 'awaiting-permission' });
+    this.setRequest(sessionId, { phase: 'awaiting-permission' });
     this.broadcastChannel(IpcEvents.agentClarificationRequest, request);
 
     return new Promise<PermissionResult>((resolve) => {
@@ -616,6 +655,7 @@ export class AgentManager {
         sessionId,
         input,
         questions,
+        request,
         resolve: (r) => {
           signal.removeEventListener('abort', onAbort);
           resolve(r);
@@ -666,7 +706,7 @@ export class AgentManager {
       this.runs.has(entry.sessionId)
     ) {
       this.setLifecycle('streaming');
-      this.setRequest({ phase: 'streaming' });
+      this.setRequest(entry.sessionId, { phase: 'streaming' });
     }
   }
 
@@ -770,8 +810,7 @@ export class AgentManager {
     const abort = new AbortController();
     this.runs.set(sessionId, { abort, query: null, mode });
     this.clearIdleTimer();
-    this.setRequest({
-      sessionId,
+    this.setRequest(sessionId, {
       phase: 'submitting',
       outcome: null,
       attempt: 0,
@@ -865,7 +904,7 @@ export class AgentManager {
         if (cls.recoverable && cfg.maxRecoveryAttempts > 0 && attempt < cfg.maxRecoveryAttempts) {
           attempt += 1;
           this.setLifecycle('reconnecting');
-          this.setRequest({ phase: 'recovering', attempt });
+          this.setRequest(sessionId, { phase: 'recovering', attempt });
           this.diag('recovery', 'info', `Reconnect attempt ${attempt}/${cfg.maxRecoveryAttempts}`, undefined, sessionId);
           const ok = await this.abortableDelay(backoff(cfg.reconnectDelay, attempt), abort);
           if (!ok) {
@@ -961,7 +1000,7 @@ export class AgentManager {
 
     const run = this.runs.get(sessionId);
     if (run) run.result = undefined;
-    this.setRequest({ phase: 'connecting' });
+    this.setRequest(sessionId, { phase: 'connecting' });
 
     try {
       const sdk = await loadSdk();
@@ -983,7 +1022,7 @@ export class AgentManager {
       };
       if (run) run.query = q;
       this.setLifecycle('streaming');
-      this.setRequest({ phase: 'streaming' });
+      this.setRequest(sessionId, { phase: 'streaming' });
       this.diag('stream', 'debug', 'Streaming response', undefined, sessionId);
 
       for await (const msg of q) {
@@ -1547,7 +1586,7 @@ export class AgentManager {
       this.pushActivity(sessionId, 'permission', `Asked to ${request.summary}`, undefined, 'warning');
       this.diag('tool', 'warning', `Approval requested: ${request.summary}`, request.detail, sessionId);
       this.setLifecycle('awaiting-permission');
-      this.setRequest({ phase: 'awaiting-permission' });
+      this.setRequest(sessionId, { phase: 'awaiting-permission' });
       this.broadcastChannel(IpcEvents.agentPermissionRequest, request);
 
       return new Promise<PermissionResult>((resolve) => {
@@ -1560,6 +1599,7 @@ export class AgentManager {
         this.pending.set(request.id, {
           sessionId,
           input,
+          request,
           resolve: (r) => {
             signal.removeEventListener('abort', onAbort);
             resolve(r);
@@ -1670,14 +1710,24 @@ export class AgentManager {
     this.setState({ lifecycle, ...patch });
   }
 
-  private setRequest(patch: Partial<RequestState>): void {
-    const request = { ...this.state.request, ...patch };
+  /**
+   * Patch ONE session's run phase. Kept per-session (see {@link requests}) so
+   * two concurrent runs can never clobber each other's phase — the bug that
+   * made an `awaiting-permission` pause on one session vanish whenever another
+   * session started or finished a run in the meantime.
+   */
+  private setRequest(sessionId: string, patch: Partial<RequestState>): void {
+    const current = this.requests.get(sessionId) ?? { ...IDLE_REQUEST, sessionId };
+    const request = { ...current, ...patch, sessionId };
+    this.requests.set(sessionId, request);
+    // Also mirror onto the legacy single-session field for any remaining
+    // back-compat reader — multi-session-aware UI must read `requestsBySession`.
     this.setState({ request });
-    this.pushEvent({ kind: 'request-state', sessionId: request.sessionId ?? '', request });
+    this.pushEvent({ kind: 'request-state', sessionId, request });
   }
 
   private completeRequest(sessionId: string, outcome: RequestOutcome, detail?: string): void {
-    this.setRequest({ sessionId, phase: 'done', outcome, detail, attempt: 0 });
+    this.setRequest(sessionId, { phase: 'done', outcome, detail, attempt: 0 });
   }
 
   /** True when the capability itself is degraded (not just the last request). */

--- a/src/renderer/features/sessions/SessionRow.tsx
+++ b/src/renderer/features/sessions/SessionRow.tsx
@@ -3,9 +3,13 @@
  * meta), not a card. The active row gets a left accent bar + raised surface.
  *
  * While the session's agent run is in flight the status dot is replaced by the
- * modern `Spinner`. Hovering reveals a `⋯` actions button; right-clicking the
- * row opens the same menu at the cursor. The title becomes an inline input
- * during rename (commit on Enter/blur, cancel on Escape).
+ * modern `Spinner`. When the run is specifically paused waiting on the user —
+ * a tool approval or an `AskUserQuestion` clarification — the dot becomes a
+ * pulsing accent dot instead, so a session that needs YOUR input is never
+ * mistaken for one that's merely streaming, no matter which session is
+ * currently open in the center pane. Hovering reveals a `⋯` actions button;
+ * right-clicking the row opens the same menu at the cursor. The title becomes
+ * an inline input during rename (commit on Enter/blur, cancel on Escape).
  */
 import { useEffect, useRef, useState } from 'react';
 import { CircleDot, GitBranch, Pin, Archive, MoreHorizontal } from 'lucide-react';
@@ -14,7 +18,7 @@ import { Badge, DiffStat, IconButton, Spinner } from '@/renderer/components/ui';
 import { cn } from '@/renderer/lib/cn';
 import { relativeTime } from '@/renderer/lib/format';
 import { useSessionStore } from '@/renderer/stores/useSessionStore';
-import { useIsSessionRunning } from './useSessionRunning';
+import { useIsSessionRunning, useSessionAwaitingInput } from './useSessionRunning';
 import { SessionRowMenu } from './SessionRowMenu';
 
 const STATUS_COLOR: Record<SessionStatus, string> = {
@@ -33,6 +37,7 @@ export function SessionRow({
   onSelect: () => void;
 }) {
   const running = useIsSessionRunning(session.id);
+  const awaitingInput = useSessionAwaitingInput(session.id);
   const rename = useSessionStore((s) => s.rename);
 
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
@@ -85,8 +90,12 @@ export function SessionRow({
         active ? 'border-accent bg-surface-2' : 'border-transparent hover:bg-surface-2',
       )}
     >
-      <span className="mt-0.5 shrink-0">
-        {running ? (
+      <span className="mt-0.5 shrink-0" title={awaitingInput ? 'Waiting for your input' : undefined}>
+        {awaitingInput ? (
+          <span className="flex h-[13px] w-[13px] items-center justify-center">
+            <span className="h-2 w-2 animate-pulse rounded-full bg-accent" />
+          </span>
+        ) : running ? (
           <Spinner size={13} />
         ) : (
           <CircleDot size={13} className={STATUS_COLOR[session.status]} />

--- a/src/renderer/features/sessions/useSessionRunning.ts
+++ b/src/renderer/features/sessions/useSessionRunning.ts
@@ -7,7 +7,8 @@
 import type { RequestPhase } from '@shared/types';
 import { useAgentStore } from '@/renderer/stores/useAgentStore';
 
-const RUNNING_PHASES = new Set<RequestPhase>([
+/** Phases in which a session's run counts as "in flight" (busy/disabled UI). */
+export const RUNNING_PHASES = new Set<RequestPhase>([
   'submitting',
   'connecting',
   'streaming',
@@ -15,14 +16,22 @@ const RUNNING_PHASES = new Set<RequestPhase>([
   'awaiting-permission',
 ]);
 
-/** The id of the session whose agent run is currently in flight, or null. */
-export function useRunningSessionId(): string | null {
-  return useAgentStore((s) =>
-    RUNNING_PHASES.has(s.request.phase) ? s.request.sessionId : null,
-  );
+/**
+ * Whether a specific session's agent run is currently in flight. Reads the
+ * per-session phase map — sessions can run concurrently, so a single global
+ * "running session id" can't correctly represent more than one at a time (that
+ * mismatch used to hide a session's `awaiting-permission` pause the moment any
+ * other session started or finished a run).
+ */
+export function useIsSessionRunning(sessionId: string): boolean {
+  return useAgentStore((s) => {
+    const phase = s.requestsBySession[sessionId]?.phase;
+    return !!phase && RUNNING_PHASES.has(phase);
+  });
 }
 
-/** Whether a specific session is the one currently running. */
-export function useIsSessionRunning(sessionId: string): boolean {
-  return useRunningSessionId() === sessionId;
+/** Whether a specific session is paused on a tool approval or AskUserQuestion,
+ *  needing the user's input to resume — distinct from merely "running". */
+export function useSessionAwaitingInput(sessionId: string): boolean {
+  return useAgentStore((s) => s.requestsBySession[sessionId]?.phase === 'awaiting-permission');
 }

--- a/src/renderer/features/workspace/CenterWorkspace.tsx
+++ b/src/renderer/features/workspace/CenterWorkspace.tsx
@@ -35,7 +35,7 @@ export function CenterWorkspace() {
   );
   // A paused AskUserQuestion for THIS session — the run resumes only once answered.
   const clarification = useAgentStore((s) =>
-    session && s.pendingClarification?.sessionId === session.id ? s.pendingClarification : null,
+    session ? (s.pendingClarificationBySession[session.id] ?? null) : null,
   );
 
   // Restore the transcript whenever the selected session changes.

--- a/src/renderer/features/workspace/ClarificationCard.tsx
+++ b/src/renderer/features/workspace/ClarificationCard.tsx
@@ -21,6 +21,7 @@ import { useAgentStore } from '@/renderer/stores/useAgentStore';
 
 export function ClarificationCard({ request }: { request: ClarificationRequest }) {
   const respondClarification = useAgentStore((s) => s.respondClarification);
+  const requestId = request.id;
   const questions = request.questions;
   const total = questions.length;
 
@@ -68,7 +69,7 @@ export function ClarificationCard({ request }: { request: ClarificationRequest }
         if (value) answers[q.question] = value;
       }
     });
-    respondClarification(answers);
+    respondClarification(requestId, answers);
   }
 
   function advance(): void {

--- a/src/renderer/features/workspace/Composer.tsx
+++ b/src/renderer/features/workspace/Composer.tsx
@@ -21,7 +21,8 @@ import { Spinner } from '@/renderer/components/ui';
 import { useSessionStore } from '@/renderer/stores/useSessionStore';
 import { useAgentStore } from '@/renderer/stores/useAgentStore';
 import { useSettingsStore } from '@/renderer/stores/useSettingsStore';
-import { BUSY_LIFECYCLES, lifecycleMeta, phaseLabel } from '@/renderer/features/agent/status';
+import { lifecycleMeta, phaseLabel } from '@/renderer/features/agent/status';
+import { RUNNING_PHASES } from '@/renderer/features/sessions/useSessionRunning';
 import { ComposerControls } from './ComposerControls';
 import { ComposerModeSwitch } from './ComposerModeSwitch';
 import { ComposerBanner } from './ComposerBanner';
@@ -35,10 +36,14 @@ export function Composer({ disabled = false }: { disabled?: boolean }) {
 
   const sessionId = useSessionStore((s) => s.selectedId);
   const lifecycle = useAgentStore((s) => s.lifecycle);
-  const phase = useAgentStore((s) => s.request.phase);
+  // This session's own run phase — sessions can run concurrently, so "is THIS
+  // composer's session busy" must never be read off a single global field (that
+  // mismatch used to make one session's composer look idle/ready while it was
+  // actually still streaming or awaiting a decision, simply because a different
+  // session had more recently touched the shared state).
+  const phase = useAgentStore((s) => (sessionId ? s.requestsBySession[sessionId]?.phase : undefined));
   const installed = useAgentStore((s) => s.install.installed);
   const installError = useAgentStore((s) => s.install.error);
-  const activeSessionId = useAgentStore((s) => s.activeSessionId);
   const runningTool = useAgentStore((s) =>
     sessionId ? s.bySession[sessionId]?.toolCalls.find((c) => c.status === 'running')?.name : undefined,
   );
@@ -53,7 +58,7 @@ export function Composer({ disabled = false }: { disabled?: boolean }) {
     setMode(defaultMode);
   }, [sessionId, defaultMode]);
 
-  const busy = activeSessionId === sessionId && BUSY_LIFECYCLES.has(lifecycle);
+  const busy = !!phase && RUNNING_PHASES.has(phase);
   const restricted = lifecycle === 'rate-limited' || lifecycle === 'auth-required';
   const blocked = disabled || !installed || busy || restricted;
 
@@ -189,7 +194,8 @@ function StatusHint({
   installError?: string;
   busy: boolean;
   lifecycle: ReturnType<typeof useAgentStore.getState>['lifecycle'];
-  phase: ReturnType<typeof useAgentStore.getState>['request']['phase'];
+  /** This session's own phase (per-session — see the `phase` selector above). */
+  phase: ReturnType<typeof useAgentStore.getState>['request']['phase'] | undefined;
   toolName?: string;
 }) {
   const meta = lifecycleMeta(lifecycle, installed);
@@ -205,7 +211,8 @@ function StatusHint({
     return (
       <span className="flex min-w-0 items-center gap-1.5 text-muted">
         <Spinner size={11} />
-        <span className="truncate">{phaseLabel(phase, toolName)}</span>
+        {/* `busy` implies `phase` is set (see the busy derivation above). */}
+        <span className="truncate">{phaseLabel(phase ?? 'streaming', toolName)}</span>
       </span>
     );
   }

--- a/src/renderer/features/workspace/ComposerBanner.tsx
+++ b/src/renderer/features/workspace/ComposerBanner.tsx
@@ -34,10 +34,12 @@ function formatReset(resetsAt?: number, timezone?: string): string {
 export function ComposerBanner() {
   const lifecycle = useAgentStore((s) => s.lifecycle);
   const rateLimit = useAgentStore((s) => s.rateLimit);
-  const outcome = useAgentStore((s) => s.request.outcome);
   const retryAuth = useAgentStore((s) => s.retryAuth);
   const clearRateLimit = useAgentStore((s) => s.clearRateLimit);
   const sessionId = useSessionStore((s) => s.selectedId);
+  // Scoped to THIS composer's session — sessions can run concurrently, so the
+  // outcome must never be read off a single global "last request" field.
+  const outcome = useAgentStore((s) => (sessionId ? s.requestsBySession[sessionId]?.outcome : null));
   const planReady = useAgentStore(
     (s) => (sessionId ? s.bySession[sessionId]?.plan?.status : undefined) === 'ready',
   );

--- a/src/renderer/features/workspace/ConversationView.tsx
+++ b/src/renderer/features/workspace/ConversationView.tsx
@@ -133,24 +133,25 @@ function buildTurns(
 
 export function ConversationView({ sessionId }: { sessionId: string }) {
   const snapshot = useAgentStore((s) => s.bySession[sessionId]) ?? EMPTY_SNAPSHOT;
-  const pending = useAgentStore((s) => s.pending);
+  const pending = useAgentStore((s) => s.pendingBySession[sessionId] ?? null);
   // The active run's phase for THIS session — drives the pre-first-token skeleton
   // so the connect→first-token gap (the part that actually feels slow) shows the
   // shimmer instead of nothing. `ensureStreaming` only fires on the first token,
-  // so without this the skeleton's empty-text window never paints.
-  const thinking = useAgentStore(
-    (s) =>
-      s.request.sessionId === sessionId &&
-      (s.request.phase === 'submitting' ||
-        s.request.phase === 'connecting' ||
-        s.request.phase === 'streaming' ||
-        s.request.phase === 'recovering'),
-  );
+  // so without this the skeleton's empty-text window never paints. Reads the
+  // per-session phase map — sessions can run concurrently, so this must never
+  // fall back to a single global "the active request" field.
+  const thinking = useAgentStore((s) => {
+    const phase = s.requestsBySession[sessionId]?.phase;
+    return (
+      phase === 'submitting' ||
+      phase === 'connecting' ||
+      phase === 'streaming' ||
+      phase === 'recovering'
+    );
+  });
   // The run is paused on an AskUserQuestion for this session — the card lives
   // above the composer; here we only show a lightweight inline "waiting" status.
-  const clarifying = useAgentStore(
-    (s) => !!s.pendingClarification && s.pendingClarification.sessionId === sessionId,
-  );
+  const clarifying = useAgentStore((s) => !!s.pendingClarificationBySession[sessionId]);
   const bottomRef = useRef<HTMLDivElement>(null);
   const stick = useRef(true);
   // Id of the last user message we pinned to — lets us force-follow the user's own

--- a/src/renderer/features/workspace/InlineApproval.tsx
+++ b/src/renderer/features/workspace/InlineApproval.tsx
@@ -35,8 +35,8 @@ export function InlineApproval({ request }: { request: PermissionRequest }) {
   // Keyboard: Ctrl/Cmd+Enter allows, Esc denies — matches the button order.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') respond('deny');
-      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) respond('allow');
+      if (e.key === 'Escape') respond(request.id, 'deny');
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) respond(request.id, 'allow');
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
@@ -70,21 +70,21 @@ export function InlineApproval({ request }: { request: PermissionRequest }) {
       <div className="flex items-center gap-3 pt-0.5">
         <button
           type="button"
-          onClick={() => respond('allow')}
+          onClick={() => respond(request.id, 'allow')}
           className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-semibold text-base transition-opacity hover:opacity-90"
         >
           Allow
         </button>
         <button
           type="button"
-          onClick={() => respond('deny')}
+          onClick={() => respond(request.id, 'deny')}
           className="rounded-md border border-line px-3 py-1.5 text-[12px] font-medium text-muted transition-colors hover:bg-elevated hover:text-fg"
         >
           Deny
         </button>
         <button
           type="button"
-          onClick={() => respond('allow', true)}
+          onClick={() => respond(request.id, 'allow', true)}
           className="ml-auto text-[11.5px] text-faint transition-colors hover:text-fg"
         >
           Always allow this session

--- a/src/renderer/stores/useAgentStore.ts
+++ b/src/renderer/stores/useAgentStore.ts
@@ -47,15 +47,22 @@ const MAX_DIAGNOSTICS = 500;
 interface AgentStoreState {
   install: AgentInstall;
   lifecycle: AgentLifecycleStatus;
+  /** @deprecated legacy single-session mirror — use {@link requestsBySession}. */
   request: RequestState;
+  /** Per-session run phase. Sessions can run concurrently, so this (not the
+   *  single `request` field) is the source of truth for "is THIS session busy
+   *  / streaming / awaiting-permission". */
+  requestsBySession: Record<string, RequestState>;
   rateLimit?: RateLimitInfo;
   heartbeat: { lastOkAt: number | null; consecutiveFailures: number };
   activeSessionId: string | null;
   bySession: Record<string, AgentSessionSnapshot>;
   diagnostics: AgentDiagnostic[];
-  pending: PermissionRequest | null;
-  /** A pending AskUserQuestion clarification awaiting the user's answers. */
-  pendingClarification: ClarificationRequest | null;
+  /** Pending tool approvals, keyed by sessionId — a second session's request
+   *  must never clobber a first session's still-unanswered one. */
+  pendingBySession: Record<string, PermissionRequest>;
+  /** Pending AskUserQuestion clarifications, keyed by sessionId (same reasoning). */
+  pendingClarificationBySession: Record<string, ClarificationRequest>;
   hydrated: boolean;
 
   hydrate: () => Promise<void>;
@@ -66,8 +73,12 @@ interface AgentStoreState {
   clear: (sessionId: string) => void;
   clearRateLimit: () => void;
   retryAuth: () => void;
-  respond: (behavior: 'allow' | 'deny', remember?: boolean) => void;
-  respondClarification: (answers: Record<string, string | string[]>, response?: string) => void;
+  respond: (id: string, behavior: 'allow' | 'deny', remember?: boolean) => void;
+  respondClarification: (
+    id: string,
+    answers: Record<string, string | string[]>,
+    response?: string,
+  ) => void;
   approvePlan: (sessionId: string) => void;
   rejectPlan: (sessionId: string) => void;
   regeneratePlan: (sessionId: string, extra?: string) => void;
@@ -78,7 +89,12 @@ export const useAgentStore = create<AgentStoreState>((set, get) => {
   function apply(event: AgentEvent): void {
     // Global (session-less) events first.
     if (event.kind === 'request-state') {
-      set({ request: event.request });
+      // Merge into the per-session map — never overwrite other sessions'
+      // in-flight phases (see requestsBySession doc comment).
+      set((state) => ({
+        request: event.request,
+        requestsBySession: { ...state.requestsBySession, [event.sessionId]: event.request },
+      }));
       return;
     }
     if (event.kind === 'diagnostic') {
@@ -151,13 +167,14 @@ export const useAgentStore = create<AgentStoreState>((set, get) => {
     install: { installed: false },
     lifecycle: 'starting',
     request: IDLE_REQUEST,
+    requestsBySession: {},
     rateLimit: undefined,
     heartbeat: { lastOkAt: null, consecutiveFailures: 0 },
     activeSessionId: null,
     bySession: {},
     diagnostics: [],
-    pending: null,
-    pendingClarification: null,
+    pendingBySession: {},
+    pendingClarificationBySession: {},
     hydrated: false,
 
     hydrate: async () => {
@@ -174,9 +191,20 @@ export const useAgentStore = create<AgentStoreState>((set, get) => {
         install,
         lifecycle: agentState.lifecycle,
         request: agentState.request,
+        requestsBySession: agentState.requestsBySession ?? {},
         rateLimit: agentState.rateLimit,
         heartbeat: agentState.heartbeat,
         activeSessionId: agentState.activeSessionId,
+        // Replay any requests that were already pending before this window
+        // hydrated (e.g. a reload while another session is paused) — the
+        // discrete onPermissionRequest/onClarificationRequest events below
+        // only fire for NEW requests going forward.
+        pendingBySession: Object.fromEntries(
+          (agentState.pendingPermissions ?? []).map((r) => [r.sessionId, r]),
+        ),
+        pendingClarificationBySession: Object.fromEntries(
+          (agentState.pendingClarifications ?? []).map((r) => [r.sessionId, r]),
+        ),
       });
 
       api.onStateChanged((s) =>
@@ -190,8 +218,21 @@ export const useAgentStore = create<AgentStoreState>((set, get) => {
         }),
       );
       api.onEvent((event) => apply(event));
-      api.onPermissionRequest((request) => set({ pending: request }));
-      api.onClarificationRequest?.((request) => set({ pendingClarification: request }));
+      // Merge, never overwrite — a second session's request must not hide a
+      // first session's still-unanswered one (see pendingBySession doc comment).
+      api.onPermissionRequest((request) =>
+        set((state) => ({
+          pendingBySession: { ...state.pendingBySession, [request.sessionId]: request },
+        })),
+      );
+      api.onClarificationRequest?.((request) =>
+        set((state) => ({
+          pendingClarificationBySession: {
+            ...state.pendingClarificationBySession,
+            [request.sessionId]: request,
+          },
+        })),
+      );
 
       // Seed the diagnostics console with recent history.
       void get().loadDiagnostics();
@@ -255,22 +296,20 @@ export const useAgentStore = create<AgentStoreState>((set, get) => {
 
     stop: (sessionId) => {
       void window.limboo?.agent?.stop(sessionId);
-      // Stopping aborts any paused clarification for this session (main resolves
-      // the canUseTool promise via the abort signal) — drop the card too.
-      const { pendingClarification } = get();
-      if (pendingClarification?.sessionId === sessionId) {
-        set({ pendingClarification: null });
-      }
+      // Stopping aborts any paused request/clarification for this session (main
+      // resolves the canUseTool promise via the abort signal) — drop the cards
+      // for THIS session only, leaving any other session's cards untouched.
+      set((state) => ({
+        pendingBySession: omitKey(state.pendingBySession, sessionId),
+        pendingClarificationBySession: omitKey(state.pendingClarificationBySession, sessionId),
+      }));
     },
 
     clear: (sessionId) => {
       void window.limboo?.agent?.clearSession(sessionId);
       set((state) => ({
         bySession: { ...state.bySession, [sessionId]: emptySnapshot() },
-        pendingClarification:
-          state.pendingClarification?.sessionId === sessionId
-            ? null
-            : state.pendingClarification,
+        pendingClarificationBySession: omitKey(state.pendingClarificationBySession, sessionId),
       }));
     },
 
@@ -282,22 +321,26 @@ export const useAgentStore = create<AgentStoreState>((set, get) => {
       void window.limboo?.agent?.retryAuth?.();
     },
 
-    respond: (behavior, remember) => {
-      const { pending } = get();
-      if (!pending) return;
-      void window.limboo?.agent?.respondPermission({ id: pending.id, behavior, remember });
-      set({ pending: null });
+    respond: (id, behavior, remember) => {
+      const { pendingBySession } = get();
+      const entry = Object.values(pendingBySession).find((r) => r.id === id);
+      if (!entry) return;
+      void window.limboo?.agent?.respondPermission({ id, behavior, remember });
+      set((state) => ({ pendingBySession: omitKey(state.pendingBySession, entry.sessionId) }));
     },
 
-    respondClarification: (answers, response) => {
-      const { pendingClarification } = get();
-      if (!pendingClarification) return;
+    respondClarification: (id, answers, response) => {
+      const { pendingClarificationBySession } = get();
+      const entry = Object.values(pendingClarificationBySession).find((r) => r.id === id);
+      if (!entry) return;
       void window.limboo?.agent?.respondClarification?.({
-        id: pendingClarification.id,
+        id,
         answers,
         response,
       });
-      set({ pendingClarification: null });
+      set((state) => ({
+        pendingClarificationBySession: omitKey(state.pendingClarificationBySession, entry.sessionId),
+      }));
     },
 
     approvePlan: (sessionId) => {
@@ -330,6 +373,14 @@ function upsertMessage(messages: ChatMessage[], message: ChatMessage): ChatMessa
 function upsertChange(changes: FileChange[], change: FileChange): FileChange[] {
   const rest = changes.filter((c) => c.path !== change.path);
   return [...rest, change];
+}
+
+/** Return a copy of `record` with `key` removed, without mutating the input. */
+function omitKey<T>(record: Record<string, T>, key: string): Record<string, T> {
+  if (!(key in record)) return record;
+  const rest = { ...record };
+  delete rest[key];
+  return rest;
 }
 
 /** Stable empty snapshot so selectors don't churn when a session has no data. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1023,10 +1023,22 @@ export interface AgentState {
   /** Axis A — capability health. */
   lifecycle: AgentLifecycleStatus;
   install: AgentInstall;
-  /** Axis B — the active / last run. */
+  /**
+   * Axis B — the active / last run, kept for back-compat with anything that
+   * only cares about the most-recently-touched session. Multi-session UI must
+   * use {@link requestsBySession} instead — sessions can run concurrently, and
+   * this single field cannot represent more than one at a time.
+   */
   request: RequestState;
   /** Session id whose run is currently active, if any. */
   activeSessionId: string | null;
+  /** Per-session run phase — the source of truth once more than one session
+   *  can be in flight at once (see CLAUDE.md multi-session concurrency notes). */
+  requestsBySession: Record<string, RequestState>;
+  /** Every tool approval currently awaiting a renderer decision, across all sessions. */
+  pendingPermissions: PermissionRequest[];
+  /** Every `AskUserQuestion` clarification currently awaiting renderer answers, across all sessions. */
+  pendingClarifications: ClarificationRequest[];
   /** Present while lifecycle === 'rate-limited'. */
   rateLimit?: RateLimitInfo;
   /** Last capability-level error (NOT a request-level failure). */


### PR DESCRIPTION
…(`Map`-based), but the state it mirrors to the renderer — `pending`, `pendingClarification`, and `request` in [useAgentStore.ts](src/renderer/stores/useAgentStore.ts) — are single global fields that get silently overwritten whenever a second session fires an event. So when Session A pauses on `AskUserQuestion` and Session B does anything concurrently, Session A's card is wiped from the renderer's memory entirely (even though the main process is still correctly waiting on it) — matching exactly what you confirmed: multiple sessions, no card ever appearing, and confusing sidebar indicators.

<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent IPC/state sync and permission/clarification bridging across sessions; incorrect mapping could still mis-route approvals, but the change is narrowly scoped to per-session bookkeeping rather than new tool execution paths.
> 
> **Overview**
> Fixes **concurrent multi-session agent runs** where the renderer kept a single global `request`, `pending`, and `pendingClarification`, so a second session’s events could wipe another session’s paused approval or clarification UI even though main was still waiting.
> 
> **Main (`AgentManager`)** tracks run phase in a per-session map, patches phase with `setRequest(sessionId, …)`, and extends `getState()` with `requestsBySession`, `pendingPermissions`, and `pendingClarifications` so reloads and new windows can replay in-flight prompts. Pending permission/clarification entries retain the full request payload for that replay.
> 
> **Renderer (`useAgentStore` + workspace UI)** mirrors the same model: `requestsBySession`, `pendingBySession`, and `pendingClarificationBySession`; `respond` / `respondClarification` resolve by **request id**. Composer, banners, conversation, and session rows read **this session’s** phase and pending state. Sidebar rows show a **pulsing accent dot** when a session is in `awaiting-permission` (distinct from the streaming spinner).
> 
> Also adds a small `.claude/launch.json` dev configuration for `npm start` on port 5173.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04de22adea91f8ef9983c68f4ee6a7f2a8fc24b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session activity, approvals, and clarification prompts now track separately per session, improving multitasking and reducing UI confusion.
  * Sessions needing input are highlighted with a distinct status indicator.

* **Bug Fixes**
  * Fixed cases where one session’s running state, permissions, or clarification prompt could overwrite another’s.
  * Approval and clarification actions now apply to the correct session and request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->