### PR TITLE
I traced each issue to its root cause (verified in source, cross-chec…

### DIFF
--- a/src/main/managers/AgentManager.ts
+++ b/src/main/managers/AgentManager.ts
@@ -108,14 +108,15 @@ const IDLE_REQUEST: RequestState = {
 
 /**
  * Streamed text is coalesced before it crosses IPC: rather than one
- * `message-delta` per token (which floods IPC and forces a React render +
- * full-Markdown re-parse per token), deltas are buffered and flushed once the
- * buffer reaches DELTA_FLUSH_CHARS or DELTA_FLUSH_MS elapses — whichever comes
- * first. This caps renderer updates at ~25/s regardless of token rate while
- * keeping perceived latency well under one frame.
+ * `message-delta` per token (which floods IPC), deltas are buffered and flushed
+ * once the buffer reaches DELTA_FLUSH_CHARS or DELTA_FLUSH_MS elapses — whichever
+ * comes first. These are kept small so text emits near display-refresh cadence
+ * (smooth, real-time reveal rather than large periodic bursts); the renderer then
+ * coalesces bursts of deltas into one render per animation frame, so a fine flush
+ * here never causes a React render storm.
  */
-const DELTA_FLUSH_CHARS = 80;
-const DELTA_FLUSH_MS = 40;
+const DELTA_FLUSH_CHARS = 24;
+const DELTA_FLUSH_MS = 16;
 
 function classifyTool(name: string): ToolRisk {
   if (WRITE_TOOLS.has(name)) return 'write';

--- a/src/renderer/features/workspace/Composer.tsx
+++ b/src/renderer/features/workspace/Composer.tsx
@@ -148,11 +148,16 @@ export function Composer({ disabled = false }: { disabled?: boolean }) {
             )}
           </div>
 
-          <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1.5 px-1">
+          {/* One-line footer: as the center column narrows (side panels dragged
+              inward) the controls SHRINK — the select labels truncate — rather
+              than wrapping onto a new bottom row. No horizontal-overflow here on
+              purpose: the selects' popovers open upward, and any overflow-x would
+              force overflow-y:auto and clip them. */}
+          <div className="flex min-w-0 flex-nowrap items-center gap-x-2 px-1">
             <ComposerModeSwitch mode={mode} onChange={setMode} disabled={disabled || !installed} />
             <span className="hidden h-3.5 w-px shrink-0 bg-line sm:block" />
             <ComposerControls disabled={disabled || !installed} />
-            <span className="ml-auto flex min-w-0 items-center gap-2 text-[11px] text-faint">
+            <span className="ml-auto flex min-w-0 shrink items-center gap-2 text-[11px] text-faint">
               <StatusHint
                 installed={installed}
                 installError={installError}

--- a/src/renderer/features/workspace/ComposerControls.tsx
+++ b/src/renderer/features/workspace/ComposerControls.tsx
@@ -11,14 +11,17 @@ import { cn } from '@/renderer/lib/cn';
 import { ProviderIcon } from '@/renderer/components/brand/ProviderIcon';
 import { useSettingsStore } from '@/renderer/stores/useSettingsStore';
 
-interface Option<T extends string> {
+export interface Option<T extends string> {
   value: T;
   label: string;
   /** Optional leading glyph rendered in the menu + trigger. */
   glyph?: React.ReactNode;
 }
 
-function MiniSelect<T extends string>({
+/** A compact popover select used across the composer footer (model / thinking /
+ *  approval — and the Plan/Build mode switch). Exported so every composer control
+ *  reads and behaves identically (same trigger, popover, click-outside, Esc). */
+export function MiniSelect<T extends string>({
   value,
   options,
   onChange,
@@ -57,14 +60,14 @@ function MiniSelect<T extends string>({
   }, [open]);
 
   return (
-    <div ref={ref} className="relative no-drag">
+    <div ref={ref} className="relative no-drag min-w-0">
       <button
         type="button"
         title={title}
         disabled={disabled}
         onClick={() => setOpen((v) => !v)}
         className={cn(
-          'flex h-6 items-center gap-1 rounded-md px-1.5 text-[11px] text-muted transition-colors hover:bg-elevated hover:text-fg disabled:cursor-not-allowed disabled:opacity-50',
+          'flex h-6 min-w-0 max-w-full items-center gap-1 rounded-md px-1.5 text-[11px] text-muted transition-colors hover:bg-elevated hover:text-fg disabled:cursor-not-allowed disabled:opacity-50',
           open && 'bg-elevated text-fg',
         )}
       >
@@ -103,7 +106,7 @@ export function ComposerControls({ disabled = false }: { disabled?: boolean }) {
   const update = useSettingsStore((s) => s.update);
 
   return (
-    <div className="flex items-center gap-0.5">
+    <div className="flex min-w-0 items-center gap-0.5">
       <MiniSelect
         title="Model"
         value={agent.model}

--- a/src/renderer/features/workspace/ComposerModeSwitch.tsx
+++ b/src/renderer/features/workspace/ComposerModeSwitch.tsx
@@ -1,20 +1,34 @@
 /**
- * Plan / Implement segmented switch — the control that governs the agent's
- * execution mode for the next prompt. In Plan mode the agent runs read-only and
- * proposes an implementation strategy for review; in Implement mode it is free to
+ * Plan / Build mode select — the control that governs the agent's execution mode
+ * for the next prompt. In Plan mode the agent runs read-only and proposes an
+ * implementation strategy for review; in Build (implement) mode it is free to
  * modify the repository (still gated by the per-tool approval policy).
+ *
+ * Rendered as a compact popover select (the shared {@link MiniSelect}) so it looks
+ * and behaves exactly like the other composer footer controls — click the trigger,
+ * pick the other mode from a small menu — rather than an always-expanded segmented
+ * block. This also keeps the footer on one line as the center column narrows.
  *
  * Pure presentation: the selected mode lives in the Composer and is passed to
  * `agent.send(sessionId, prompt, mode)`.
  */
+import type { ReactNode } from 'react';
 import { ClipboardList, Hammer } from 'lucide-react';
 import type { AgentMode } from '@shared/types';
-import { cn } from '@/renderer/lib/cn';
+import { MiniSelect, type Option } from './ComposerControls';
 
-const MODES: Array<{ value: AgentMode; label: string; icon: typeof ClipboardList; title: string }> = [
-  { value: 'plan', label: 'Plan', icon: ClipboardList, title: 'Plan — analyze the repository and propose a strategy (read-only)' },
-  { value: 'implement', label: 'Build', icon: Hammer, title: 'Implement — let the agent modify the repository' },
+const MODE_GLYPH: Record<AgentMode, ReactNode> = {
+  plan: <ClipboardList size={13} className="text-accent" />,
+  implement: <Hammer size={13} className="text-muted" />,
+};
+
+const MODE_OPTIONS: Option<AgentMode>[] = [
+  { value: 'plan', label: 'Plan', glyph: MODE_GLYPH.plan },
+  { value: 'implement', label: 'Build', glyph: MODE_GLYPH.implement },
 ];
+
+const MODE_TITLE =
+  'Execution mode — Plan analyzes the repository read-only and proposes a strategy; Build lets the agent modify it';
 
 export function ComposerModeSwitch({
   mode,
@@ -26,30 +40,15 @@ export function ComposerModeSwitch({
   disabled?: boolean;
 }) {
   return (
-    <div className="no-drag inline-flex items-center gap-0.5 rounded-md border border-line bg-surface p-0.5">
-      {MODES.map(({ value, label, icon: Icon, title }) => {
-        const active = mode === value;
-        return (
-          <button
-            key={value}
-            type="button"
-            title={title}
-            disabled={disabled}
-            onClick={() => onChange(value)}
-            className={cn(
-              'flex h-6 items-center gap-1 rounded-[5px] px-2 text-[11px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50',
-              active
-                ? value === 'plan'
-                  ? 'bg-elevated text-accent'
-                  : 'bg-elevated text-fg'
-                : 'text-muted hover:text-fg',
-            )}
-          >
-            <Icon size={12} />
-            {label}
-          </button>
-        );
-      })}
-    </div>
+    <MiniSelect
+      title={MODE_TITLE}
+      value={mode}
+      options={MODE_OPTIONS}
+      onChange={onChange}
+      // Mirror the active mode's glyph on the trigger so the current mode reads at
+      // a glance, matching the model select's provider-mark trigger.
+      triggerGlyph={MODE_GLYPH[mode]}
+      disabled={disabled}
+    />
   );
 }

--- a/src/renderer/features/workspace/ConversationView.tsx
+++ b/src/renderer/features/workspace/ConversationView.tsx
@@ -13,7 +13,7 @@
  * full-width Markdown (with streaming-aware highlighted code blocks); the user's
  * turn renders as a compact right-aligned bubble.
  */
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { memo, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import {
   Check,
   ChevronRight,
@@ -238,7 +238,11 @@ function findScrollParent(node: HTMLElement | null): HTMLElement | null {
   return null;
 }
 
-function TurnView({
+// Memoized so a streaming delta (which re-renders ConversationView every frame)
+// only re-renders the in-flight turn: settled turns receive referentially-stable
+// props (their `turn` object keeps identity across rebuilds, and approval/waiting/
+// thinking are only truthy for the last turn) and skip re-rendering entirely.
+const TurnView = memo(function TurnView({
   turn,
   approval,
   waiting,
@@ -266,6 +270,38 @@ function TurnView({
       {showAssistant && <AssistantBlock blocks={turn.blocks} trailing={trailing} />}
     </div>
   );
+}, turnsEqual);
+
+/** The payload behind a block (message / tool call / activity item). Blocks are
+ *  rebuilt (fresh wrappers) on every event, but the underlying entities keep their
+ *  identity unless they actually changed — so a settled turn compares equal and a
+ *  streaming turn (whose message object is replaced each frame) does not. */
+function blockPayload(b: Block): unknown {
+  return b.kind === 'text' ? b.message : b.kind === 'tool' ? b.call : b.item;
+}
+
+function sameBlocks(a: Block[], b: Block[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].kind !== b[i].kind || blockPayload(a[i]) !== blockPayload(b[i])) return false;
+  }
+  return true;
+}
+
+/** memo comparator for {@link TurnView}: skip re-render when nothing this turn
+ *  depends on changed by identity. This is what keeps streaming cheap. */
+function turnsEqual(
+  prev: { turn: Turn; approval: PermissionRequest | null; waiting?: boolean; thinking?: boolean },
+  next: { turn: Turn; approval: PermissionRequest | null; waiting?: boolean; thinking?: boolean },
+): boolean {
+  return (
+    prev.approval === next.approval &&
+    prev.waiting === next.waiting &&
+    prev.thinking === next.thinking &&
+    prev.turn.key === next.turn.key &&
+    prev.turn.user === next.turn.user &&
+    sameBlocks(prev.turn.blocks, next.turn.blocks)
+  );
 }
 
 /** Lightweight inline status while the run is paused on an AskUserQuestion. The
@@ -282,7 +318,7 @@ function WaitingForDecision() {
 function UserBubble({ message }: { message: ChatMessage }) {
   return (
     <div className="flex justify-end">
-      <div className="max-w-[85%] whitespace-pre-wrap break-words rounded-md bg-surface-2 px-4 py-2.5 text-[13.5px] leading-relaxed text-fg shadow-sm animate-fade-in">
+      <div className="max-w-[85%] whitespace-pre-wrap break-words rounded-2xl rounded-br-md border border-line bg-surface-2 px-4 py-2.5 text-[13.5px] leading-relaxed text-fg shadow-sm animate-fade-in">
         {message.text}
       </div>
     </div>
@@ -292,7 +328,13 @@ function UserBubble({ message }: { message: ChatMessage }) {
 /** The assistant's response for a turn: a single avatar plus a vertical flow of
  *  chronologically-interleaved sub-items (text, tool rows, status markers, and an
  *  optional trailing approval). */
-function AssistantBlock({ blocks, trailing }: { blocks: Block[]; trailing?: ReactNode }) {
+const AssistantBlock = memo(function AssistantBlock({
+  blocks,
+  trailing,
+}: {
+  blocks: Block[];
+  trailing?: ReactNode;
+}) {
   const streaming = blocks.some((b) => b.kind === 'text' && b.message.streaming);
   return (
     <div className="flex gap-3 animate-fade-in">
@@ -309,7 +351,7 @@ function AssistantBlock({ blocks, trailing }: { blocks: Block[]; trailing?: Reac
       </div>
     </div>
   );
-}
+});
 
 function AssistantText({ message }: { message: ChatMessage }) {
   // A streaming message with no text yet is the pre-first-token moment — reserve

--- a/src/renderer/stores/useAgentStore.ts
+++ b/src/renderer/stores/useAgentStore.ts
@@ -85,6 +85,56 @@ interface AgentStoreState {
 }
 
 export const useAgentStore = create<AgentStoreState>((set, get) => {
+  // Streamed-delta frame batching. A burst of `message-delta` events (the main
+  // process now flushes finely so text reveals smoothly) would otherwise force a
+  // React render per delta. Instead we accumulate delta text per streaming
+  // message and apply it to the store ONCE per animation frame — collapsing a
+  // burst into a single render aligned to the display refresh. Any non-delta
+  // event flushes the buffer first so `message-done` carries the full text and
+  // timeline ordering is preserved.
+  const deltaBuffer = new Map<string, { sessionId: string; text: string }>(); // key: messageId
+  let rafHandle: number | null = null;
+
+  const scheduleFlush = (): void => {
+    if (rafHandle !== null) return;
+    if (typeof requestAnimationFrame === 'function') {
+      rafHandle = requestAnimationFrame(() => flushDeltasNow());
+    } else {
+      rafHandle = setTimeout(() => flushDeltasNow(), 16) as unknown as number;
+    }
+  };
+
+  const flushDeltasNow = (): void => {
+    if (rafHandle !== null) {
+      if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(rafHandle);
+      else clearTimeout(rafHandle as unknown as ReturnType<typeof setTimeout>);
+      rafHandle = null;
+    }
+    if (deltaBuffer.size === 0) return;
+    // messageId -> accumulated text, and the set of sessions touched this frame.
+    const appends = new Map<string, string>(); // key: messageId
+    const sessions = new Set<string>();
+    for (const [messageId, entry] of deltaBuffer) {
+      appends.set(messageId, entry.text);
+      sessions.add(entry.sessionId);
+    }
+    deltaBuffer.clear();
+    set((state) => {
+      const bySession = { ...state.bySession };
+      for (const sessionId of sessions) {
+        const prev = bySession[sessionId] ?? emptySnapshot();
+        bySession[sessionId] = {
+          ...prev,
+          messages: prev.messages.map((m) => {
+            const add = appends.get(m.id);
+            return add ? { ...m, text: m.text + add, streaming: true } : m;
+          }),
+        };
+      }
+      return { bySession };
+    });
+  };
+
   /** Apply a structured event to its session's snapshot / global state. */
   function apply(event: AgentEvent): void {
     // Global (session-less) events first.
@@ -104,6 +154,18 @@ export const useAgentStore = create<AgentStoreState>((set, get) => {
       return;
     }
 
+    // Streamed text: accumulate and apply on the next frame (see deltaBuffer).
+    if (event.kind === 'message-delta') {
+      const existing = deltaBuffer.get(event.messageId);
+      if (existing) existing.text += event.text;
+      else deltaBuffer.set(event.messageId, { sessionId: event.sessionId, text: event.text });
+      scheduleFlush();
+      return;
+    }
+    // Any other event must see the fully-applied stream first — otherwise a
+    // `message-done` (which replaces text) could race ahead of buffered deltas.
+    flushDeltasNow();
+
     set((state) => {
       const prev = state.bySession[event.sessionId] ?? emptySnapshot();
       const next: AgentSessionSnapshot = {
@@ -119,11 +181,8 @@ export const useAgentStore = create<AgentStoreState>((set, get) => {
         case 'message-start':
           next.messages = upsertMessage(prev.messages, event.message);
           break;
-        case 'message-delta':
-          next.messages = prev.messages.map((m) =>
-            m.id === event.messageId ? { ...m, text: m.text + event.text, streaming: true } : m,
-          );
-          break;
+        // 'message-delta' is handled ahead of this switch via the frame-batched
+        // deltaBuffer (flushed just above), so it never reaches here.
         case 'message-done':
           next.messages = upsertMessage(prev.messages, event.message);
           break;

--- a/src/renderer/styles/index.css
+++ b/src/renderer/styles/index.css
@@ -131,8 +131,10 @@ html[data-reduced-motion="true"] *::after {
 }
 
 /* Skeleton shimmer for the pre-first-token assistant placeholder. Sweeps a
-   surface-2 → elevated → surface-2 highlight across the bar, on-palette (no new
-   hex, no content gradient — purely a loading affordance). */
+   highlight across the bar, on-palette (no content gradient — purely a loading
+   affordance). The base/highlight sit high enough on the gray ramp to stay
+   clearly legible on the pure-black background (surface-2 → elevated was nearly
+   invisible against #000). */
 @keyframes limboo-shimmer {
   from { background-position: -200% 0; }
   to { background-position: 200% 0; }
@@ -149,9 +151,9 @@ html[data-reduced-motion="true"] *::after {
 @utility animate-shimmer {
   background-image: linear-gradient(
     90deg,
-    var(--color-surface-2) 25%,
-    var(--color-elevated) 50%,
-    var(--color-surface-2) 75%
+    var(--color-line) 25%,
+    var(--color-line-strong) 50%,
+    var(--color-line) 75%
   );
   background-size: 200% 100%;
   animation: limboo-shimmer 1.4s ease-in-out infinite;


### PR DESCRIPTION
…ked with web research on streaming-render patterns) and fixed all five.

<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renderer streaming batching and UI layout only; no auth, IPC contract, or main-process security path changes beyond delta flush tuning.
> 
> **Overview**
> Improves **assistant text streaming** end-to-end: main process flushes smaller, faster `message-delta` IPC chunks (~24 chars / ~16ms), and the agent store **batches deltas per animation frame** so bursts collapse to one React update per frame; non-delta events flush the buffer first so `message-done` cannot race buffered text.
> 
> **Conversation performance** adds `memo` on turn and assistant blocks with identity-based comparators so only the in-flight turn re-renders during streaming, not the full history.
> 
> **Composer footer** keeps controls on one line when the center column narrows (`flex-nowrap`, `min-w-0` truncation). Plan/Build switches from a segmented control to the shared **`MiniSelect`** popover used by model/thinking/approval.
> 
> Minor polish: user message bubble border/radius, and skeleton **shimmer** tokens adjusted for visibility on pure black.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2da8f593b8af82e112f9d271c6493d116943853. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->