### PR TITLE
Create-workspace bug fix** → clicking "Create workspace" now opens an…

### DIFF
--- a/src/main/ipc/workspaceHandlers.ts
+++ b/src/main/ipc/workspaceHandlers.ts
@@ -44,6 +44,42 @@ function assertValidPath(p: unknown): asserts p is string {
   }
 }
 
+/** Characters never allowed in a new workspace folder name: Windows reserved
+ *  filename characters plus ASCII control codes. */
+// eslint-disable-next-line no-control-regex
+const ILLEGAL_NAME_CHARS = /[<>:"/\\|?*\x00-\x1f]/;
+/** Reserved device names Windows forbids as a directory name (case-insensitive). */
+const RESERVED_NAMES = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
+
+/**
+ * Validate a renderer-supplied name for a *new* workspace folder. Rejects path
+ * separators, traversal, illegal characters, reserved Windows device names, and
+ * over-long input before the main process ever calls `mkdir`. The name must be a
+ * single folder segment — the parent location is validated separately.
+ */
+function assertValidWorkspaceName(name: unknown): asserts name is string {
+  if (typeof name !== 'string') {
+    throw new Error('workspace:createNew name must be a string');
+  }
+  const trimmed = name.trim();
+  if (trimmed.length === 0 || trimmed.length > WORKSPACE_LIMITS.nameMax) {
+    throw new Error('workspace:createNew name is empty or too long');
+  }
+  if (trimmed === '.' || trimmed === '..') {
+    throw new Error('workspace:createNew name is not a valid folder name');
+  }
+  if (ILLEGAL_NAME_CHARS.test(trimmed)) {
+    throw new Error('workspace:createNew name contains characters that are not allowed');
+  }
+  // Trailing dots/spaces are stripped by Windows and cause surprising folder names.
+  if (/[. ]$/.test(trimmed)) {
+    throw new Error('workspace:createNew name may not end with a space or dot');
+  }
+  if (RESERVED_NAMES.test(trimmed)) {
+    throw new Error('workspace:createNew name is a reserved system name');
+  }
+}
+
 /** Cap on how many ignored-dir entries a config patch may carry. */
 const MAX_IGNORED_DIRS = 200;
 /** Per-entry length cap for an ignored-dir glob/name. */
@@ -127,6 +163,34 @@ export function registerWorkspaceHandlers(workspace: WorkspaceManager): void {
       return rethrow(err);
     }
   });
+
+  handle<[{ name: string; parentPath: string; initGit: boolean }], Workspace>(
+    IpcChannels.workspaceCreateNew,
+    (_e, input) => {
+      if (!isPlainObject(input)) {
+        throw new Error('workspace:createNew expects an object payload');
+      }
+      // Keep the prototype-pollution guard consistent with updateConfig.
+      assertNoPollutingKeys(input);
+      assertValidWorkspaceName((input as { name?: unknown }).name);
+      assertValidPath((input as { parentPath?: unknown }).parentPath);
+      const initGit = (input as { initGit?: unknown }).initGit;
+      if (typeof initGit !== 'boolean') {
+        throw new Error('workspace:createNew initGit must be a boolean');
+      }
+      try {
+        return workspace.createNew({
+          name: (input as { name: string }).name.trim(),
+          parentPath: (input as { parentPath: string }).parentPath,
+          initGit,
+        });
+      } catch (err) {
+        // Log the failure without the raw path (redaction: id/paths stay out of logs).
+        logger.warn('workspace:createNew failed');
+        return rethrow(err);
+      }
+    },
+  );
 
   handle<[string], Workspace>(IpcChannels.workspaceOpen, (_e, p) => {
     assertValidPath(p);

--- a/src/main/managers/WorkspaceManager.ts
+++ b/src/main/managers/WorkspaceManager.ts
@@ -8,6 +8,8 @@
  * lifecycle state machine, and broadcast changes to all windows.
  */
 import crypto from 'node:crypto';
+import fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { BrowserWindow } from 'electron';
 import type Database from 'better-sqlite3';
 import { IpcEvents } from '@shared/ipc-channels';
@@ -26,7 +28,7 @@ import path from 'node:path';
 import { deriveIcon } from './workspace/icon';
 import { detectWorkspace } from './workspace/detect';
 import { computeStats } from './workspace/stats';
-import { validateWorkspacePath } from './workspace/validate';
+import { validateWorkspacePath, isInsideRoot } from './workspace/validate';
 
 interface WorkspaceRow {
   id: string;
@@ -115,6 +117,68 @@ export class WorkspaceManager {
   /** Register a directory as a new workspace (or open it if it already exists). */
   create(inputPath: string): Workspace {
     return this.register(inputPath, 'created');
+  }
+
+  /**
+   * Create a brand-new project directory inside `parentPath` and register it as a
+   * workspace. Unlike `create()` (which expects an already-existing folder), this
+   * makes the folder itself so the in-app "Create workspace" flow never has to pop
+   * the native OS folder dialog.
+   *
+   * Security (CLAUDE.md §6): the parent is validated through the same pipeline as
+   * an opened workspace (realpath, forbidden roots, home dir, read/write perms);
+   * the leaf name is re-checked to stay directly inside that *real* parent so a
+   * crafted name with separators or `..` can never escape the chosen location; the
+   * directory is created non-recursively and an existing non-empty folder is
+   * refused; `git init` runs argv-only (no `shell: true`) with a bounded timeout
+   * and its failure is soft (the workspace is still valid without a repo).
+   */
+  createNew(input: { name: string; parentPath: string; initGit: boolean }): Workspace {
+    const name = input.name.trim();
+
+    // Validate + canonicalize the parent directory (reuses the open-time checks).
+    const { result, realPath: parentReal } = validateWorkspacePath(input.parentPath, {
+      existingPaths: [],
+    });
+    if (!result.ok) {
+      throw new WorkspaceValidationError(result);
+    }
+
+    const target = path.join(parentReal, name);
+    // Defense in depth: after path.join, the new folder must be a *direct* child of
+    // the real parent. This rejects any name that still slipped a separator or `..`.
+    if (!isInsideRoot(parentReal, target) || path.dirname(target) !== parentReal) {
+      throw new WorkspaceValidationError({
+        ok: false,
+        errors: ['The workspace name must be a single folder name, not a path.'],
+        warnings: [],
+      });
+    }
+
+    // Create the directory. Never silently adopt a pre-existing, non-empty folder.
+    if (fs.existsSync(target)) {
+      if (fs.readdirSync(target).length > 0) {
+        throw new WorkspaceValidationError({
+          ok: false,
+          errors: ['A non-empty folder with that name already exists at this location.'],
+          warnings: [],
+        });
+      }
+    } else {
+      fs.mkdirSync(target, { recursive: false });
+    }
+
+    if (input.initGit) {
+      try {
+        execFileSync('git', ['init'], { cwd: target, timeout: 5000, stdio: 'ignore' });
+      } catch (err) {
+        logger.warn('workspace:createNew git init failed (workspace still created)', err);
+      }
+    }
+
+    // Register the freshly-created path through the shared pipeline (detect + icon +
+    // persist + set active). Logs the workspace id, not the raw path.
+    return this.register(target, 'created');
   }
 
   /** Open an existing directory as a workspace (same pipeline as create). */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -120,6 +120,8 @@ const workspaceApi = {
     ipcRenderer.invoke(IpcChannels.workspacePickDirectory),
   create: (path: string): Promise<Workspace> =>
     ipcRenderer.invoke(IpcChannels.workspaceCreate, path),
+  createNew: (input: { name: string; parentPath: string; initGit: boolean }): Promise<Workspace> =>
+    ipcRenderer.invoke(IpcChannels.workspaceCreateNew, input),
   open: (path: string): Promise<Workspace> => ipcRenderer.invoke(IpcChannels.workspaceOpen, path),
   switch: (id: string): Promise<Workspace> => ipcRenderer.invoke(IpcChannels.workspaceSwitch, id),
   remove: (id: string, deleteFiles = false): Promise<void> =>

--- a/src/renderer/features/workspace/WorkspaceActionButton.tsx
+++ b/src/renderer/features/workspace/WorkspaceActionButton.tsx
@@ -12,6 +12,12 @@ interface WorkspaceActionButtonProps {
   children: ReactNode;
   onClick: () => void;
   variant?: 'primary' | 'secondary';
+  /** `lg` gives the roomier, higher-emphasis target used on the launcher hero. */
+  size?: 'md' | 'lg';
+  /** Stretch to fill its container (used for stacked, narrow-width layouts). */
+  fullWidth?: boolean;
+  type?: 'button' | 'submit';
+  disabled?: boolean;
   className?: string;
 }
 
@@ -20,21 +26,29 @@ export function WorkspaceActionButton({
   children,
   onClick,
   variant = 'secondary',
+  size = 'md',
+  fullWidth = false,
+  type = 'button',
+  disabled = false,
   className,
 }: WorkspaceActionButtonProps) {
+  const lg = size === 'lg';
   return (
     <button
-      type="button"
+      type={type}
       onClick={onClick}
+      disabled={disabled}
       className={cn(
-        'flex items-center gap-2 rounded-lg px-4 py-2 text-[13px] font-medium transition-colors active:scale-[0.99]',
+        'flex items-center justify-center font-medium transition-colors active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50',
+        lg ? 'gap-2.5 rounded-xl px-6 py-3 text-[15px]' : 'gap-2 rounded-lg px-4 py-2 text-[13px]',
+        fullWidth && 'w-full',
         variant === 'primary'
           ? 'bg-accent text-base font-semibold transition-opacity hover:opacity-90'
           : 'border border-line bg-surface-2 text-fg hover:border-line-strong',
         className,
       )}
     >
-      <Icon size={16} />
+      <Icon size={lg ? 18 : 16} />
       {children}
     </button>
   );

--- a/src/renderer/features/workspace/WorkspaceCreatePanel.tsx
+++ b/src/renderer/features/workspace/WorkspaceCreatePanel.tsx
@@ -1,0 +1,189 @@
+/**
+ * In-app "Create workspace" panel. Replaces the old behaviour where clicking
+ * "Create workspace" immediately opened the native OS folder dialog — instead the
+ * launcher switches to this form, so the user stays inside the app. It collects a
+ * folder name, a parent location (the only place a native picker is used, behind an
+ * explicit "Browse" button), and an optional "Initialize git repository" toggle,
+ * then calls the validated `workspace:createNew` IPC which creates the directory and
+ * enters the new workspace.
+ *
+ * All filesystem work + authoritative validation happen in the main process; this
+ * form only does light, friendly pre-checks to guide input.
+ */
+import { useMemo, useState } from 'react';
+import { ArrowLeft, FolderSearch, GitBranch, FolderPlus } from 'lucide-react';
+import { cn } from '@/renderer/lib/cn';
+import { useWorkspaceStore } from '@/renderer/stores/useWorkspaceStore';
+import { useUIStore } from '@/renderer/stores/useUIStore';
+import { WorkspaceActionButton } from './WorkspaceActionButton';
+
+/** Mirror of the main-process name guard, for immediate inline feedback only. */
+// eslint-disable-next-line no-control-regex
+const ILLEGAL = /[<>:"/\\|?*\x00-\x1f]/;
+const RESERVED = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
+
+function nameError(name: string): string | null {
+  const n = name.trim();
+  if (n.length === 0) return null; // empty = just disabled, not an error yet
+  if (n === '.' || n === '..') return 'Not a valid folder name.';
+  if (ILLEGAL.test(n)) return 'Remove characters like / \\ : * ? " < > |.';
+  if (/[. ]$/.test(n)) return 'Cannot end with a space or a dot.';
+  if (RESERVED.test(n)) return 'That is a reserved system name.';
+  return null;
+}
+
+export function WorkspaceCreatePanel() {
+  const pickDirectory = useWorkspaceStore((s) => s.pickDirectory);
+  const createNew = useWorkspaceStore((s) => s.createNew);
+  const setLauncherView = useWorkspaceStore((s) => s.setLauncherView);
+  const addToast = useUIStore((s) => s.addToast);
+
+  const [name, setName] = useState('');
+  const [parentPath, setParentPath] = useState('');
+  const [initGit, setInitGit] = useState(true);
+  const [busy, setBusy] = useState(false);
+
+  const err = useMemo(() => nameError(name), [name]);
+  const canCreate = name.trim().length > 0 && parentPath.trim().length > 0 && !err && !busy;
+
+  const preview = useMemo(() => {
+    const p = parentPath.trim().replace(/[/\\]+$/, '');
+    const n = name.trim();
+    if (!p) return '';
+    // Join with the separator already present in the parent path (win vs posix).
+    const sep = p.includes('\\') ? '\\' : '/';
+    return n ? `${p}${sep}${n}` : p;
+  }, [parentPath, name]);
+
+  const browse = async () => {
+    try {
+      const dir = await pickDirectory();
+      if (dir) setParentPath(dir);
+    } catch {
+      /* cancelling the picker is not an error */
+    }
+  };
+
+  const submit = async () => {
+    if (!canCreate) return;
+    setBusy(true);
+    try {
+      await createNew(name.trim(), parentPath.trim(), initGit);
+      // On success the store flips activeId and the shell replaces this screen.
+    } catch (e) {
+      addToast({
+        title: 'Could not create workspace',
+        description: e instanceof Error ? e.message : String(e),
+        tone: 'danger',
+      });
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto flex h-full w-full max-w-xl flex-col justify-center gap-6 py-8">
+      <button
+        type="button"
+        onClick={() => setLauncherView('list')}
+        className="flex w-fit items-center gap-1.5 text-[12px] text-muted transition-colors hover:text-fg"
+      >
+        <ArrowLeft size={14} />
+        Back to workspaces
+      </button>
+
+      <div className="flex flex-col gap-1">
+        <h1 className="text-lg font-semibold tracking-tight text-fg">Create a workspace</h1>
+        <p className="text-[12px] text-muted">
+          Limboo creates the project folder, then profiles it automatically.
+        </p>
+      </div>
+
+      <form
+        className="flex flex-col gap-5"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void submit();
+        }}
+      >
+        {/* Name */}
+        <label className="flex flex-col gap-1.5">
+          <span className="text-[12px] font-medium text-muted">Name</span>
+          <input
+            autoFocus
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="my-project"
+            className={cn(
+              'rounded-lg border bg-surface-2 px-3 py-2.5 text-[14px] text-fg placeholder:text-faint focus:outline-none',
+              err ? 'border-danger' : 'border-line focus:border-line-strong',
+            )}
+          />
+          {err && <span className="text-[11px] text-danger">{err}</span>}
+        </label>
+
+        {/* Location */}
+        <label className="flex flex-col gap-1.5">
+          <span className="text-[12px] font-medium text-muted">Location</span>
+          <div className="flex items-center gap-2">
+            <input
+              value={parentPath}
+              onChange={(e) => setParentPath(e.target.value)}
+              placeholder="Choose a parent folder…"
+              className="min-w-0 flex-1 rounded-lg border border-line bg-surface-2 px-3 py-2.5 text-[14px] text-fg placeholder:text-faint focus:border-line-strong focus:outline-none"
+            />
+            <button
+              type="button"
+              onClick={browse}
+              className="flex shrink-0 items-center gap-1.5 rounded-lg border border-line bg-surface-2 px-3 py-2.5 text-[13px] text-fg transition-colors hover:border-line-strong"
+            >
+              <FolderSearch size={15} />
+              Browse
+            </button>
+          </div>
+          {preview && (
+            <span className="truncate font-mono text-[11px] text-faint" title={preview}>
+              → {preview}
+            </span>
+          )}
+        </label>
+
+        {/* Initialize git */}
+        <button
+          type="button"
+          onClick={() => setInitGit((v) => !v)}
+          className="flex items-center justify-between rounded-lg border border-line bg-surface-2 px-3 py-2.5 text-left transition-colors hover:border-line-strong"
+        >
+          <span className="flex items-center gap-2 text-[13px] text-fg">
+            <GitBranch size={15} className="text-muted" />
+            Initialize git repository
+          </span>
+          <span
+            className={cn(
+              'relative h-5 w-9 rounded-full transition-colors',
+              initGit ? 'bg-accent' : 'bg-line-strong',
+            )}
+          >
+            <span
+              className={cn(
+                'absolute top-0.5 h-4 w-4 rounded-full bg-base transition-all',
+                initGit ? 'left-[18px]' : 'left-0.5',
+              )}
+            />
+          </span>
+        </button>
+
+        <div className="mt-1 flex items-center justify-end gap-2">
+          <WorkspaceActionButton
+            icon={FolderPlus}
+            variant="primary"
+            size="lg"
+            disabled={!canCreate}
+            onClick={submit}
+          >
+            {busy ? 'Creating…' : 'Create workspace'}
+          </WorkspaceActionButton>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/renderer/features/workspace/WorkspaceDropZone.tsx
+++ b/src/renderer/features/workspace/WorkspaceDropZone.tsx
@@ -1,60 +1,83 @@
 /**
- * Drag-and-drop target for adding a workspace by dropping a project folder.
- * Doubles as the modern empty state on the launcher. Resolves the dropped
- * folder's real path through `window.limboo.system.getDroppedPath` (the
- * Electron-32+ supported replacement for `File.path`) and hands it to the
- * validated `workspace:open` IPC — the renderer never touches the filesystem.
+ * Drag-and-drop support for adding a workspace by dropping a project folder, split
+ * into two pieces:
  *
- * Marked `data-dropzone` so the global drop-navigation guard
- * (`usePreventFileDrop`) lets these events through to be handled here.
+ *  - `WorkspaceDragOverlay` — a full-area drop target that appears ONLY while a file
+ *    is being dragged over the window (no permanent dashed box at rest). It resolves
+ *    the dropped folder's real path through `window.limboo.system.getDroppedPath`
+ *    (the Electron-32+ replacement for `File.path`) and hands it to the validated
+ *    `workspace:open` IPC — the renderer never touches the filesystem.
+ *  - `WorkspaceActions` — the always-visible Open / Create buttons (no dashed
+ *    border), used by both the empty state and the populated launcher.
+ *
+ * The overlay is marked `data-dropzone` so the global drop-navigation guard
+ * (`usePreventFileDrop`) lets its events through to be handled here.
  */
-import { useRef, useState } from 'react';
-import { FolderInput, FolderOpen, FolderPlus } from 'lucide-react';
+import { FolderOpen, FolderPlus, FolderInput } from 'lucide-react';
 import { cn } from '@/renderer/lib/cn';
 import { useWorkspaceStore } from '@/renderer/stores/useWorkspaceStore';
 import { useUIStore } from '@/renderer/stores/useUIStore';
+import { useFileDragActive } from '@/renderer/hooks/usePreventFileDrop';
 import { WorkspaceActionButton } from './WorkspaceActionButton';
-import type { Workspace } from '@shared/types';
 
-interface WorkspaceDropZoneProps {
-  /** Compact variant for the always-visible affordance above a populated list. */
-  compact?: boolean;
-}
-
-export function WorkspaceDropZone({ compact = false }: WorkspaceDropZoneProps) {
+/** Open / Create actions. `size='lg'` is the roomier hero variant on the empty state. */
+export function WorkspaceActions({ size = 'md' }: { size?: 'md' | 'lg' }) {
   const pickDirectory = useWorkspaceStore((s) => s.pickDirectory);
   const open = useWorkspaceStore((s) => s.open);
-  const create = useWorkspaceStore((s) => s.create);
-  const openPath = useWorkspaceStore((s) => s.openPath);
+  const setLauncherView = useWorkspaceStore((s) => s.setLauncherView);
   const addToast = useUIStore((s) => s.addToast);
 
-  const [isDragging, setIsDragging] = useState(false);
-  // Drag enter/leave fire for child elements too; count depth to know when the
-  // cursor has truly left the zone.
-  const depth = useRef(0);
-
-  const toastError = (err: unknown) =>
-    addToast({
-      title: 'Could not open workspace',
-      description: err instanceof Error ? err.message : String(err),
-      tone: 'danger',
-    });
-
-  const pickAnd = async (action: (path: string) => Promise<Workspace | null>) => {
+  const openFolder = async () => {
     try {
       const dir = await pickDirectory();
       if (!dir) return;
-      await action(dir);
+      await open(dir);
     } catch (err) {
-      toastError(err);
+      addToast({
+        title: 'Could not open workspace',
+        description: err instanceof Error ? err.message : String(err),
+        tone: 'danger',
+      });
     }
   };
+
+  return (
+    <div
+      className={cn(
+        'flex w-full flex-wrap items-center justify-center gap-2',
+        size === 'lg' && 'gap-3',
+      )}
+    >
+      <WorkspaceActionButton icon={FolderOpen} variant="secondary" size={size} onClick={openFolder}>
+        Open folder
+      </WorkspaceActionButton>
+      {/* In-app create flow — opens the Create panel, never the OS folder dialog. */}
+      <WorkspaceActionButton
+        icon={FolderPlus}
+        variant="primary"
+        size={size}
+        onClick={() => setLauncherView('create')}
+      >
+        Create workspace
+      </WorkspaceActionButton>
+    </div>
+  );
+}
+
+/**
+ * Full-area drop target, rendered only during an active file drag. Absolute-fills
+ * its positioned parent (the launcher body), so the parent must be `relative`.
+ */
+export function WorkspaceDragOverlay() {
+  const openPath = useWorkspaceStore((s) => s.openPath);
+  const addToast = useUIStore((s) => s.addToast);
+  const dragging = useFileDragActive();
+
+  if (!dragging) return null;
 
   const onDrop = async (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    depth.current = 0;
-    setIsDragging(false);
 
     const files = Array.from(e.dataTransfer.files ?? []);
     if (files.length === 0) return;
@@ -75,57 +98,33 @@ export function WorkspaceDropZone({ compact = false }: WorkspaceDropZoneProps) {
       // happens in the main process via the workspace:open IPC.
       await openPath(path);
     } catch (err) {
-      toastError(err);
+      addToast({
+        title: 'Could not open workspace',
+        description: err instanceof Error ? err.message : String(err),
+        tone: 'danger',
+      });
     }
   };
 
   return (
     <div
       data-dropzone
-      onDragEnter={(e) => {
-        e.preventDefault();
-        depth.current += 1;
-        setIsDragging(true);
-      }}
       onDragOver={(e) => {
         e.preventDefault();
         e.dataTransfer.dropEffect = 'copy';
       }}
-      onDragLeave={() => {
-        depth.current = Math.max(0, depth.current - 1);
-        if (depth.current === 0) setIsDragging(false);
-      }}
       onDrop={onDrop}
       className={cn(
-        'flex flex-col items-center justify-center rounded-xl border-2 border-dashed text-center transition-colors',
-        compact ? 'gap-2 px-4 py-5' : 'gap-4 px-6 py-12',
-        isDragging
-          ? 'border-accent bg-surface-2'
-          : 'border-line-strong bg-surface/40 hover:border-line-strong',
+        'animate-fade-in absolute inset-2 z-40 flex flex-col items-center justify-center gap-4',
+        'rounded-2xl border-2 border-dashed border-accent bg-base/80 text-center backdrop-blur-sm',
       )}
     >
-      <FolderInput
-        size={compact ? 22 : 40}
-        className={cn('transition-colors', isDragging ? 'text-accent' : 'text-faint')}
-      />
+      <FolderInput size={44} className="text-accent" />
       <div className="flex flex-col gap-1">
-        <span className={cn('font-medium text-fg', compact ? 'text-[12px]' : 'text-sm')}>
-          {isDragging ? 'Drop to open as a workspace' : 'Drop a folder here'}
+        <span className="text-sm font-medium text-fg">Drop to open as a workspace</span>
+        <span className="text-[12px] text-muted">
+          Limboo profiles its languages, package managers, and git branch automatically.
         </span>
-        {!compact && (
-          <span className="max-w-[28rem] text-[12px] leading-relaxed text-muted">
-            Drag a project folder in, or browse below. Limboo profiles its languages,
-            package managers, and git branch automatically.
-          </span>
-        )}
-      </div>
-      <div className="mt-1 flex items-center justify-center gap-2">
-        <WorkspaceActionButton icon={FolderOpen} variant="secondary" onClick={() => pickAnd(open)}>
-          Open folder
-        </WorkspaceActionButton>
-        <WorkspaceActionButton icon={FolderPlus} variant="primary" onClick={() => pickAnd(create)}>
-          Create workspace
-        </WorkspaceActionButton>
       </div>
     </div>
   );

--- a/src/renderer/features/workspace/WorkspaceLauncher.tsx
+++ b/src/renderer/features/workspace/WorkspaceLauncher.tsx
@@ -9,17 +9,19 @@
  * it owns the project-launcher experience that gates the rest of the shell.
  */
 import { useEffect, useMemo, useState } from 'react';
-import { FileText, GitBranch, GitCommitHorizontal, HardDrive, Pin, RefreshCw, Search, Trash2 } from 'lucide-react';
+import { FileText, FolderInput, GitBranch, GitCommitHorizontal, HardDrive, Pin, RefreshCw, Search, Trash2 } from 'lucide-react';
 import type { Workspace } from '@shared/types';
 import { Badge, EmptyState, IconButton } from '@/renderer/components/ui';
 import { formatBytes, formatCount, relativeTime } from '@/renderer/lib/format';
 import { useWorkspaceStore } from '@/renderer/stores/useWorkspaceStore';
 import { WorkspaceIconBadge } from './WorkspaceIconBadge';
-import { WorkspaceDropZone } from './WorkspaceDropZone';
+import { WorkspaceActions } from './WorkspaceDropZone';
+import { WorkspaceCreatePanel } from './WorkspaceCreatePanel';
 import { WorkspaceRemoveDialog } from './WorkspaceRemoveDialog';
 
 export function WorkspaceLauncher() {
   const workspaces = useWorkspaceStore((s) => s.workspaces);
+  const launcherView = useWorkspaceStore((s) => s.launcherView);
 
   const [query, setQuery] = useState('');
   // Workspace pending safe-delete confirmation (null = dialog closed).
@@ -41,58 +43,75 @@ export function WorkspaceLauncher() {
     });
   }, [workspaces, query]);
 
+  // The in-app Create form takes over the launcher body (no native folder dialog).
+  if (launcherView === 'create') {
+    return <WorkspaceCreatePanel />;
+  }
+
+  // Empty state: a centered hero with large Open / Create actions. Dropping a
+  // folder anywhere on the window works too (handled by the drag overlay).
+  if (workspaces.length === 0) {
+    return (
+      <div className="mx-auto flex h-full w-full max-w-3xl flex-col items-center justify-center gap-7 py-8 text-center">
+        <div className="flex flex-col items-center gap-4">
+          <div className="rounded-2xl border border-line bg-surface-2 p-4">
+            <FolderInput size={40} className="text-faint" />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <h1 className="text-xl font-semibold tracking-tight text-fg">Open a project to begin</h1>
+            <p className="max-w-md text-[13px] leading-relaxed text-muted">
+              Every session lives inside a workspace. Open an existing folder, create a
+              new one, or drop a folder anywhere on this window.
+            </p>
+          </div>
+        </div>
+        <WorkspaceActions size="lg" />
+      </div>
+    );
+  }
+
   return (
-    <div className="mx-auto flex h-full w-full max-w-3xl flex-col gap-5 py-8">
-      {/* Heading */}
-      <div className="flex flex-col gap-1">
-        <h1 className="text-base font-semibold tracking-tight text-fg">Workspaces</h1>
-        <p className="text-[12px] text-muted">
-          Open a project folder to begin. Every session lives inside a workspace.
-        </p>
+    <div className="mx-auto flex h-full w-full max-w-3xl flex-col gap-4 py-8">
+      {/* Heading + primary actions */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-base font-semibold tracking-tight text-fg">Workspaces</h1>
+          <p className="text-[12px] text-muted">
+            Open a project folder to begin. Every session lives inside a workspace.
+          </p>
+        </div>
+        <WorkspaceActions />
       </div>
 
-      {workspaces.length === 0 ? (
-        // Modern empty state: the drop zone IS the primary affordance.
-        <WorkspaceDropZone />
-      ) : (
-        <>
-          {/* Always-visible compact drop zone + actions above the list. */}
-          <WorkspaceDropZone compact />
+      <div className="flex items-center gap-2 rounded-md border border-line bg-surface-2 px-2.5">
+        <Search size={14} className="text-faint" />
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Filter workspaces…"
+          className="flex-1 bg-transparent py-2 text-[12px] text-fg placeholder:text-faint focus:outline-none"
+        />
+      </div>
 
-          <div className="flex items-center gap-2 rounded-md border border-line bg-surface-2 px-2.5">
-            <Search size={14} className="text-faint" />
-            <input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Filter workspaces…"
-              className="flex-1 bg-transparent py-2 text-[12px] text-fg placeholder:text-faint focus:outline-none"
-            />
-          </div>
-
-          <div className="min-h-0 flex-1 overflow-y-auto">
-            {filtered.length === 0 ? (
-              <EmptyState
-                compact
-                icon={Search}
-                title="No matches"
-                description="No workspaces match your filter."
-              />
-            ) : (
-              <ul className="flex flex-col gap-2">
-                {filtered.map((ws) => (
-                  <WorkspaceCard key={ws.id} ws={ws} onRequestRemove={() => setPendingRemove(ws)} />
-                ))}
-              </ul>
-            )}
-          </div>
-        </>
-      )}
+      <div className="min-h-0 flex-1 overflow-y-auto pb-2">
+        {filtered.length === 0 ? (
+          <EmptyState
+            compact
+            icon={Search}
+            title="No matches"
+            description="No workspaces match your filter."
+          />
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {filtered.map((ws) => (
+              <WorkspaceCard key={ws.id} ws={ws} onRequestRemove={() => setPendingRemove(ws)} />
+            ))}
+          </ul>
+        )}
+      </div>
 
       {pendingRemove && (
-        <WorkspaceRemoveDialog
-          workspace={pendingRemove}
-          onClose={() => setPendingRemove(null)}
-        />
+        <WorkspaceRemoveDialog workspace={pendingRemove} onClose={() => setPendingRemove(null)} />
       )}
     </div>
   );

--- a/src/renderer/features/workspace/WorkspaceSelection.tsx
+++ b/src/renderer/features/workspace/WorkspaceSelection.tsx
@@ -6,21 +6,30 @@
  * of truth every subsystem depends on.
  *
  * Structure: the frameless TitleBar on top (window controls + drag preserved),
- * then the recent-workspaces launcher centered in the body. Pure-black, dark
- * only — reuses existing primitives so it matches the rest of the app exactly.
+ * the recent-workspaces launcher in the body, and a themed, full-width animated
+ * skyline anchored to the bottom. A drag overlay covers the whole body so a folder
+ * can be dropped anywhere on the window (it only appears while dragging). Pure
+ * black, dark only — reuses existing primitives so it matches the app exactly.
  */
 import { TitleBar } from '@/renderer/components/layout/TitleBar';
 import { WorkspaceLauncher } from './WorkspaceLauncher';
+import { WorkspaceSkyline } from './WorkspaceSkyline';
+import { WorkspaceDragOverlay } from './WorkspaceDropZone';
 
 export function WorkspaceSelection() {
   return (
-    <div className="flex h-full w-full flex-col bg-base text-fg">
+    <div className="flex h-full w-full flex-col overflow-hidden bg-base text-fg">
       <TitleBar />
-      {/* The launcher owns its own internal scroll for the workspace list, so
-          give it the full remaining height rather than a second scroller. */}
-      <div className="min-h-0 flex-1 px-4">
+      {/* Body: the launcher scrolls internally; the drop overlay fills it during a
+          drag. `relative` anchors both the overlay and the bottom fade. */}
+      <div className="relative min-h-0 flex-1 px-4">
         <WorkspaceLauncher />
+        <WorkspaceDragOverlay />
+        {/* Soft fade so the list dissolves into the skyline instead of colliding. */}
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 z-[5] h-16 bg-gradient-to-t from-base to-transparent" />
       </div>
+      {/* Full-window-width skyline footer, edge to edge, alive on hover. */}
+      <WorkspaceSkyline className="h-[24vh] max-h-[220px] min-h-[130px] shrink-0" />
     </div>
   );
 }

--- a/src/renderer/features/workspace/WorkspaceSkyline.tsx
+++ b/src/renderer/features/workspace/WorkspaceSkyline.tsx
@@ -1,0 +1,90 @@
+/**
+ * Decorative "skyline" that anchors the bottom of the Workspace Selection screen.
+ * On-palette (a `--color-surface-2` silhouette on pure black, plus a fainter
+ * back layer for depth) — no gradients, dark-only, per the theme rules.
+ *
+ * It comes alive on hover with a liquid wave-morph: an SVG `feTurbulence` +
+ * `feDisplacementMap` filter whose displacement ramps up while the pointer is over
+ * the graphic, so the bar tops ripple like poured liquid, then settle when the
+ * pointer leaves. SMIL `<animate>` gated on `mouseover` / `mouseout` (DOM event
+ * names SMIL understands, well-supported in Chromium/Electron) drives it, and a
+ * subtle CSS "breathe" makes the bars rise slightly on hover. Both are skipped
+ * when the user prefers reduced motion.
+ */
+import { cn } from '@/renderer/lib/cn';
+
+/** The user-supplied skyline path (viewBox 0 0 1440 320). */
+const SKYLINE_PATH =
+  'M0,256L0,288L36.9,288L36.9,32L73.8,32L73.8,32L110.8,32L110.8,256L147.7,256L147.7,96L184.6,96L184.6,32L221.5,32L221.5,0L258.5,0L258.5,96L295.4,96L295.4,0L332.3,0L332.3,64L369.2,64L369.2,288L406.2,288L406.2,192L443.1,192L443.1,160L480,160L480,192L516.9,192L516.9,256L553.8,256L553.8,224L590.8,224L590.8,256L627.7,256L627.7,256L664.6,256L664.6,96L701.5,96L701.5,128L738.5,128L738.5,288L775.4,288L775.4,160L812.3,160L812.3,192L849.2,192L849.2,320L886.2,320L886.2,224L923.1,224L923.1,64L960,64L960,128L996.9,128L996.9,256L1033.8,256L1033.8,0L1070.8,0L1070.8,256L1107.7,256L1107.7,192L1144.6,192L1144.6,192L1181.5,192L1181.5,0L1218.5,0L1218.5,224L1255.4,224L1255.4,128L1292.3,128L1292.3,256L1329.2,256L1329.2,160L1366.2,160L1366.2,224L1403.1,224L1403.1,192L1440,192L1440,0L1403.1,0L1403.1,0L1366.2,0L1366.2,0L1329.2,0L1329.2,0L1292.3,0L1292.3,0L1255.4,0L1255.4,0L1218.5,0L1218.5,0L1181.5,0L1181.5,0L1144.6,0L1144.6,0L1107.7,0L1107.7,0L1070.8,0L1070.8,0L1033.8,0L1033.8,0L996.9,0L996.9,0L960,0L960,0L923.1,0L923.1,0L886.2,0L886.2,0L849.2,0L849.2,0L812.3,0L812.3,0L775.4,0L775.4,0L738.5,0L738.5,0L701.5,0L701.5,0L664.6,0L664.6,0L627.7,0L627.7,0L590.8,0L590.8,0L553.8,0L553.8,0L516.9,0L516.9,0L480,0L480,0L443.1,0L443.1,0L406.2,0L406.2,0L369.2,0L369.2,0L332.3,0L332.3,0L295.4,0L295.4,0L258.5,0L258.5,0L221.5,0L221.5,0L184.6,0L184.6,0L147.7,0L147.7,0L110.8,0L110.8,0L73.8,0L73.8,0L36.9,0L36.9,0L0,0L0,0Z';
+
+function prefersReducedMotion(): boolean {
+  if (typeof document === 'undefined') return false;
+  return document.documentElement.dataset.reducedMotion === 'true';
+}
+
+export function WorkspaceSkyline({ className }: { className?: string }) {
+  const reduced = prefersReducedMotion();
+
+  return (
+    <div className={cn('limboo-skyline group w-full select-none', className)} aria-hidden>
+      <svg
+        viewBox="0 0 1440 320"
+        preserveAspectRatio="none"
+        className="block h-full w-full"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <defs>
+          <filter id="limboo-skyline-liquid" x="-20%" y="-20%" width="140%" height="140%">
+            <feTurbulence
+              type="fractalNoise"
+              baseFrequency="0.005 0.012"
+              numOctaves={2}
+              seed={7}
+              result="noise"
+            >
+              {!reduced && (
+                <animate
+                  attributeName="baseFrequency"
+                  begin="limboo-skyline-root.mouseover"
+                  end="limboo-skyline-root.mouseout"
+                  dur="7s"
+                  values="0.005 0.008;0.008 0.02;0.005 0.008"
+                  repeatCount="indefinite"
+                />
+              )}
+            </feTurbulence>
+            <feDisplacementMap in="SourceGraphic" in2="noise" scale="0">
+              {!reduced && (
+                <animate
+                  attributeName="scale"
+                  begin="limboo-skyline-root.mouseover"
+                  end="limboo-skyline-root.mouseout"
+                  dur="2.4s"
+                  values="0;16;9;16;0"
+                  repeatCount="indefinite"
+                />
+              )}
+            </feDisplacementMap>
+          </filter>
+        </defs>
+
+        {/* Hover target spans the whole graphic so the ripple triggers anywhere. */}
+        <g id="limboo-skyline-root">
+          {/* Transparent hit area (the path itself has gaps between bars). */}
+          <rect x="0" y="0" width="1440" height="320" fill="transparent" />
+          {/* Back layer: fainter + offset for a sense of depth. */}
+          <path
+            d={SKYLINE_PATH}
+            transform="translate(0 26)"
+            style={{ fill: 'var(--color-surface)' }}
+            opacity={0.7}
+          />
+          {/* Front layer: the silhouette that ripples on hover. */}
+          <g className="limboo-skyline-bars" filter="url(#limboo-skyline-liquid)">
+            <path d={SKYLINE_PATH} style={{ fill: 'var(--color-surface-2)' }} />
+          </g>
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/src/renderer/hooks/usePreventFileDrop.ts
+++ b/src/renderer/hooks/usePreventFileDrop.ts
@@ -9,10 +9,55 @@
  * `will-redirect`, but stopping the drop at the source avoids the flicker and
  * keeps drag semantics owned by the renderer.
  */
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 function isInsideDropZone(target: EventTarget | null): boolean {
   return target instanceof Element && target.closest('[data-dropzone]') !== null;
+}
+
+/** True only while a *file* drag is in progress anywhere over the window. */
+function dragCarriesFiles(e: DragEvent): boolean {
+  const types = e.dataTransfer?.types;
+  return types ? Array.prototype.includes.call(types, 'Files') : false;
+}
+
+/**
+ * Track whether the user is currently dragging a file over the window. Lets a
+ * surface reveal its drop affordance *only* during an active drag (so nothing is
+ * shown at rest) rather than keeping a permanent dashed target on screen.
+ *
+ * Uses a depth counter because `dragenter`/`dragleave` also fire for child
+ * elements; the drag is only truly over when depth returns to zero.
+ */
+export function useFileDragActive(): boolean {
+  const [active, setActive] = useState(false);
+  useEffect(() => {
+    let depth = 0;
+    const onEnter = (e: DragEvent) => {
+      if (!dragCarriesFiles(e)) return;
+      depth += 1;
+      setActive(true);
+    };
+    const onLeave = () => {
+      depth = Math.max(0, depth - 1);
+      if (depth === 0) setActive(false);
+    };
+    const reset = () => {
+      depth = 0;
+      setActive(false);
+    };
+    window.addEventListener('dragenter', onEnter);
+    window.addEventListener('dragleave', onLeave);
+    window.addEventListener('drop', reset);
+    window.addEventListener('dragend', reset);
+    return () => {
+      window.removeEventListener('dragenter', onEnter);
+      window.removeEventListener('dragleave', onLeave);
+      window.removeEventListener('drop', reset);
+      window.removeEventListener('dragend', reset);
+    };
+  }, []);
+  return active;
 }
 
 export function usePreventFileDrop(): void {

--- a/src/renderer/lib/commands.ts
+++ b/src/renderer/lib/commands.ts
@@ -42,14 +42,14 @@ async function reindexActiveWorkspace(): Promise<void> {
   }
 }
 
-/** Pick a directory and run a workspace action, surfacing errors as a toast. */
-async function pickWorkspace(action: 'open' | 'create'): Promise<void> {
+/** Pick a folder and open it as a workspace, surfacing errors as a toast. Creating
+ *  a *new* workspace goes through the in-app Create panel instead (no OS dialog). */
+async function openWorkspaceFolder(): Promise<void> {
   const store = useWorkspaceStore.getState();
   try {
     const dir = await store.pickDirectory();
     if (!dir) return;
-    if (action === 'open') await store.open(dir);
-    else await store.create(dir);
+    await store.open(dir);
   } catch (err) {
     useUIStore.getState().addToast({
       title: 'Could not open workspace',
@@ -78,14 +78,15 @@ export const COMMANDS: Command[] = [
     section: 'Workspace',
     keys: ['Mod', 'O'],
     inPalette: true,
-    run: () => void pickWorkspace('open'),
+    run: () => void openWorkspaceFolder(),
   },
   {
     id: 'workspace.new',
     title: 'Create workspace',
     section: 'Workspace',
     inPalette: true,
-    run: () => void pickWorkspace('create'),
+    // Open the in-app Create panel rather than firing the native folder dialog.
+    run: () => useWorkspaceStore.getState().setLauncherView('create'),
   },
   {
     id: 'session.new',

--- a/src/renderer/stores/useWorkspaceStore.ts
+++ b/src/renderer/stores/useWorkspaceStore.ts
@@ -16,6 +16,10 @@ interface WorkspaceState {
   hydrated: boolean;
   /** True while a native directory picker is open (mirrors the main-process guard). */
   picking: boolean;
+  /** Which view the full-screen launcher shows: the recent list or the create form.
+   *  Held here (not local component state) so the command palette / native menu can
+   *  open the in-app "Create workspace" panel without firing the OS folder dialog. */
+  launcherView: 'list' | 'create';
   /** Lazily-loaded per-workspace statistics, memoized by id (each entry is one
    *  bounded filesystem walk, so we fetch on demand — not eagerly for every card). */
   statsById: Record<string, WorkspaceStats>;
@@ -24,6 +28,9 @@ interface WorkspaceState {
   open: (path: string) => Promise<Workspace | null>;
   openPath: (path: string) => Promise<Workspace | null>;
   create: (path: string) => Promise<Workspace | null>;
+  /** Create a brand-new project folder and open it (no native folder dialog). */
+  createNew: (name: string, parentPath: string, initGit: boolean) => Promise<Workspace | null>;
+  setLauncherView: (view: 'list' | 'create') => void;
   switchTo: (id: string) => Promise<void>;
   remove: (id: string) => Promise<void>;
   toggleFavorite: (id: string) => Promise<void>;
@@ -54,6 +61,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   activeId: null,
   hydrated: false,
   picking: false,
+  launcherView: 'list',
   statsById: {},
 
   hydrate: async () => {
@@ -115,6 +123,22 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     set((s) => ({ workspaces: mergeWorkspace(s.workspaces, ws), activeId: ws.id }));
     return ws;
   },
+
+  createNew: async (name, parentPath, initGit) => {
+    const api = workspaceApi();
+    if (!api) return null;
+    const ws = await api.createNew({ name, parentPath, initGit });
+    // Optimistically activate + reset the launcher back to the list (the launcher
+    // unmounts anyway once activeId flips the shell in).
+    set((s) => ({
+      workspaces: mergeWorkspace(s.workspaces, ws),
+      activeId: ws.id,
+      launcherView: 'list',
+    }));
+    return ws;
+  },
+
+  setLauncherView: (view) => set({ launcherView: view }),
 
   switchTo: async (id) => {
     const api = workspaceApi();

--- a/src/renderer/styles/index.css
+++ b/src/renderer/styles/index.css
@@ -140,6 +140,22 @@ html[data-reduced-motion="true"] *::after {
   to { background-position: 200% 0; }
 }
 
+/* Skyline "breathe": bars rise a touch while the launcher skyline is hovered,
+   pairing with the SVG liquid-displacement filter for a poured-liquid feel. */
+@keyframes limboo-skyline-breathe {
+  0%, 100% { transform: scaleY(1); }
+  50% { transform: scaleY(1.035); }
+}
+
+.limboo-skyline .limboo-skyline-bars {
+  transform-origin: bottom;
+  transition: transform 400ms ease-out;
+}
+
+.limboo-skyline:hover .limboo-skyline-bars {
+  animation: limboo-skyline-breathe 3.2s ease-in-out infinite;
+}
+
 @utility animate-fade-in {
   animation: limboo-fade-in 120ms ease-out;
 }

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -33,6 +33,7 @@ export const IpcChannels = {
   workspaceGet: 'workspace:get',
   workspacePickDirectory: 'workspace:pickDirectory',
   workspaceCreate: 'workspace:create',
+  workspaceCreateNew: 'workspace:createNew',
   workspaceOpen: 'workspace:open',
   workspaceSwitch: 'workspace:switch',
   workspaceRemove: 'workspace:remove',


### PR DESCRIPTION
… **in-app Create panel** (Name + Location Browse + Initialize-git) instead of the native file manager. A new `workspace:createNew` IPC path makes the folder, optionally `git init`s it, and drops you straight into the workspace shell.

<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New main-process filesystem and `git init` spawning with layered path/name validation; mistakes could create folders in wrong locations, though guards mirror existing open-time checks.
> 
> **Overview**
> **Create workspace** no longer opens the native folder dialog. It switches the launcher to an in-app **Create** panel (name, parent location via Browse, optional git init), wired through a new **`workspace:createNew`** IPC path from preload → store → main.
> 
> The main process adds **`WorkspaceManager.createNew`**: validate the parent like an open, enforce a single safe folder segment, `mkdir` non-recursively (reject non-empty collisions), optionally run **`git init`** via `execFileSync` (soft failure), then register and activate the workspace. IPC adds **`assertValidWorkspaceName`** and payload checks (prototype-pollution guard, typed `initGit`).
> 
> The launcher UX is reworked: **`launcherView`** in the workspace store drives list vs create (command palette **Create workspace** uses this too). **`WorkspaceActions`** and a drag-only **`WorkspaceDragOverlay`** (via **`useFileDragActive`**) replace the always-visible dashed drop zone; empty and list layouts get a hero and header actions. **`WorkspaceSelection`** adds a bottom **`WorkspaceSkyline`** and a list-to-skyline fade.
> 
> **`WorkspaceActionButton`** gains `size`, `disabled`, and `fullWidth` for the new flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e29cedcfcde25b9fb4dce45d0021f22463dd691b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-app workspace creation flow with workspace name, parent folder selection, and optional Git initialization.
  * Introduced a redesigned empty state with drag-and-drop open support and a new decorative skyline.
  * Added larger, disabled, and full-width options to workspace action buttons.

* **Bug Fixes**
  * Strengthened validation for workspace names and folder paths to prevent invalid or unsafe entries.
  * Improved workspace opening and creation error handling with clearer user-facing feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->