### PR TITLE
fixed the center workspace isssues

### DIFF
--- a/src/main/ipc/workspaceHandlers.ts
+++ b/src/main/ipc/workspaceHandlers.ts
@@ -47,7 +47,7 @@ function assertValidPath(p: unknown): asserts p is string {
 /** Characters never allowed in a new workspace folder name: Windows reserved
  *  filename characters plus ASCII control codes. */
 // eslint-disable-next-line no-control-regex
-const ILLEGAL_NAME_CHARS = /[<>:"/\\|?*\x00-\x1f]/;
+const ILLEGAL_NAME_CHARS = /[<>:"/\\|?*\x00-\x1f\x7f]/;
 /** Reserved device names Windows forbids as a directory name (case-insensitive). */
 const RESERVED_NAMES = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6,6 +6,7 @@
 import { useEffect } from 'react';
 import { AppShell } from '@/renderer/app/AppShell';
 import { WorkspaceSelection } from '@/renderer/features/workspace/WorkspaceSelection';
+import { WorkspaceCreateScreen } from '@/renderer/features/workspace/WorkspaceCreateScreen';
 import { CommandPalette } from '@/renderer/features/command-palette/CommandPalette';
 import { SettingsModal } from '@/renderer/features/settings/SettingsModal';
 import { UpdateBanner } from '@/renderer/features/updates/UpdateBanner';
@@ -33,6 +34,9 @@ export function App() {
   // the persisted active workspace has loaded.
   const hydrated = useWorkspaceStore((s) => s.hydrated);
   const hasWorkspace = useWorkspaceStore((s) => s.activeId !== null);
+  // The in-app Create flow takes over the whole window (works with or without an
+  // active workspace) so the title-bar switcher can reach it too — see gating below.
+  const creating = useWorkspaceStore((s) => s.launcherView === 'create');
 
   // Load registered workspaces + sessions + connect to the coding agent once the
   // shell is up. Workspaces hydrate first so the session list can scope to the
@@ -58,7 +62,13 @@ export function App() {
 
   return (
     <>
-      {!hydrated ? null : hasWorkspace ? <AppShell /> : <WorkspaceSelection />}
+      {!hydrated ? null : creating ? (
+        <WorkspaceCreateScreen />
+      ) : hasWorkspace ? (
+        <AppShell />
+      ) : (
+        <WorkspaceSelection />
+      )}
       <CommandPalette />
       <SettingsModal />
       <UpdateBanner />

--- a/src/renderer/features/workspace/WorkspaceCreatePanel.tsx
+++ b/src/renderer/features/workspace/WorkspaceCreatePanel.tsx
@@ -19,7 +19,7 @@ import { WorkspaceActionButton } from './WorkspaceActionButton';
 
 /** Mirror of the main-process name guard, for immediate inline feedback only. */
 // eslint-disable-next-line no-control-regex
-const ILLEGAL = /[<>:"/\\|?*\x00-\x1f]/;
+const ILLEGAL = /[<>:"/\\|?*\x00-\x1f\x7f]/;
 const RESERVED = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
 
 function nameError(name: string): string | null {

--- a/src/renderer/features/workspace/WorkspaceCreateScreen.tsx
+++ b/src/renderer/features/workspace/WorkspaceCreateScreen.tsx
@@ -1,0 +1,24 @@
+/**
+ * Full-screen "Create workspace" screen. Shown by `App` whenever the launcher
+ * view is set to `create` — from the empty launcher OR from the title-bar
+ * workspace switcher while a workspace is already active. It owns the window so
+ * the in-app Create flow works in both cases (previously the panel only rendered
+ * inside `WorkspaceLauncher`, which is hidden once a workspace is active).
+ *
+ * Structure mirrors `WorkspaceSelection` (frameless TitleBar + body) minus the
+ * launcher list and skyline. "Back to workspaces" in the panel resets the view to
+ * `list`, returning to the shell (active workspace) or the selection screen (none).
+ */
+import { TitleBar } from '@/renderer/components/layout/TitleBar';
+import { WorkspaceCreatePanel } from './WorkspaceCreatePanel';
+
+export function WorkspaceCreateScreen() {
+  return (
+    <div className="flex h-full w-full flex-col overflow-hidden bg-base text-fg">
+      <TitleBar />
+      <div className="relative min-h-0 flex-1 px-4">
+        <WorkspaceCreatePanel />
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/features/workspace/WorkspaceLauncher.tsx
+++ b/src/renderer/features/workspace/WorkspaceLauncher.tsx
@@ -16,12 +16,10 @@ import { formatBytes, formatCount, relativeTime } from '@/renderer/lib/format';
 import { useWorkspaceStore } from '@/renderer/stores/useWorkspaceStore';
 import { WorkspaceIconBadge } from './WorkspaceIconBadge';
 import { WorkspaceActions } from './WorkspaceDropZone';
-import { WorkspaceCreatePanel } from './WorkspaceCreatePanel';
 import { WorkspaceRemoveDialog } from './WorkspaceRemoveDialog';
 
 export function WorkspaceLauncher() {
   const workspaces = useWorkspaceStore((s) => s.workspaces);
-  const launcherView = useWorkspaceStore((s) => s.launcherView);
 
   const [query, setQuery] = useState('');
   // Workspace pending safe-delete confirmation (null = dialog closed).
@@ -42,11 +40,6 @@ export function WorkspaceLauncher() {
       return b.lastOpenedAt - a.lastOpenedAt;
     });
   }, [workspaces, query]);
-
-  // The in-app Create form takes over the launcher body (no native folder dialog).
-  if (launcherView === 'create') {
-    return <WorkspaceCreatePanel />;
-  }
 
   // Empty state: a centered hero with large Open / Create actions. Dropping a
   // folder anywhere on the window works too (handled by the drag overlay).

--- a/src/renderer/features/workspace/WorkspaceSwitcher.tsx
+++ b/src/renderer/features/workspace/WorkspaceSwitcher.tsx
@@ -16,7 +16,7 @@ export function WorkspaceSwitcher() {
   const switchTo = useWorkspaceStore((s) => s.switchTo);
   const pickDirectory = useWorkspaceStore((s) => s.pickDirectory);
   const open = useWorkspaceStore((s) => s.open);
-  const create = useWorkspaceStore((s) => s.create);
+  const setLauncherView = useWorkspaceStore((s) => s.setLauncherView);
   const rescan = useWorkspaceStore((s) => s.rescan);
   const addToast = useUIStore((s) => s.addToast);
 
@@ -67,7 +67,7 @@ export function WorkspaceSwitcher() {
       <button
         type="button"
         onClick={() => setOpenMenu((v) => !v)}
-        className="no-drag ml-1 flex items-center gap-2 rounded-md border border-line bg-surface-2 px-2 py-1 text-[11px] text-muted transition-colors hover:border-line-strong hover:text-fg"
+        className="no-drag ml-1 flex items-center gap-2 rounded-md px-2 py-1 text-[11px] text-muted transition-colors hover:text-fg"
       >
         {active ? (
           <>
@@ -139,7 +139,10 @@ export function WorkspaceSwitcher() {
           </button>
           <button
             type="button"
-            onClick={() => pickAnd(create)}
+            onClick={() => {
+              setOpenMenu(false);
+              setLauncherView('create');
+            }}
             className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-[12px] text-muted transition-colors hover:bg-surface-2 hover:text-fg"
           >
             <FolderPlus size={14} />


### PR DESCRIPTION
<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI routing and client-side name checks only; main-process validation is tightened, not relaxed.
> 
> **Overview**
> **Create workspace** is now a **full-window** flow driven by `launcherView === 'create'`, so it works from the title-bar switcher while a workspace is already open—not only inside the pre-shell launcher.
> 
> `App` renders the new `WorkspaceCreateScreen` (title bar + existing `WorkspaceCreatePanel`) ahead of `AppShell` / `WorkspaceSelection`. The launcher list no longer swaps its body for the create panel; **Create workspace…** in `WorkspaceSwitcher` sets `launcherView` to `'create'` instead of opening the native folder picker + `create` IPC. The switcher trigger also drops its border styling.
> 
> Workspace **folder name** validation (main IPC + renderer mirror) now rejects ASCII **DEL** (`\x7f`) via an explicit range in `ILLEGAL_NAME_CHARS` / `ILLEGAL`, replacing a broken control-character pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd0e406bd7d366db54c2bab00164793b116ef63e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated full-screen “Create workspace” view for a smoother workspace setup flow.
  * The workspace switcher now opens the create-workspace screen directly from the menu.

* **Bug Fixes**
  * Improved workspace folder name validation to better reject invalid control characters, including the delete character.
  * Updated the workspace launcher so it no longer switches into an embedded create panel unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->