### PR TITLE
Plan Mode is now implemented as a first-class workflow. Here's what l…

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -161,6 +161,22 @@ function migrate(database: Database.Database): void {
       updated_at  INTEGER NOT NULL
     );
 
+    -- Plan revisions — historical snapshots of a session's plan, captured on each
+    -- regenerate / re-capture so iterative planning cycles can be compared and
+    -- restored. Additive to agent_plans (which always holds the current plan).
+    CREATE TABLE IF NOT EXISTS plan_revisions (
+      id          TEXT PRIMARY KEY,
+      session_id  TEXT NOT NULL,
+      rev         INTEGER NOT NULL,
+      status      TEXT NOT NULL,
+      title       TEXT NOT NULL,
+      markdown    TEXT NOT NULL,
+      meta        TEXT NOT NULL,
+      created_at  INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_plan_revisions_session
+      ON plan_revisions (session_id, rev DESC);
+
     -- Git checkpoints — lightweight, session-scoped recovery points stored as
     -- dedicated git refs (refs/limboo/checkpoints/<sessionId>/<ts>); this table
     -- holds only the metadata + which ref to restore. Never on a branch, never

--- a/src/main/ipc/agentHandlers.ts
+++ b/src/main/ipc/agentHandlers.ts
@@ -10,11 +10,12 @@ import { AGENT_LIMITS } from '@shared/constants';
 import type {
   AgentDiagnostic,
   AgentInstall,
-  AgentMode,
   AgentSessionSnapshot,
   AgentState,
   ClarificationDecision,
   PermissionDecision,
+  PlanRevision,
+  SessionPermissionMode,
   SessionPlan,
 } from '@shared/types';
 import type { AgentManager } from '../managers/AgentManager';
@@ -35,11 +36,22 @@ function assertSessionId(value: unknown): string {
   return value;
 }
 
-/** Default to implement when unspecified; reject any value outside the union. */
-function assertMode(value: unknown): AgentMode {
-  if (value === undefined) return 'implement';
-  if (value !== 'plan' && value !== 'implement') {
-    throw new Error('Agent mode must be "plan" or "implement"');
+const PERMISSION_MODES: SessionPermissionMode[] = ['plan', 'default', 'acceptEdits'];
+
+/** Default to ask-before-edits when unspecified; reject values outside the union. */
+function assertMode(value: unknown): SessionPermissionMode {
+  if (value === undefined) return 'default';
+  if (!PERMISSION_MODES.includes(value as SessionPermissionMode)) {
+    throw new Error('Permission mode must be "plan", "default" or "acceptEdits"');
+  }
+  return value as SessionPermissionMode;
+}
+
+/** Approval never re-enters planning — restrict to the execution modes. */
+function assertExecMode(value: unknown): SessionPermissionMode {
+  if (value === undefined) return 'default';
+  if (value !== 'default' && value !== 'acceptEdits') {
+    throw new Error('Execution mode must be "default" or "acceptEdits"');
   }
   return value;
 }
@@ -53,7 +65,7 @@ export function registerAgentHandlers(agent: AgentManager): void {
     agent.getSnapshot(assertSessionId(sessionId)),
   );
 
-  handle<[string, string, AgentMode?, string?], void>(
+  handle<[string, string, SessionPermissionMode?, string?], void>(
     IpcChannels.agentSend,
     async (_event, sessionId, prompt, mode, clientMessageId) => {
       const id = assertSessionId(sessionId);
@@ -103,13 +115,38 @@ export function registerAgentHandlers(agent: AgentManager): void {
     agent.getPlan(assertSessionId(sessionId)),
   );
 
-  handle<[string], void>(IpcChannels.agentApprovePlan, async (_event, sessionId) => {
-    await agent.approvePlan(assertSessionId(sessionId));
-  });
+  handle<[string, SessionPermissionMode?], void>(
+    IpcChannels.agentApprovePlan,
+    async (_event, sessionId, execMode) => {
+      await agent.approvePlan(assertSessionId(sessionId), assertExecMode(execMode));
+    },
+  );
 
   handle<[string], void>(IpcChannels.agentRejectPlan, (_event, sessionId) => {
     agent.rejectPlan(assertSessionId(sessionId));
   });
+
+  handle<[string, boolean], void>(
+    IpcChannels.agentSetPlanPinned,
+    (_event, sessionId, pinned) => {
+      agent.setPlanPinned(assertSessionId(sessionId), pinned === true);
+    },
+  );
+
+  handle<[string], PlanRevision[]>(IpcChannels.agentListPlanRevisions, (_event, sessionId) =>
+    agent.listPlanRevisions(assertSessionId(sessionId)),
+  );
+
+  handle<[string, string], void>(
+    IpcChannels.agentRestorePlanRevision,
+    (_event, sessionId, revisionId) => {
+      const id = assertSessionId(sessionId);
+      if (typeof revisionId !== 'string' || revisionId.length === 0 || revisionId.length > 200) {
+        throw new Error('Expected a valid revision id');
+      }
+      agent.restorePlanRevision(id, revisionId);
+    },
+  );
 
   handle<[string, string?], void>(
     IpcChannels.agentRegeneratePlan,

--- a/src/main/managers/AgentManager.ts
+++ b/src/main/managers/AgentManager.ts
@@ -46,10 +46,12 @@ import type {
   PermissionDecision,
   PermissionRequest,
   PlanMeta,
+  PlanRevision,
   PlanStatus,
   RateLimitInfo,
   RequestOutcome,
   RequestState,
+  SessionPermissionMode,
   SessionPlan,
   TaskItem,
   TaskStatus,
@@ -763,9 +765,10 @@ export class AgentManager {
   async send(
     sessionId: string,
     prompt: string,
-    mode: AgentMode = 'implement',
+    permMode: SessionPermissionMode = 'default',
     clientMessageId?: string,
   ): Promise<void> {
+    const isPlan = permMode === 'plan';
     if (this.runs.has(sessionId)) {
       throw new Error('The agent is already working on this session.');
     }
@@ -799,17 +802,17 @@ export class AgentManager {
     // Name an untitled session after its first prompt (a no-op once renamed).
     this.sessions?.autoTitle(sessionId, prompt);
     // Remember the mode so the composer restores it when this session reopens.
-    this.sessions?.setMode(sessionId, mode);
+    this.sessions?.setMode(sessionId, permMode);
 
     // Plan run: open a fresh planning artifact so the panel switches into its
     // "analyzing repository" state immediately while the agent reads.
-    if (mode === 'plan') {
+    if (isPlan) {
       this.beginPlan(sessionId, prompt);
     }
 
     const cfg = this.settings.getAll().agent.connection;
     const abort = new AbortController();
-    this.runs.set(sessionId, { abort, query: null, mode });
+    this.runs.set(sessionId, { abort, query: null, mode: isPlan ? 'plan' : 'implement' });
     this.clearIdleTimer();
     this.setRequest(sessionId, {
       phase: 'submitting',
@@ -819,16 +822,16 @@ export class AgentManager {
       detail: undefined,
     });
     this.setLifecycle('busy', { activeSessionId: sessionId, error: undefined });
-    this.diag('request', 'info', `Prompt submitted (${mode})`, prompt.slice(0, ACTIVITY_LIMITS.detailMax), sessionId);
+    this.diag('request', 'info', `Prompt submitted (${permMode})`, prompt.slice(0, ACTIVITY_LIMITS.detailMax), sessionId);
 
     try {
-      await this.runWithRecovery(sessionId, prompt, abort, cfg, mode);
+      await this.runWithRecovery(sessionId, prompt, abort, cfg, permMode);
     } finally {
       const captured = this.runs.get(sessionId)?.planCaptured;
       this.runs.delete(sessionId);
       // A plan run that ended without presenting a plan (error/cancel) must not
       // leave the panel stuck "analyzing" — settle it back to a rejected state.
-      if (mode === 'plan' && !captured) {
+      if (isPlan && !captured) {
         const plan = this.loadPlan(sessionId);
         if (plan && plan.status === 'planning') {
           const settled: SessionPlan = { ...plan, status: 'rejected' };
@@ -847,12 +850,12 @@ export class AgentManager {
     prompt: string,
     abort: AbortController,
     cfg: ReturnType<SettingsManager['getAll']>['agent']['connection'],
-    mode: AgentMode,
+    permMode: SessionPermissionMode,
   ): Promise<void> {
     let attempt = 0;
     for (;;) {
       try {
-        await this.runOnce(sessionId, prompt, abort, mode);
+        await this.runOnce(sessionId, prompt, abort, permMode);
         if (abort.signal.aborted) {
           // The user stopped mid-stream; stop() already recorded 'cancelled'.
           return;
@@ -864,7 +867,7 @@ export class AgentManager {
           return;
         }
         // A successful implement run that fulfilled a plan marks it completed.
-        if (mode === 'implement') this.markPlanCompletedIfImplementing(sessionId);
+        if (permMode !== 'plan') this.markPlanCompletedIfImplementing(sessionId);
         this.completeRequest(sessionId, 'success');
         this.markHeartbeatOk();
         if (this.state.lifecycle === 'reconnecting') {
@@ -936,7 +939,7 @@ export class AgentManager {
     sessionId: string,
     prompt: string,
     abort: AbortController,
-    mode: AgentMode,
+    permMode: SessionPermissionMode,
   ): Promise<void> {
     const ws = this.workspace.getActive();
     if (!ws) throw new Error('Open a workspace before talking to the agent.');
@@ -1007,7 +1010,7 @@ export class AgentManager {
       const sdk = await loadSdk();
       const { query } = sdk;
       const memoryContext = this.memoryContextFor(sessionId, prompt);
-      const options = this.buildOptions(sessionId, cwd, abort, agent, mode, memoryContext);
+      const options = this.buildOptions(sessionId, cwd, abort, agent, permMode, memoryContext);
       // Expose a live, read-only view of the Local Memory System so the agent can
       // actually list/search the developer's memories on demand (the injected
       // <project-memory> block is only a one-shot snapshot).
@@ -1347,22 +1350,34 @@ export class AgentManager {
    * writes (implement mode), and resumes the same SDK session so the agent keeps
    * the plan in context. The only transition that lets the agent touch the repo.
    */
-  async approvePlan(sessionId: string): Promise<void> {
+  async approvePlan(sessionId: string, execMode: SessionPermissionMode = 'default'): Promise<void> {
     const plan = this.loadPlan(sessionId);
     if (!plan || plan.status !== 'ready') {
       throw new Error('There is no plan ready to approve for this session.');
     }
+    // Approving a plan never starts another planning pass — coerce a stray 'plan'
+    // to the ask-before-edits execution mode.
+    const mode: SessionPermissionMode = execMode === 'plan' ? 'default' : execMode;
     const approved: SessionPlan = { ...plan, status: 'implementing', approvedAt: Date.now() };
     this.savePlan(approved);
     this.pushEvent({ kind: 'plan', sessionId, plan: approved });
     this.pushActivity(sessionId, 'status', 'Plan approved — implementing', undefined, 'success');
-    this.diag('request', 'info', 'Plan approved', undefined, sessionId);
+    this.diag('request', 'info', `Plan approved (${mode})`, undefined, sessionId);
 
     await this.send(
       sessionId,
       'The plan is approved. Implement it now, working through the steps in order and tracking your progress with the TodoWrite tool. Ask for approval before any change you are unsure about.',
-      'implement',
+      mode,
     );
+  }
+
+  /** Pin / unpin the current plan so it is preserved even after a new plan begins. */
+  setPlanPinned(sessionId: string, pinned: boolean): void {
+    const plan = this.loadPlan(sessionId);
+    if (!plan) return;
+    const next: SessionPlan = { ...plan, pinned };
+    this.savePlan(next);
+    this.pushEvent({ kind: 'plan', sessionId, plan: next });
   }
 
   /** Reject a ready plan; the session returns to an idle, no-plan state. */
@@ -1379,9 +1394,102 @@ export class AgentManager {
   /** Discard the current plan and run a fresh planning pass (optionally guided). */
   async regeneratePlan(sessionId: string, extra?: string): Promise<void> {
     const plan = this.loadPlan(sessionId);
+    // Preserve the outgoing plan as a revision before the new pass overwrites it,
+    // so iterative planning cycles can be compared/restored.
+    if (plan && plan.markdown.trim().length > 0) this.snapshotRevision(plan);
     const base = plan?.title ? `Reconsider the plan for: ${plan.title}.` : 'Produce a new implementation plan.';
     const prompt = extra && extra.trim().length > 0 ? `${base}\n\n${extra.trim()}` : base;
     await this.send(sessionId, prompt, 'plan');
+  }
+
+  /** List the historical plan revisions for a session, newest first. */
+  listPlanRevisions(sessionId: string): PlanRevision[] {
+    if (!this.settings.getAll().agent.plan.retainPlanHistory) return [];
+    const rows = getDb()
+      .prepare(
+        'SELECT id, session_id, rev, status, title, markdown, meta, created_at FROM plan_revisions WHERE session_id = ? ORDER BY rev DESC',
+      )
+      .all(sessionId) as Array<{
+      id: string;
+      session_id: string;
+      rev: number;
+      status: string;
+      title: string;
+      markdown: string;
+      meta: string;
+      created_at: number;
+    }>;
+    return rows.map((r) => {
+      let meta: PlanMeta = {};
+      try {
+        meta = JSON.parse(r.meta) as PlanMeta;
+      } catch {
+        /* keep empty meta on a corrupt row */
+      }
+      return {
+        id: r.id,
+        sessionId: r.session_id,
+        rev: r.rev,
+        status: r.status as PlanStatus,
+        title: r.title,
+        markdown: r.markdown,
+        meta,
+        createdAt: r.created_at,
+      };
+    });
+  }
+
+  /** Restore a historical revision as the session's current (ready) plan. */
+  restorePlanRevision(sessionId: string, revisionId: string): void {
+    const rev = this.listPlanRevisions(sessionId).find((r) => r.id === revisionId);
+    if (!rev) throw new Error('That plan revision no longer exists.');
+    const current = this.loadPlan(sessionId);
+    // Snapshot the current plan first so the restore itself is reversible.
+    if (current && current.markdown.trim().length > 0) this.snapshotRevision(current);
+    const restored: SessionPlan = {
+      sessionId,
+      status: 'ready',
+      title: rev.title,
+      markdown: rev.markdown,
+      meta: rev.meta,
+      createdAt: current?.createdAt ?? Date.now(),
+      pinned: current?.pinned,
+    };
+    this.savePlan(restored);
+    this.pushEvent({ kind: 'plan', sessionId, plan: restored });
+    this.pushActivity(sessionId, 'status', 'Plan revision restored', undefined, 'info');
+  }
+
+  /** Persist a plan snapshot into `plan_revisions`, pruning to the history limit. */
+  private snapshotRevision(plan: SessionPlan): void {
+    const planCfg = this.settings.getAll().agent.plan;
+    if (!planCfg.retainPlanHistory) return;
+    const db = getDb();
+    const next =
+      ((db
+        .prepare('SELECT MAX(rev) AS m FROM plan_revisions WHERE session_id = ?')
+        .get(plan.sessionId) as { m: number | null } | undefined)?.m ?? 0) + 1;
+    db.prepare(
+      `INSERT INTO plan_revisions (id, session_id, rev, status, title, markdown, meta, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      newId(),
+      plan.sessionId,
+      next,
+      plan.status,
+      plan.title,
+      plan.markdown,
+      JSON.stringify(plan.meta ?? {}),
+      Date.now(),
+    );
+    // Prune older revisions beyond the configured limit.
+    db.prepare(
+      `DELETE FROM plan_revisions
+        WHERE session_id = ?
+          AND id NOT IN (
+            SELECT id FROM plan_revisions WHERE session_id = ? ORDER BY rev DESC LIMIT ?
+          )`,
+    ).run(plan.sessionId, plan.sessionId, planCfg.historyLimit);
   }
 
   /** When a plan was being implemented and the run succeeds, mark it completed. */
@@ -1392,6 +1500,37 @@ export class AgentManager {
     this.savePlan(completed);
     this.pushEvent({ kind: 'plan', sessionId, plan: completed });
     this.diag('request', 'info', 'Plan implementation completed', undefined, sessionId);
+    this.savePlanToMemory(completed);
+  }
+
+  /**
+   * Persist a completed plan into the Local Memory system (opt-in) so its strategy
+   * becomes retrievable project knowledge on future tasks. Best-effort: a memory
+   * failure never breaks the run.
+   */
+  private savePlanToMemory(plan: SessionPlan): void {
+    const s = this.settings.getAll();
+    if (!this.memory || !s.memory.enabled || !s.agent.plan.savePlansToMemory) return;
+    if (plan.markdown.trim().length === 0) return;
+    try {
+      this.memory.create({
+        workspaceId: this.workspace.getActive()?.id ?? null,
+        tier: 'solution',
+        title: `Plan: ${plan.title}`.slice(0, 200),
+        body: plan.markdown,
+        source: 'conversation',
+        sessionId: plan.sessionId,
+      });
+      this.diag('request', 'info', 'Plan saved to memory', undefined, plan.sessionId);
+    } catch (err) {
+      this.diag(
+        'request',
+        'warning',
+        'Could not save plan to memory',
+        err instanceof Error ? err.message : String(err),
+        plan.sessionId,
+      );
+    }
   }
 
   private savePlan(plan: SessionPlan): void {
@@ -1459,17 +1598,20 @@ export class AgentManager {
     cwd: string,
     abort: AbortController,
     agent: ReturnType<SettingsManager['getAll']>['agent'],
-    mode: AgentMode,
+    permMode: SessionPermissionMode,
     memoryContext?: string,
   ): Options {
     const options: Options = {
       cwd,
       model: agent.model,
-      // Plan mode keeps the SDK read-only and lets the agent present a plan via
-      // the ExitPlanMode tool; our canUseTool captures it. Implement mode runs
-      // normally with the per-tool approval bridge.
-      permissionMode: mode === 'plan' ? 'plan' : 'default',
-      canUseTool: this.makeCanUseTool(sessionId, cwd, mode),
+      // The composer's permission mode maps 1:1 to the SDK's:
+      //   plan        → read-only; agent presents a plan via ExitPlanMode.
+      //   default     → writes/commands prompt through our canUseTool bridge.
+      //   acceptEdits → SDK auto-approves file edits; commands still prompt.
+      // bypassPermissions is never used (safety); the auto/approve-all knobs are
+      // enforced on top inside canUseTool.
+      permissionMode: permMode,
+      canUseTool: this.makeCanUseTool(sessionId, cwd, permMode === 'plan'),
       maxTurns: agent.maxTurns,
       includePartialMessages: true,
       abortController: abort,
@@ -1499,8 +1641,7 @@ export class AgentManager {
     return row?.sdk_session_id || undefined;
   }
 
-  private makeCanUseTool(sessionId: string, cwd: string, mode: AgentMode) {
-    const planRun = mode === 'plan';
+  private makeCanUseTool(sessionId: string, cwd: string, planRun: boolean) {
     return async (
       toolName: string,
       input: Record<string, unknown>,

--- a/src/main/managers/SessionManager.ts
+++ b/src/main/managers/SessionManager.ts
@@ -17,7 +17,12 @@ import { BrowserWindow } from 'electron';
 import type Database from 'better-sqlite3';
 import { IpcEvents } from '@shared/ipc-channels';
 import { SESSION_DEFAULTS } from '@shared/constants';
-import type { AgentMode, Session, SessionStatus, SessionUpdate } from '@shared/types';
+import type {
+  Session,
+  SessionPermissionMode,
+  SessionStatus,
+  SessionUpdate,
+} from '@shared/types';
 import { getDb } from '../db/database';
 import { logger } from '../logger';
 
@@ -273,10 +278,10 @@ export class SessionManager {
   }
 
   /**
-   * Persist the last composer mode used for a session (drives the Plan/Implement
-   * switch on reopen). Does NOT bump `updated_at` — mode is UI state, not activity.
+   * Persist the last composer permission mode used for a session (drives the
+   * mode selector on reopen). Does NOT bump `updated_at` — it is UI state.
    */
-  setMode(id: string, mode: AgentMode): void {
+  setMode(id: string, mode: SessionPermissionMode): void {
     const info = this.db
       .prepare('UPDATE sessions SET mode = ? WHERE id = ? AND (mode IS NULL OR mode != ?)')
       .run(mode, id, mode);
@@ -397,6 +402,17 @@ function rowToSession(row: SessionRow): Session {
     pinned: row.pinned === 1,
     archived: row.archived === 1,
     deletedAt: row.deleted_at,
-    mode: row.mode === 'plan' || row.mode === 'implement' ? row.mode : undefined,
+    mode: coerceMode(row.mode),
   };
+}
+
+/**
+ * Map a persisted `sessions.mode` string to a {@link SessionPermissionMode}. The
+ * column predates the harness-aligned modes, so coerce the legacy `implement`
+ * value to `default` and drop anything unrecognized.
+ */
+function coerceMode(value: string | null): SessionPermissionMode | undefined {
+  if (value === 'plan' || value === 'default' || value === 'acceptEdits') return value;
+  if (value === 'implement') return 'default';
+  return undefined;
 }

--- a/src/main/managers/SettingsManager.ts
+++ b/src/main/managers/SettingsManager.ts
@@ -145,6 +145,14 @@ export class SettingsManager {
       clamp(mem.expiry.staleDays, MEMORY_LIMITS.staleDays.min, MEMORY_LIMITS.staleDays.max),
     );
 
+    // Plan Mode — the composer now speaks harness permission modes. Coerce the
+    // legacy 'implement' default (pre-v9) to 'default' and reject stray values.
+    const plan = merged.agent.plan;
+    if (!['plan', 'default', 'acceptEdits'].includes(plan.defaultMode as string)) {
+      plan.defaultMode = plan.defaultMode === ('implement' as unknown) ? 'default' : 'plan';
+    }
+    plan.historyLimit = Math.round(clamp(plan.historyLimit, 1, 100));
+
     merged.updates.autoCheck = !!merged.updates.autoCheck;
     merged.updates.autoDownload = !!merged.updates.autoDownload;
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -14,7 +14,6 @@ import type {
   AgentDiagnostic,
   AgentEvent,
   AgentInstall,
-  AgentMode,
   AgentSessionSnapshot,
   AgentState,
   AppInfo,
@@ -47,7 +46,9 @@ import type {
   MemoryUpdateInput,
   PermissionDecision,
   PermissionRequest,
+  PlanRevision,
   Session,
+  SessionPermissionMode,
   SessionPlan,
   SessionUpdate,
   TerminalChunk,
@@ -167,19 +168,25 @@ const agentApi = {
   send: (
     sessionId: string,
     prompt: string,
-    mode?: AgentMode,
+    mode?: SessionPermissionMode,
     clientMessageId?: string,
   ): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.agentSend, sessionId, prompt, mode, clientMessageId),
   stop: (sessionId: string): Promise<void> => ipcRenderer.invoke(IpcChannels.agentStop, sessionId),
   getPlan: (sessionId: string): Promise<SessionPlan | null> =>
     ipcRenderer.invoke(IpcChannels.agentGetPlan, sessionId),
-  approvePlan: (sessionId: string): Promise<void> =>
-    ipcRenderer.invoke(IpcChannels.agentApprovePlan, sessionId),
+  approvePlan: (sessionId: string, execMode?: SessionPermissionMode): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.agentApprovePlan, sessionId, execMode),
   rejectPlan: (sessionId: string): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.agentRejectPlan, sessionId),
   regeneratePlan: (sessionId: string, extra?: string): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.agentRegeneratePlan, sessionId, extra),
+  setPlanPinned: (sessionId: string, pinned: boolean): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.agentSetPlanPinned, sessionId, pinned),
+  listPlanRevisions: (sessionId: string): Promise<PlanRevision[]> =>
+    ipcRenderer.invoke(IpcChannels.agentListPlanRevisions, sessionId),
+  restorePlanRevision: (sessionId: string, revisionId: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.agentRestorePlanRevision, sessionId, revisionId),
   clearSession: (sessionId: string): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.agentClearSession, sessionId),
   getDiagnostics: (sessionId?: string | null): Promise<AgentDiagnostic[]> =>

--- a/src/renderer/features/activity/PlanPanel.tsx
+++ b/src/renderer/features/activity/PlanPanel.tsx
@@ -1,19 +1,23 @@
 /**
- * Plan panel — the Task tab's rich view of Plan Mode. It visualizes the agent's
- * proposed implementation strategy and its live execution checklist:
+ * Plan panel — the Task tab's rich view of Plan Mode. It is the orchestration
+ * surface for the whole Explore → Plan → Approve → Execute lifecycle:
  *
- *   • planning      → a "analyzing the repository" placeholder while the agent
- *                     reads (read-only); any early TodoWrite items stream in.
- *   • ready         → the rendered plan markdown + metadata + a toolbar, with
- *                     Approve & Execute / Reject / Regenerate controls. Nothing is
- *                     executed until the user approves.
- *   • implementing  → the live checklist ticks off as the agent works the plan.
- *   • completed     → the finished plan + its checklist, preserved for audit.
+ *   • planning      → "analyzing the repository" placeholder while the agent reads
+ *                     (read-only); the derived outline streams in as the plan grows.
+ *   • ready         → the rendered plan + a hierarchical, expandable task outline +
+ *                     a toolbar and an approval menu. Nothing runs until approved.
+ *   • implementing  → the outline becomes a live execution dashboard: tasks tick
+ *                     through pending → active → completed, with waiting/failed
+ *                     states derived from the run.
+ *   • completed     → the finished plan + outline, preserved for audit.
  *
- * Everything is driven by the active session's agent snapshot (plan + tasks); no
- * mock data. Theme tokens only — no new colors.
+ * The hierarchy (phases + per-task files/notes) is DERIVED from the plan Markdown
+ * — the harness only streams flat TodoWrite items — via {@link parsePlanOutline}
+ * and cross-referenced with live task status via {@link applyRuntime}. Everything
+ * is driven by the active session's agent snapshot; no mock data. Theme tokens
+ * only — no new colors.
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   CheckCircle2,
   ChevronDown,
@@ -21,23 +25,50 @@ import {
   ClipboardList,
   Code2,
   Copy,
-  Download,
+  FileDown,
+  FileText,
+  Filter,
+  History,
   Loader2,
+  ListChecks,
+  Pin,
+  PinOff,
+  Printer,
   RefreshCw,
+  Rows3,
+  Search,
+  TriangleAlert,
 } from 'lucide-react';
-import type { PlanMeta, PlanStatus, SessionPlan, TaskItem } from '@shared/types';
+import type {
+  PlanMeta,
+  PlanRevision,
+  PlanStatus,
+  SessionPermissionMode,
+  SessionPlan,
+  TaskItem,
+} from '@shared/types';
 import { EmptyState, IconButton, Spinner } from '@/renderer/components/ui';
 import { cn } from '@/renderer/lib/cn';
+import {
+  applyRuntime,
+  outlineToJson,
+  parsePlanOutline,
+  type OutlinePhase,
+  type OutlineTask,
+  type TaskExecStatus,
+} from '@/renderer/lib/planOutline';
+import { RUNNING_PHASES } from '@/renderer/features/sessions/useSessionRunning';
 import { useSessionStore } from '@/renderer/stores/useSessionStore';
 import { useAgentStore } from '@/renderer/stores/useAgentStore';
 import { useSettingsStore } from '@/renderer/stores/useSettingsStore';
+import { useLayoutStore } from '@/renderer/stores/useLayoutStore';
 import { useUIStore } from '@/renderer/stores/useUIStore';
 import { Markdown } from '@/renderer/features/workspace/Markdown';
 
 const STATUS_BADGE: Record<PlanStatus, { label: string; cls: string }> = {
   planning: { label: 'Planning', cls: 'text-accent' },
-  ready: { label: 'Ready for review', cls: 'text-accent' },
-  implementing: { label: 'Implementing', cls: 'text-warning' },
+  ready: { label: 'Ready for approval', cls: 'text-accent' },
+  implementing: { label: 'Active execution', cls: 'text-warning' },
   completed: { label: 'Completed', cls: 'text-success' },
   rejected: { label: 'Rejected', cls: 'text-faint' },
 };
@@ -47,6 +78,8 @@ const RISK_CLS: Record<NonNullable<PlanMeta['risk']>, string> = {
   medium: 'text-warning',
   high: 'text-danger',
 };
+
+type TaskFilter = 'all' | 'pending' | 'done';
 
 export function PlanPanel() {
   const sessionId = useSessionStore((s) => s.selectedId);
@@ -65,7 +98,7 @@ export function PlanPanel() {
     );
   }
 
-  // A checklist with no plan (a direct Implement run using TodoWrite).
+  // A checklist with no plan (a direct execution run using TodoWrite).
   if (!plan) {
     return (
       <div className="flex flex-col gap-3">
@@ -90,40 +123,56 @@ function PlanView({
   const approvePlan = useAgentStore((s) => s.approvePlan);
   const rejectPlan = useAgentStore((s) => s.rejectPlan);
   const regeneratePlan = useAgentStore((s) => s.regeneratePlan);
+  const setPlanPinned = useAgentStore((s) => s.setPlanPinned);
   const addToast = useUIStore((s) => s.addToast);
+
+  // Run signals used to derive live per-task execution states.
+  const awaitingPermission = useAgentStore((s) => (sessionId ? !!s.pendingBySession[sessionId] : false));
+  const request = useAgentStore((s) => (sessionId ? s.requestsBySession[sessionId] : undefined));
+  const running = !!request && RUNNING_PHASES.has(request.phase);
+  const failed = request?.outcome === 'failed' || request?.outcome === 'tool-rejected';
 
   const [raw, setRaw] = useState(false);
   const [bodyOpen, setBodyOpen] = useState(true);
-  const [confirming, setConfirming] = useState(false);
+  const [search, setSearch] = useState('');
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [filter, setFilter] = useState<TaskFilter>('all');
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+  const [historyOpen, setHistoryOpen] = useState(false);
 
   // Collapse the plan body automatically once implementation starts so the live
-  // checklist is what the eye lands on.
+  // outline is what the eye lands on.
   useEffect(() => {
     if (plan.status === 'implementing') setBodyOpen(false);
   }, [plan.status]);
 
-  const badge = STATUS_BADGE[plan.status];
   const planning = plan.status === 'planning';
   const ready = plan.status === 'ready';
+  const badge = STATUS_BADGE[plan.status];
+
+  // Derive the phase/task outline from the plan Markdown and overlay live status.
+  const outline = useMemo(() => {
+    const parsed = parsePlanOutline(plan.markdown);
+    return applyRuntime(parsed, { tasks, awaitingPermission, failed, running });
+  }, [plan.markdown, tasks, awaitingPermission, failed, running]);
+
+  const hasOutline = outline.taskCount > 0;
 
   const copy = () => {
     void window.limboo?.system?.clipboardWrite(plan.markdown);
     addToast({ title: 'Plan copied', tone: 'success' });
   };
-
-  const download = () => {
-    const ext = settings.defaultExportFormat === 'txt' ? 'txt' : 'md';
-    downloadText(`${slugify(plan.title)}.${ext}`, plan.markdown);
+  const exportMarkdown = () => downloadText(`${slugify(plan.title)}.md`, plan.markdown);
+  const exportJson = () =>
+    downloadText(`${slugify(plan.title)}.json`, outlineToJson(outline, plan.title));
+  const print = () => printPlan(plan.title, plan.markdown);
+  const togglePin = () => {
+    if (sessionId) setPlanPinned(sessionId, !plan.pinned);
   };
-
-  const onApprove = () => {
-    if (!sessionId) return;
-    if (settings.requireSecondaryConfirm && !confirming) {
-      setConfirming(true);
-      return;
-    }
-    setConfirming(false);
-    approvePlan(sessionId);
+  const setAllCollapsed = (value: boolean) => {
+    const next: Record<string, boolean> = {};
+    for (const p of outline.phases) next[p.id] = value;
+    setCollapsed(next);
   };
 
   return (
@@ -131,21 +180,48 @@ function PlanView({
       {/* Header + toolbar */}
       <div className="flex items-start gap-2">
         <div className="min-w-0 flex-1">
-          <p className="truncate text-[13px] font-semibold text-fg" title={plan.title}>
+          <p className="flex items-center gap-1.5 truncate text-[13px] font-semibold text-fg" title={plan.title}>
+            {plan.pinned && <Pin size={11} className="shrink-0 text-accent" />}
             {plan.title}
           </p>
           <span className={cn('text-[11px] font-medium', badge.cls)}>
             {planning && <Loader2 size={10} className="mr-1 inline animate-spin" />}
             {badge.label}
+            {hasOutline && ` · ${outline.completed}/${outline.taskCount}`}
           </span>
         </div>
         {!planning && (
-          <div className="flex shrink-0 items-center gap-0.5">
+          <div className="flex shrink-0 flex-wrap items-center justify-end gap-0.5">
             <IconButton size="sm" label="Copy plan as Markdown" onClick={copy}>
               <Copy size={13} />
             </IconButton>
-            <IconButton size="sm" label="Download plan" onClick={download}>
-              <Download size={13} />
+            <IconButton size="sm" label="Export as Markdown" onClick={exportMarkdown}>
+              <FileText size={13} />
+            </IconButton>
+            <IconButton size="sm" label="Export outline as JSON" onClick={exportJson}>
+              <FileDown size={13} />
+            </IconButton>
+            <IconButton size="sm" label="Print plan" onClick={print}>
+              <Printer size={13} />
+            </IconButton>
+            <IconButton
+              size="sm"
+              label="Search tasks"
+              active={searchOpen}
+              onClick={() => setSearchOpen((v) => !v)}
+            >
+              <Search size={13} />
+            </IconButton>
+            <IconButton
+              size="sm"
+              label={`Filter: ${filter}`}
+              active={filter !== 'all'}
+              onClick={() => setFilter((f) => (f === 'all' ? 'pending' : f === 'pending' ? 'done' : 'all'))}
+            >
+              <Filter size={13} />
+            </IconButton>
+            <IconButton size="sm" label="Collapse all phases" onClick={() => setAllCollapsed(true)}>
+              <Rows3 size={13} />
             </IconButton>
             <IconButton
               size="sm"
@@ -155,19 +231,33 @@ function PlanView({
             >
               <Code2 size={13} />
             </IconButton>
-            <IconButton
-              size="sm"
-              label="Regenerate plan"
-              onClick={() => sessionId && regeneratePlan(sessionId)}
-            >
+            <IconButton size="sm" label={plan.pinned ? 'Unpin plan' : 'Pin plan'} active={plan.pinned} onClick={togglePin}>
+              {plan.pinned ? <PinOff size={13} /> : <Pin size={13} />}
+            </IconButton>
+            <IconButton size="sm" label="History" active={historyOpen} onClick={() => setHistoryOpen((v) => !v)}>
+              <History size={13} />
+            </IconButton>
+            <IconButton size="sm" label="Regenerate plan" onClick={() => sessionId && regeneratePlan(sessionId)}>
               <RefreshCw size={13} />
             </IconButton>
           </div>
         )}
       </div>
 
+      {searchOpen && (
+        <input
+          autoFocus
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Filter tasks…"
+          className="w-full rounded-md border border-line bg-surface-2 px-2.5 py-1.5 text-[12px] text-fg placeholder:text-faint focus:border-line-strong focus:outline-none"
+        />
+      )}
+
       {/* Metadata */}
-      {settings.showEstimates && !planning && <PlanMetaRow meta={plan.meta} highlightRisk={settings.highlightRisk} />}
+      {settings.showEstimates && !planning && (
+        <PlanMetaRow meta={plan.meta} highlightRisk={settings.highlightRisk} />
+      )}
 
       {/* Planning placeholder */}
       {planning && (
@@ -203,50 +293,403 @@ function PlanView({
 
       {/* Approval controls */}
       {ready && (
-        <div className="flex flex-col gap-2 rounded-md border border-accent/40 bg-accent/10 px-3 py-2.5">
-          <p className="text-[12px] text-muted">
-            Review the plan above. Approving unlocks file changes and begins implementation against this
-            checklist.
-          </p>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={onApprove}
-              className="flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-[12px] font-semibold text-base transition-opacity hover:opacity-90"
-            >
-              <CheckCircle2 size={13} />
-              {confirming ? 'Confirm — start now' : 'Approve & Execute'}
-            </button>
-            <button
-              type="button"
-              onClick={() => sessionId && regeneratePlan(sessionId)}
-              className="rounded-md border border-line bg-surface-2 px-2.5 py-1.5 text-[12px] text-muted transition-colors hover:bg-elevated hover:text-fg"
-            >
-              Regenerate
-            </button>
-            <button
-              type="button"
-              onClick={() => sessionId && rejectPlan(sessionId)}
-              className="ml-auto rounded-md px-2.5 py-1.5 text-[12px] text-faint transition-colors hover:text-danger"
-            >
-              Reject
-            </button>
-          </div>
-        </div>
+        <ApprovalControls
+          settings={settings}
+          onApprove={(mode) => sessionId && approvePlan(sessionId, mode)}
+          onRegenerate={() => sessionId && regeneratePlan(sessionId)}
+          onReject={() => sessionId && rejectPlan(sessionId)}
+        />
       )}
 
-      {/* Live checklist */}
-      {tasks.length > 0 && <TaskChecklist tasks={tasks} />}
+      {/* Task outline (or the flat checklist fallback) */}
+      {hasOutline ? (
+        <OutlineTree
+          phases={outline.phases}
+          collapsed={collapsed}
+          onToggle={(id) => setCollapsed((c) => ({ ...c, [id]: !c[id] }))}
+          search={search}
+          filter={filter}
+          showDurations={settings.showTaskDurations}
+          onJump={(tab) => useLayoutStore.getState().setActiveTab(tab)}
+        />
+      ) : (
+        tasks.length > 0 && <TaskChecklist tasks={tasks} />
+      )}
+
+      {/* Revision history */}
+      {historyOpen && sessionId && <HistorySection sessionId={sessionId} plan={plan} />}
     </div>
   );
 }
 
+/* ------------------------------------------------------------------ */
+/* Approval                                                            */
+/* ------------------------------------------------------------------ */
+
+function ApprovalControls({
+  settings,
+  onApprove,
+  onRegenerate,
+  onReject,
+}: {
+  settings: { requireSecondaryConfirm: boolean };
+  onApprove: (mode: SessionPermissionMode) => void;
+  onRegenerate: () => void;
+  onReject: () => void;
+}) {
+  const [confirming, setConfirming] = useState<SessionPermissionMode | null>(null);
+
+  const approve = (mode: SessionPermissionMode) => {
+    if (settings.requireSecondaryConfirm && confirming !== mode) {
+      setConfirming(mode);
+      return;
+    }
+    setConfirming(null);
+    onApprove(mode);
+  };
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border border-accent/40 bg-accent/10 px-3 py-2.5">
+      <p className="text-[12px] text-muted">
+        Review the plan above. Approving exits Plan Mode and begins implementation against this
+        outline — choose how much to review as it works.
+      </p>
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => approve('default')}
+          className="flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-[12px] font-semibold text-base transition-opacity hover:opacity-90"
+        >
+          <CheckCircle2 size={13} />
+          {confirming === 'default' ? 'Confirm — start now' : 'Approve & ask before edits'}
+        </button>
+        <button
+          type="button"
+          onClick={() => approve('acceptEdits')}
+          className="rounded-md border border-accent/50 bg-accent/15 px-2.5 py-1.5 text-[12px] font-medium text-accent transition-colors hover:bg-accent/25"
+        >
+          {confirming === 'acceptEdits' ? 'Confirm — accept edits' : 'Approve & accept edits'}
+        </button>
+        <button
+          type="button"
+          onClick={onRegenerate}
+          className="rounded-md border border-line bg-surface-2 px-2.5 py-1.5 text-[12px] text-muted transition-colors hover:bg-elevated hover:text-fg"
+        >
+          Keep planning
+        </button>
+        <button
+          type="button"
+          onClick={onReject}
+          className="ml-auto rounded-md px-2.5 py-1.5 text-[12px] text-faint transition-colors hover:text-danger"
+        >
+          Reject
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Outline tree                                                        */
+/* ------------------------------------------------------------------ */
+
+const ACTIVE_STATES = new Set<TaskExecStatus>(['active', 'waiting', 'failed']);
+
+function OutlineTree({
+  phases,
+  collapsed,
+  onToggle,
+  search,
+  filter,
+  showDurations,
+  onJump,
+}: {
+  phases: OutlinePhase[];
+  collapsed: Record<string, boolean>;
+  onToggle: (id: string) => void;
+  search: string;
+  filter: TaskFilter;
+  showDurations: boolean;
+  onJump: (tab: 'changes' | 'terminal' | 'activity') => void;
+}) {
+  const q = search.trim().toLowerCase();
+  const matches = (t: OutlineTask): boolean => {
+    if (filter === 'pending' && t.status === 'completed') return false;
+    if (filter === 'done' && t.status !== 'completed') return false;
+    if (q && !t.title.toLowerCase().includes(q) && !t.notes.some((n) => n.toLowerCase().includes(q))) {
+      return false;
+    }
+    return true;
+  };
+
+  const visible = phases
+    .map((p) => ({ ...p, tasks: p.tasks.filter(matches) }))
+    .filter((p) => p.tasks.length > 0);
+
+  if (visible.length === 0) {
+    return <p className="px-1 py-2 text-[12px] text-faint">No tasks match the current filter.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {visible.map((phase) => {
+        const done = phase.tasks.filter((t) => t.status === 'completed').length;
+        const isCollapsed = collapsed[phase.id];
+        return (
+          <div key={phase.id} className="rounded-md border border-line bg-surface-2/40">
+            <button
+              type="button"
+              onClick={() => onToggle(phase.id)}
+              className="flex w-full items-center gap-1.5 px-2 py-1.5 text-left"
+            >
+              {isCollapsed ? (
+                <ChevronRight size={12} className="text-faint" />
+              ) : (
+                <ChevronDown size={12} className="text-faint" />
+              )}
+              <ListChecks size={12} className="text-muted" />
+              <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-fg">
+                {phase.title}
+              </span>
+              <span className="shrink-0 text-[10.5px] font-medium text-faint">
+                {done}/{phase.tasks.length}
+              </span>
+            </button>
+            {!isCollapsed && (
+              <ul className="flex flex-col gap-0.5 border-t border-line px-1.5 py-1">
+                {phase.tasks.map((task) => (
+                  <TaskRow key={task.id} task={task} showDurations={showDurations} onJump={onJump} />
+                ))}
+              </ul>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const EXEC_LABEL: Record<TaskExecStatus, string> = {
+  pending: 'Pending',
+  active: 'Active',
+  completed: 'Completed',
+  waiting: 'Waiting for approval',
+  failed: 'Failed',
+};
+
+function TaskRow({
+  task,
+  showDurations,
+  onJump,
+}: {
+  task: OutlineTask;
+  showDurations: boolean;
+  onJump: (tab: 'changes' | 'terminal' | 'activity') => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const hasDetail = task.notes.length > 0 || task.files.length > 0;
+  return (
+    <li className="rounded-md">
+      <div className="flex items-start gap-2 px-1 py-1">
+        <ExecMark status={task.status} />
+        <button
+          type="button"
+          onClick={() => hasDetail && setOpen((v) => !v)}
+          className={cn(
+            'min-w-0 flex-1 text-left text-[12px] leading-snug',
+            task.status === 'completed' && 'text-faint line-through',
+            task.status === 'active' && 'text-fg',
+            task.status === 'waiting' && 'text-warning',
+            task.status === 'failed' && 'text-danger',
+            task.status === 'pending' && 'text-muted',
+          )}
+        >
+          <span className="mr-1 text-faint">{task.order}.</span>
+          {task.title}
+          {ACTIVE_STATES.has(task.status) && (
+            <span className="ml-1.5 text-[10px] font-medium uppercase tracking-wide text-faint">
+              {EXEC_LABEL[task.status]}
+            </span>
+          )}
+        </button>
+        {hasDetail && (
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            className="mt-0.5 shrink-0 text-faint transition-colors hover:text-muted"
+            aria-label={open ? 'Collapse task' : 'Expand task'}
+          >
+            {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+          </button>
+        )}
+      </div>
+      {open && hasDetail && (
+        <div className="ml-6 flex flex-col gap-1.5 pb-1.5 pr-1">
+          {task.notes.length > 0 && (
+            <ul className="flex flex-col gap-0.5">
+              {task.notes.map((n, i) => (
+                <li key={i} className="text-[11.5px] leading-snug text-muted">
+                  · {n}
+                </li>
+              ))}
+            </ul>
+          )}
+          {task.files.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1">
+              {task.files.map((f) => (
+                <span
+                  key={f}
+                  className="rounded border border-line bg-surface-2 px-1.5 py-0.5 font-mono text-[10.5px] text-muted"
+                  title={f}
+                >
+                  {f}
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="flex items-center gap-2 text-[10.5px]">
+            <button type="button" onClick={() => onJump('changes')} className="text-accent hover:underline">
+              Jump to changes
+            </button>
+            <button type="button" onClick={() => onJump('terminal')} className="text-accent hover:underline">
+              Terminal
+            </button>
+            <button type="button" onClick={() => onJump('activity')} className="text-accent hover:underline">
+              Activity
+            </button>
+            {showDurations && task.status === 'completed' && (
+              <span className="ml-auto text-faint">done</span>
+            )}
+          </div>
+        </div>
+      )}
+    </li>
+  );
+}
+
+function ExecMark({ status }: { status: TaskExecStatus }) {
+  if (status === 'active' || status === 'waiting') {
+    return (
+      <span className="mt-0.5 flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+        <Spinner size={12} />
+      </span>
+    );
+  }
+  if (status === 'failed') {
+    return (
+      <span className="mt-0.5 flex h-3.5 w-3.5 shrink-0 items-center justify-center text-danger">
+        <TriangleAlert size={12} />
+      </span>
+    );
+  }
+  return (
+    <span
+      className={cn(
+        'mt-0.5 flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-[4px] border',
+        status === 'completed'
+          ? 'border-success bg-success/20 text-success'
+          : 'border-line-strong text-transparent',
+      )}
+    >
+      <CheckCircle2 size={10} />
+    </span>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Revision history                                                    */
+/* ------------------------------------------------------------------ */
+
+function HistorySection({ sessionId, plan }: { sessionId: string; plan: SessionPlan }) {
+  const listPlanRevisions = useAgentStore((s) => s.listPlanRevisions);
+  const restorePlanRevision = useAgentStore((s) => s.restorePlanRevision);
+  const [revisions, setRevisions] = useState<PlanRevision[]>([]);
+  const [compareId, setCompareId] = useState<string | null>(null);
+
+  // Reload whenever the current plan changes (a new revision may have landed).
+  useEffect(() => {
+    let alive = true;
+    void listPlanRevisions(sessionId).then((r) => {
+      if (alive) setRevisions(r);
+    });
+    return () => {
+      alive = false;
+    };
+  }, [sessionId, listPlanRevisions, plan.markdown]);
+
+  if (revisions.length === 0) {
+    return (
+      <div className="rounded-md border border-line bg-surface-2/40 px-3 py-2 text-[11.5px] text-faint">
+        No earlier revisions yet. Regenerating the plan keeps the previous version here for
+        comparison.
+      </div>
+    );
+  }
+
+  const compare = compareId ? revisions.find((r) => r.id === compareId) : null;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="text-[10px] font-medium uppercase tracking-wider text-faint">Plan history</div>
+      <ul className="flex flex-col gap-1">
+        {revisions.map((rev) => {
+          const diff = diffLines(plan.markdown, rev.markdown);
+          return (
+            <li key={rev.id} className="rounded-md border border-line bg-surface-2/40 px-2 py-1.5">
+              <div className="flex items-center gap-2">
+                <span className="shrink-0 rounded bg-surface-2 px-1.5 py-0.5 text-[10px] font-medium text-muted">
+                  r{rev.rev}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-[12px] text-fg" title={rev.title}>
+                  {rev.title}
+                </span>
+                <span className="shrink-0 text-[10px] text-faint">
+                  <span className="text-success">+{diff.added}</span>{' '}
+                  <span className="text-danger">-{diff.removed}</span>
+                </span>
+              </div>
+              <div className="mt-1 flex items-center gap-2 text-[10.5px]">
+                <button
+                  type="button"
+                  onClick={() => setCompareId((c) => (c === rev.id ? null : rev.id))}
+                  className="text-accent hover:underline"
+                >
+                  {compareId === rev.id ? 'Hide' : 'Compare'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => restorePlanRevision(sessionId, rev.id)}
+                  className="text-muted hover:text-fg"
+                >
+                  Restore
+                </button>
+                <span className="ml-auto text-faint">{formatTime(rev.createdAt)}</span>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+      {compare && (
+        <pre className="max-h-[40vh] overflow-auto rounded-md border border-line bg-surface-2 px-3 py-2 text-[11px] leading-relaxed text-muted">
+          {compare.markdown}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Shared bits                                                         */
+/* ------------------------------------------------------------------ */
+
 function PlanMetaRow({ meta, highlightRisk }: { meta: PlanMeta; highlightRisk: boolean }) {
   const chips: Array<{ label: string; cls?: string }> = [];
   if (meta.taskCount) chips.push({ label: `${meta.taskCount} task${meta.taskCount === 1 ? '' : 's'}` });
-  if (meta.affectedFiles) chips.push({ label: `~${meta.affectedFiles} file${meta.affectedFiles === 1 ? '' : 's'}` });
+  if (meta.affectedFiles)
+    chips.push({ label: `~${meta.affectedFiles} file${meta.affectedFiles === 1 ? '' : 's'}` });
   if (meta.risk) chips.push({ label: `${meta.risk} risk`, cls: highlightRisk ? RISK_CLS[meta.risk] : undefined });
-  if (meta.frameworks && meta.frameworks.length > 0) chips.push({ label: meta.frameworks.slice(0, 3).join(', ') });
+  if (meta.frameworks && meta.frameworks.length > 0)
+    chips.push({ label: meta.frameworks.slice(0, 3).join(', ') });
   if (chips.length === 0) return null;
   return (
     <div className="flex flex-wrap items-center gap-1.5">
@@ -280,7 +723,7 @@ function TaskChecklist({ tasks }: { tasks: TaskItem[] }) {
           const status = task.status ?? (task.done ? 'completed' : 'pending');
           return (
             <li key={task.id} className="flex items-start gap-2 rounded-md px-1 py-1">
-              <TaskMark status={status} />
+              <ExecMark status={status === 'in_progress' ? 'active' : status} />
               <span
                 className={cn(
                   'text-[12px] leading-snug',
@@ -296,28 +739,6 @@ function TaskChecklist({ tasks }: { tasks: TaskItem[] }) {
         })}
       </ul>
     </div>
-  );
-}
-
-function TaskMark({ status }: { status: NonNullable<TaskItem['status']> }) {
-  if (status === 'in_progress') {
-    return (
-      <span className="mt-0.5 flex h-3.5 w-3.5 shrink-0 items-center justify-center">
-        <Spinner size={12} />
-      </span>
-    );
-  }
-  return (
-    <span
-      className={cn(
-        'mt-0.5 flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-[4px] border',
-        status === 'completed'
-          ? 'border-success bg-success/20 text-success'
-          : 'border-line-strong text-transparent',
-      )}
-    >
-      <CheckCircle2 size={10} />
-    </span>
   );
 }
 
@@ -346,4 +767,65 @@ function downloadText(filename: string, text: string): void {
   a.click();
   a.remove();
   URL.revokeObjectURL(url);
+}
+
+/**
+ * Print just the plan via an offscreen iframe. A new BrowserWindow is denied by
+ * the app's window-open handler, so we print the iframe's own document instead of
+ * the whole shell. The raw Markdown is shown in a readable monospace block.
+ */
+function printPlan(title: string, markdown: string): void {
+  const iframe = document.createElement('iframe');
+  iframe.style.position = 'fixed';
+  iframe.style.right = '0';
+  iframe.style.bottom = '0';
+  iframe.style.width = '0';
+  iframe.style.height = '0';
+  iframe.style.border = '0';
+  document.body.appendChild(iframe);
+  const doc = iframe.contentWindow?.document;
+  if (!doc) {
+    iframe.remove();
+    return;
+  }
+  const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  doc.open();
+  doc.write(
+    `<html><head><title>${esc(title)}</title><style>` +
+      'body{font:12px/1.5 -apple-system,Segoe UI,Roboto,sans-serif;color:#111;padding:24px}' +
+      'h1{font-size:18px;margin:0 0 12px}pre{white-space:pre-wrap;word-wrap:break-word;font:11px/1.5 ui-monospace,Menlo,Consolas,monospace}' +
+      `</style></head><body><h1>${esc(title)}</h1><pre>${esc(markdown)}</pre></body></html>`,
+  );
+  doc.close();
+  const win = iframe.contentWindow;
+  if (win) {
+    win.focus();
+    win.print();
+  }
+  // Give the print dialog time to read the document before tearing it down.
+  window.setTimeout(() => iframe.remove(), 1000);
+}
+
+/** Naive line set-diff for a compact +added / -removed history summary. */
+function diffLines(current: string, revision: string): { added: number; removed: number } {
+  const cur = new Set(current.split(/\r?\n/).map((l) => l.trim()).filter(Boolean));
+  const rev = new Set(revision.split(/\r?\n/).map((l) => l.trim()).filter(Boolean));
+  let added = 0;
+  let removed = 0;
+  for (const l of cur) if (!rev.has(l)) added += 1;
+  for (const l of rev) if (!cur.has(l)) removed += 1;
+  return { added, removed };
+}
+
+function formatTime(ts: number): string {
+  try {
+    return new Date(ts).toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return '';
+  }
 }

--- a/src/renderer/features/settings/catalog.tsx
+++ b/src/renderer/features/settings/catalog.tsx
@@ -15,6 +15,7 @@ import {
   GitBranch,
   Keyboard,
   Info,
+  ListTodo,
   TerminalSquare,
   ArrowUpCircle,
   type LucideIcon,
@@ -24,6 +25,7 @@ import { AppearancePanel } from './panels/AppearancePanel';
 import { WorkspacePanel } from './panels/WorkspacePanel';
 import { BehaviorPanel } from './panels/BehaviorPanel';
 import { AgentPanel } from './panels/AgentPanel';
+import { PlanTasksPanel } from './panels/PlanTasksPanel';
 import { TerminalPanel } from './panels/TerminalPanel';
 import { GitPanel } from './panels/GitPanel';
 import { MemoryPanel } from './panels/MemoryPanel';
@@ -76,6 +78,7 @@ export const SETTINGS_CATALOG: SettingsCategory[] = [
     fields: [
       { id: 'approveTerminal', label: 'Approve terminal commands', keywords: ['shell', 'safety'] },
       { id: 'preferredShell', label: 'Preferred shell', keywords: ['bash', 'zsh', 'terminal'] },
+      { id: 'wsPlanDefaultMode', label: 'Start sessions in', keywords: ['plan', 'permission mode', 'default', 'accept edits'] },
       { id: 'ignoredDirs', label: 'Ignored directories', keywords: ['exclude', 'node_modules', 'index'] },
       { id: 'rescan', label: 'Refresh & reindex', keywords: ['rescan', 'reindex', 'detect', 'index', 'files'] },
     ],
@@ -115,6 +118,32 @@ export const SETTINGS_CATALOG: SettingsCategory[] = [
       { id: 'logVerbosity', label: 'Log verbosity', keywords: ['diagnostics', 'console', 'debug', 'log'] },
     ],
     Panel: AgentPanel,
+  },
+  {
+    id: 'plan',
+    label: 'Plan & Tasks',
+    icon: ListTodo,
+    keywords: ['plan', 'plan mode', 'tasks', 'todo', 'checklist', 'approve', 'execute', 'permission mode', 'accept edits', 'history', 'revisions', 'outline', 'phases'],
+    fields: [
+      { id: 'planDefaultMode', label: 'Default permission mode', keywords: ['plan', 'ask', 'accept edits', 'permission', 'start'] },
+      { id: 'planRequireSecondaryConfirm', label: 'Confirm before executing', keywords: ['approve', 'confirm', 'safety'] },
+      { id: 'planSaveToMemory', label: 'Save completed plans to Memory', keywords: ['memory', 'retain', 'knowledge'] },
+      { id: 'planShowReasoning', label: 'Show plan reasoning', keywords: ['markdown', 'reasoning', 'plan body'] },
+      { id: 'planShowEstimates', label: 'Show plan metadata', keywords: ['risk', 'files', 'task count'] },
+      { id: 'planHighlightRisk', label: 'Highlight risk', keywords: ['risk', 'color'] },
+      { id: 'planStreamIncrementally', label: 'Stream tasks as they appear', keywords: ['stream', 'incremental', 'live'] },
+      { id: 'planAutoExpandTasks', label: 'Auto-expand new tasks', keywords: ['expand', 'tasks'] },
+      { id: 'planAutoCollapseCompleted', label: 'Collapse completed tasks', keywords: ['collapse', 'done'] },
+      { id: 'planExportFormat', label: 'Plan export format', keywords: ['export', 'markdown', 'download'] },
+      { id: 'planShowTaskDurations', label: 'Show task durations', keywords: ['duration', 'time', 'execution'] },
+      { id: 'planShowCheckpoints', label: 'Show checkpoints on tasks', keywords: ['git', 'checkpoint', 'recovery'] },
+      { id: 'planAllowReorder', label: 'Allow manual reordering', keywords: ['reorder', 'drag', 'tasks'] },
+      { id: 'planNotifyPhase', label: 'Notify on phase completion', keywords: ['notify', 'notification', 'phase'] },
+      { id: 'planArchiveCompleted', label: 'Archive on completion', keywords: ['archive', 'done'] },
+      { id: 'planRetainHistory', label: 'Keep plan revisions', keywords: ['history', 'revisions', 'compare', 'restore'] },
+      { id: 'planHistoryLimit', label: 'Revisions kept per session', keywords: ['history', 'limit', 'prune'] },
+    ],
+    Panel: PlanTasksPanel,
   },
   {
     id: 'terminal',

--- a/src/renderer/features/settings/panels/AgentPanel.tsx
+++ b/src/renderer/features/settings/panels/AgentPanel.tsx
@@ -26,8 +26,6 @@ export function AgentPanel() {
     key: K,
     value: (typeof agent.connection)[K],
   ) => void update({ agent: { connection: { [key]: value } } });
-  const setPlan = <K extends keyof typeof agent.plan>(key: K, value: (typeof agent.plan)[K]) =>
-    void update({ agent: { plan: { [key]: value } } });
 
   return (
     <div className="flex flex-col gap-5">
@@ -140,68 +138,12 @@ export function AgentPanel() {
 
       <Section
         title="Plan Mode"
-        hint="The review-first workflow: the agent analyzes the repository read-only and proposes a plan you approve before any files change."
+        hint="Plan Mode is the review-first workflow — the agent analyzes read-only and proposes a plan you approve before any files change. Its settings now live in the dedicated Plan & Tasks category."
       >
-        <Field
-          id="planDefaultMode"
-          label="Default composer mode"
-          hint="What new sessions start in. Plan-first (default) is safest — the agent proposes before it changes anything."
-        >
-          <SegmentedControl
-            value={agent.plan.defaultMode}
-            options={[
-              { value: 'plan', label: 'Plan' },
-              { value: 'implement', label: 'Implement' },
-            ]}
-            onChange={(value) => setPlan('defaultMode', value)}
-          />
-        </Field>
-        <Field
-          id="planRequireSecondaryConfirm"
-          label="Confirm before executing"
-          hint="Require a second click on Approve & Execute before implementation begins. Default off."
-        >
-          <Toggle
-            checked={agent.plan.requireSecondaryConfirm}
-            onChange={(v) => setPlan('requireSecondaryConfirm', v)}
-          />
-        </Field>
-        <Field
-          id="planShowReasoning"
-          label="Show plan reasoning"
-          hint="Render the full implementation-plan markdown in the Tasks panel. Default on."
-        >
-          <Toggle checked={agent.plan.showReasoning} onChange={(v) => setPlan('showReasoning', v)} />
-        </Field>
-        <Field
-          id="planShowEstimates"
-          label="Show plan metadata"
-          hint="Show the affected-files / task-count / risk row above the plan. Default on."
-        >
-          <Toggle checked={agent.plan.showEstimates} onChange={(v) => setPlan('showEstimates', v)} />
-        </Field>
-        <Field
-          id="planHighlightRisk"
-          label="Highlight risk"
-          hint="Color the risk estimate (low / medium / high). Default on."
-        >
-          <Toggle checked={agent.plan.highlightRisk} onChange={(v) => setPlan('highlightRisk', v)} />
-        </Field>
-        <Field
-          id="planExportFormat"
-          label="Plan export format"
-          hint="Format used by the plan Download action."
-        >
-          <SegmentedControl
-            value={agent.plan.defaultExportFormat}
-            options={[
-              { value: 'md', label: 'Markdown' },
-              { value: 'txt', label: 'Text' },
-              { value: 'pdf', label: 'PDF' },
-            ]}
-            onChange={(value) => setPlan('defaultExportFormat', value)}
-          />
-        </Field>
+        <p className="text-[12px] text-faint">
+          Configure Plan-mode defaults, the Task Panel, execution, and plan history under
+          <span className="text-muted"> Settings › Plan &amp; Tasks</span>.
+        </p>
       </Section>
 
       <Section

--- a/src/renderer/features/settings/panels/PlanTasksPanel.tsx
+++ b/src/renderer/features/settings/panels/PlanTasksPanel.tsx
@@ -1,0 +1,202 @@
+/**
+ * Plan & Tasks settings — the governance surface for Plan Mode and the Task Panel.
+ * Plan Mode is the review-first workflow: the agent analyzes the repository
+ * read-only and proposes a plan you approve before any files change. These knobs
+ * control the default permission mode, how the plan/outline is presented, how
+ * execution is surfaced, and how planning history is retained.
+ */
+import type { SessionPermissionMode } from '@shared/types';
+import { useSettingsStore } from '@/renderer/stores/useSettingsStore';
+import { Field, Section, SegmentedControl, Select, Toggle } from '../controls';
+
+export function PlanTasksPanel() {
+  const plan = useSettingsStore((s) => s.settings.agent.plan);
+  const update = useSettingsStore((s) => s.update);
+
+  const setPlan = <K extends keyof typeof plan>(key: K, value: (typeof plan)[K]) =>
+    void update({ agent: { plan: { [key]: value } } });
+
+  return (
+    <div className="flex flex-col gap-5">
+      <Section
+        title="Plan Mode"
+        hint="The review-first workflow — the agent analyzes read-only and proposes a plan you approve before any files change. bypassPermissions is never offered (safety-first)."
+      >
+        <Field
+          id="planDefaultMode"
+          label="Default permission mode"
+          hint="What new sessions start in. Plan-first (default) is safest; a workspace can override this under Settings › Workspace."
+        >
+          <SegmentedControl<SessionPermissionMode>
+            value={plan.defaultMode}
+            options={[
+              { value: 'plan', label: 'Plan' },
+              { value: 'default', label: 'Ask' },
+              { value: 'acceptEdits', label: 'Accept' },
+            ]}
+            onChange={(value) => setPlan('defaultMode', value)}
+          />
+        </Field>
+        <Field
+          id="planRequireSecondaryConfirm"
+          label="Confirm before executing"
+          hint="Require a second click when approving a plan before implementation begins. Default off."
+        >
+          <Toggle
+            checked={plan.requireSecondaryConfirm}
+            onChange={(v) => setPlan('requireSecondaryConfirm', v)}
+          />
+        </Field>
+        <Field
+          id="planSaveToMemory"
+          label="Save completed plans to Memory"
+          hint="Store each finished plan in the Local Memory system so its strategy is retrievable on future tasks. Default off."
+        >
+          <Toggle checked={plan.savePlansToMemory} onChange={(v) => setPlan('savePlansToMemory', v)} />
+        </Field>
+      </Section>
+
+      <Section
+        title="Task Panel"
+        hint="How the derived plan outline is presented in the Tasks tab."
+      >
+        <Field
+          id="planShowReasoning"
+          label="Show plan reasoning"
+          hint="Render the full implementation-plan markdown in the Tasks panel. Default on."
+        >
+          <Toggle checked={plan.showReasoning} onChange={(v) => setPlan('showReasoning', v)} />
+        </Field>
+        <Field
+          id="planShowEstimates"
+          label="Show plan metadata"
+          hint="Show the affected-files / task-count / risk row above the plan. Default on."
+        >
+          <Toggle checked={plan.showEstimates} onChange={(v) => setPlan('showEstimates', v)} />
+        </Field>
+        <Field
+          id="planHighlightRisk"
+          label="Highlight risk"
+          hint="Color the risk estimate (low / medium / high). Default on."
+        >
+          <Toggle checked={plan.highlightRisk} onChange={(v) => setPlan('highlightRisk', v)} />
+        </Field>
+        <Field
+          id="planStreamIncrementally"
+          label="Stream tasks as they appear"
+          hint="Update the outline incrementally while the plan is built, rather than only when it completes. Default on."
+        >
+          <Toggle
+            checked={plan.streamIncrementally}
+            onChange={(v) => setPlan('streamIncrementally', v)}
+          />
+        </Field>
+        <Field
+          id="planAutoExpandTasks"
+          label="Auto-expand new tasks"
+          hint="Expand newly generated task groups automatically. Default on."
+        >
+          <Toggle checked={plan.autoExpandTasks} onChange={(v) => setPlan('autoExpandTasks', v)} />
+        </Field>
+        <Field
+          id="planAutoCollapseCompleted"
+          label="Collapse completed tasks"
+          hint="Collapse tasks automatically as they complete during execution. Default off."
+        >
+          <Toggle
+            checked={plan.autoCollapseCompleted}
+            onChange={(v) => setPlan('autoCollapseCompleted', v)}
+          />
+        </Field>
+        <Field
+          id="planExportFormat"
+          label="Plan export format"
+          hint="Default format used by the plan Export action."
+        >
+          <SegmentedControl<typeof plan.defaultExportFormat>
+            value={plan.defaultExportFormat}
+            options={[
+              { value: 'md', label: 'Markdown' },
+              { value: 'txt', label: 'Text' },
+              { value: 'pdf', label: 'PDF' },
+            ]}
+            onChange={(value) => setPlan('defaultExportFormat', value)}
+          />
+        </Field>
+      </Section>
+
+      <Section
+        title="Execution"
+        hint="How live progress is surfaced while a plan is implemented."
+      >
+        <Field
+          id="planShowTaskDurations"
+          label="Show task durations"
+          hint="Display how long each task took once implementation completes. Default on."
+        >
+          <Toggle checked={plan.showTaskDurations} onChange={(v) => setPlan('showTaskDurations', v)} />
+        </Field>
+        <Field
+          id="planShowCheckpoints"
+          label="Show checkpoints on tasks"
+          hint="Surface a Git-checkpoint hint next to tasks during execution. Default on."
+        >
+          <Toggle
+            checked={plan.showCheckpointsOnTasks}
+            onChange={(v) => setPlan('showCheckpointsOnTasks', v)}
+          />
+        </Field>
+        <Field
+          id="planAllowReorder"
+          label="Allow manual reordering"
+          hint="Let tasks be re-ordered after approval (best-effort UI). Default off."
+        >
+          <Toggle checked={plan.allowManualReorder} onChange={(v) => setPlan('allowManualReorder', v)} />
+        </Field>
+        <Field
+          id="planNotifyPhase"
+          label="Notify on phase completion"
+          hint="Fire a desktop notification when a plan phase completes. Default off."
+        >
+          <Toggle
+            checked={plan.notifyOnPhaseComplete}
+            onChange={(v) => setPlan('notifyOnPhaseComplete', v)}
+          />
+        </Field>
+        <Field
+          id="planArchiveCompleted"
+          label="Archive on completion"
+          hint="Archive a plan automatically once its implementation completes. Default off."
+        >
+          <Toggle checked={plan.archiveCompleted} onChange={(v) => setPlan('archiveCompleted', v)} />
+        </Field>
+      </Section>
+
+      <Section
+        title="History"
+        hint="Iterative planning keeps previous revisions so you can compare and restore across planning cycles."
+      >
+        <Field
+          id="planRetainHistory"
+          label="Keep plan revisions"
+          hint="Snapshot the previous plan whenever it is regenerated or restored. Default on."
+        >
+          <Toggle checked={plan.retainPlanHistory} onChange={(v) => setPlan('retainPlanHistory', v)} />
+        </Field>
+        {plan.retainPlanHistory && (
+          <Field
+            id="planHistoryLimit"
+            label="Revisions kept per session"
+            hint="Older revisions beyond this count are pruned."
+          >
+            <Select<number>
+              value={plan.historyLimit}
+              options={[5, 10, 20, 50, 100].map((n) => ({ value: n, label: String(n) }))}
+              onChange={(v) => setPlan('historyLimit', v)}
+            />
+          </Field>
+        )}
+      </Section>
+    </div>
+  );
+}

--- a/src/renderer/features/settings/panels/WorkspacePanel.tsx
+++ b/src/renderer/features/settings/panels/WorkspacePanel.tsx
@@ -11,7 +11,7 @@ import { useWorkspaceStore } from '@/renderer/stores/useWorkspaceStore';
 import { useFileSystemStore } from '@/renderer/stores/useFileSystemStore';
 import { useUIStore } from '@/renderer/stores/useUIStore';
 import { CircularProgress } from '@/renderer/components/ui';
-import { Section, Field, StackedField, Toggle, TextInput } from '../controls';
+import { Section, Field, Select, StackedField, Toggle, TextInput } from '../controls';
 import { detectedStack, suggestedIgnores } from '../detectIgnores';
 
 export function WorkspacePanel() {
@@ -157,6 +157,28 @@ function WorkspaceConfig({ workspace }: { workspace: Workspace }) {
           value={workspace.config.preferredShell}
           placeholder="OS default"
           onChange={(preferredShell) => void updateConfig(workspace.id, { preferredShell })}
+        />
+      </Field>
+
+      <Field
+        id="wsPlanDefaultMode"
+        label="Start sessions in"
+        hint="Permission mode every new session in this workspace begins in — overrides the global default. The desktop equivalent of a repo's permissions.defaultMode."
+      >
+        <Select<string>
+          value={workspace.config.planDefaultMode ?? 'inherit'}
+          options={[
+            { value: 'inherit', label: 'Global default' },
+            { value: 'plan', label: 'Plan' },
+            { value: 'default', label: 'Ask before edits' },
+            { value: 'acceptEdits', label: 'Accept edits' },
+          ]}
+          onChange={(value) =>
+            void updateConfig(workspace.id, {
+              planDefaultMode:
+                value === 'inherit' ? undefined : (value as 'plan' | 'default' | 'acceptEdits'),
+            })
+          }
         />
       </Field>
 

--- a/src/renderer/features/workspace/Composer.tsx
+++ b/src/renderer/features/workspace/Composer.tsx
@@ -15,12 +15,13 @@
 import { useEffect, useRef, useState } from 'react';
 import type { KeyboardEvent } from 'react';
 import { ArrowUp, CircleStop, Paperclip, Sparkles } from 'lucide-react';
-import type { AgentMode } from '@shared/types';
+import type { SessionPermissionMode } from '@shared/types';
 import { cn } from '@/renderer/lib/cn';
 import { Spinner } from '@/renderer/components/ui';
 import { useSessionStore } from '@/renderer/stores/useSessionStore';
 import { useAgentStore } from '@/renderer/stores/useAgentStore';
 import { useSettingsStore } from '@/renderer/stores/useSettingsStore';
+import { useWorkspaceStore } from '@/renderer/stores/useWorkspaceStore';
 import { lifecycleMeta, phaseLabel } from '@/renderer/features/agent/status';
 import { RUNNING_PHASES } from '@/renderer/features/sessions/useSessionRunning';
 import { ComposerControls } from './ComposerControls';
@@ -49,11 +50,17 @@ export function Composer({ disabled = false }: { disabled?: boolean }) {
   );
   const send = useAgentStore((s) => s.send);
   const stop = useAgentStore((s) => s.stop);
-  const defaultMode = useSettingsStore((s) => s.settings.agent.plan.defaultMode);
+  const globalDefaultMode = useSettingsStore((s) => s.settings.agent.plan.defaultMode);
+  // A workspace can pin its own starting mode (repo-level Plan-first), overriding
+  // the global default — the desktop equivalent of `permissions.defaultMode`.
+  const workspaceDefaultMode = useWorkspaceStore(
+    (s) => s.workspaces.find((w) => w.id === s.activeId)?.config.planDefaultMode,
+  );
+  const defaultMode: SessionPermissionMode = workspaceDefaultMode ?? globalDefaultMode;
 
-  // Per-session composer mode, defaulting to the configured Plan-first default.
+  // Per-session composer mode, defaulting to the resolved Plan-first default.
   // Reset to the default whenever the active session changes.
-  const [mode, setMode] = useState<AgentMode>(defaultMode);
+  const [mode, setMode] = useState<SessionPermissionMode>(defaultMode);
   useEffect(() => {
     setMode(defaultMode);
   }, [sessionId, defaultMode]);
@@ -178,7 +185,7 @@ function composerPlaceholder(
   disabled: boolean,
   installed: boolean,
   restricted: boolean,
-  mode: AgentMode,
+  mode: SessionPermissionMode,
 ): string {
   if (!installed) return 'Sign in to Claude Code to start…';
   if (restricted) return 'Drafting is fine — sending resumes shortly…';

--- a/src/renderer/features/workspace/ComposerControls.tsx
+++ b/src/renderer/features/workspace/ComposerControls.tsx
@@ -5,7 +5,7 @@
  * `useSettingsStore.update`, so changes apply to the next prompt immediately.
  */
 import { useEffect, useRef, useState } from 'react';
-import { Brain, Check, ChevronDown, ShieldCheck, type LucideIcon } from 'lucide-react';
+import { Brain, Check, ChevronDown, type LucideIcon } from 'lucide-react';
 import { AGENT_MODELS, providerForModel } from '@shared/constants';
 import { cn } from '@/renderer/lib/cn';
 import { ProviderIcon } from '@/renderer/components/brand/ProviderIcon';
@@ -29,6 +29,7 @@ export function MiniSelect<T extends string>({
   triggerGlyph,
   title,
   disabled,
+  accent = false,
 }: {
   value: T;
   options: Option<T>[];
@@ -38,6 +39,8 @@ export function MiniSelect<T extends string>({
   triggerGlyph?: React.ReactNode;
   title: string;
   disabled?: boolean;
+  /** Render the trigger as a filled accent pill (used for the active Plan state). */
+  accent?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -67,8 +70,12 @@ export function MiniSelect<T extends string>({
         disabled={disabled}
         onClick={() => setOpen((v) => !v)}
         className={cn(
-          'flex h-6 min-w-0 max-w-full items-center gap-1 rounded-md px-1.5 text-[11px] text-muted transition-colors hover:bg-elevated hover:text-fg disabled:cursor-not-allowed disabled:opacity-50',
-          open && 'bg-elevated text-fg',
+          'flex h-6 min-w-0 max-w-full items-center gap-1 rounded-md px-1.5 text-[11px] transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+          accent
+            ? 'bg-accent/15 font-medium text-accent hover:bg-accent/25'
+            : 'text-muted hover:bg-elevated hover:text-fg',
+          open && !accent && 'bg-elevated text-fg',
+          open && accent && 'bg-accent/25',
         )}
       >
         {triggerGlyph ?? (Icon && <Icon size={12} className="text-faint" />)}
@@ -132,19 +139,6 @@ export function ComposerControls({ disabled = false }: { disabled?: boolean }) {
           { value: 'adaptive', label: 'Thinking: Adaptive' },
         ]}
         onChange={(thinking) => void update({ agent: { thinking } })}
-        disabled={disabled}
-      />
-      <span className="h-3.5 w-px bg-line" />
-      <MiniSelect
-        title="Approval policy"
-        icon={ShieldCheck}
-        value={agent.permissionMode}
-        options={[
-          { value: 'approve-edits', label: 'Approve edits & commands' },
-          { value: 'approve-all', label: 'Approve everything' },
-          { value: 'auto', label: 'Auto-approve' },
-        ]}
-        onChange={(permissionMode) => void update({ agent: { permissionMode } })}
         disabled={disabled}
       />
     </div>

--- a/src/renderer/features/workspace/ComposerModeSwitch.tsx
+++ b/src/renderer/features/workspace/ComposerModeSwitch.tsx
@@ -1,42 +1,47 @@
 /**
- * Plan / Build mode select — the control that governs the agent's execution mode
- * for the next prompt. In Plan mode the agent runs read-only and proposes an
- * implementation strategy for review; in Build (implement) mode it is free to
- * modify the repository (still gated by the per-tool approval policy).
+ * Permission-mode selector — the single composer control that governs how the
+ * agent is allowed to act on the next prompt. It mirrors Claude Code's own
+ * `Shift+Tab` cycle vocabulary so the desktop app stays in lock-step with the
+ * harness (see {@link SessionPermissionMode}):
  *
- * Rendered as a compact popover select (the shared {@link MiniSelect}) so it looks
- * and behaves exactly like the other composer footer controls — click the trigger,
- * pick the other mode from a small menu — rather than an always-expanded segmented
- * block. This also keeps the footer on one line as the center column narrows.
+ *   • Plan            — read-only; the agent proposes a strategy for review.
+ *   • Ask before edits — writes/commands prompt for approval (SDK `default`).
+ *   • Accept edits     — file edits auto-approve; commands still prompt.
+ *
+ * `bypassPermissions` is deliberately absent (this is a safety-first local app).
+ * When Plan is active the trigger renders as a prominent accent "Plan" pill so the
+ * planning state reads at a glance without a separate panel.
  *
  * Pure presentation: the selected mode lives in the Composer and is passed to
- * `agent.send(sessionId, prompt, mode)`.
+ * `agent.send(sessionId, prompt, mode)`; every prompt inherits it until changed.
  */
 import type { ReactNode } from 'react';
-import { ClipboardList, Hammer } from 'lucide-react';
-import type { AgentMode } from '@shared/types';
+import { ClipboardList, FilePen, ShieldCheck } from 'lucide-react';
+import type { SessionPermissionMode } from '@shared/types';
 import { MiniSelect, type Option } from './ComposerControls';
 
-const MODE_GLYPH: Record<AgentMode, ReactNode> = {
+const MODE_GLYPH: Record<SessionPermissionMode, ReactNode> = {
   plan: <ClipboardList size={13} className="text-accent" />,
-  implement: <Hammer size={13} className="text-muted" />,
+  default: <ShieldCheck size={13} className="text-muted" />,
+  acceptEdits: <FilePen size={13} className="text-muted" />,
 };
 
-const MODE_OPTIONS: Option<AgentMode>[] = [
+const MODE_OPTIONS: Option<SessionPermissionMode>[] = [
   { value: 'plan', label: 'Plan', glyph: MODE_GLYPH.plan },
-  { value: 'implement', label: 'Build', glyph: MODE_GLYPH.implement },
+  { value: 'default', label: 'Ask before edits', glyph: MODE_GLYPH.default },
+  { value: 'acceptEdits', label: 'Accept edits', glyph: MODE_GLYPH.acceptEdits },
 ];
 
 const MODE_TITLE =
-  'Execution mode — Plan analyzes the repository read-only and proposes a strategy; Build lets the agent modify it';
+  'Permission mode — Plan is read-only and proposes a strategy; Ask before edits prompts for every change; Accept edits auto-approves file edits (commands still prompt)';
 
 export function ComposerModeSwitch({
   mode,
   onChange,
   disabled = false,
 }: {
-  mode: AgentMode;
-  onChange: (mode: AgentMode) => void;
+  mode: SessionPermissionMode;
+  onChange: (mode: SessionPermissionMode) => void;
   disabled?: boolean;
 }) {
   return (
@@ -45,9 +50,10 @@ export function ComposerModeSwitch({
       value={mode}
       options={MODE_OPTIONS}
       onChange={onChange}
-      // Mirror the active mode's glyph on the trigger so the current mode reads at
-      // a glance, matching the model select's provider-mark trigger.
+      // Mirror the active mode's glyph on the trigger so it reads at a glance, and
+      // light the trigger up in accent while Plan is active (first-class state).
       triggerGlyph={MODE_GLYPH[mode]}
+      accent={mode === 'plan'}
       disabled={disabled}
     />
   );

--- a/src/renderer/lib/commands.ts
+++ b/src/renderer/lib/commands.ts
@@ -5,7 +5,7 @@
  * Commands operate on Zustand stores via `getState()` so they can run from
  * anywhere (inside or outside React) without prop drilling.
  */
-import type { AgentMode, CommandId } from '@shared/types';
+import type { CommandId, SessionPermissionMode } from '@shared/types';
 import { useLayoutStore } from '@/renderer/stores/useLayoutStore';
 import { useSessionStore } from '@/renderer/stores/useSessionStore';
 import { useUIStore } from '@/renderer/stores/useUIStore';
@@ -15,8 +15,8 @@ import { useSettingsStore } from '@/renderer/stores/useSettingsStore';
 import { useFileSystemStore } from '@/renderer/stores/useFileSystemStore';
 import { useTerminalStore } from '@/renderer/stores/useTerminalStore';
 
-/** Set the composer's default execution mode (Plan-first vs direct Implement). */
-function setDefaultMode(defaultMode: AgentMode): void {
+/** Set the composer's default permission mode (Plan / Ask before edits / Accept edits). */
+function setDefaultMode(defaultMode: SessionPermissionMode): void {
   void useSettingsStore.getState().update({ agent: { plan: { defaultMode } } });
 }
 
@@ -136,10 +136,10 @@ export const COMMANDS: Command[] = [
   },
   {
     id: 'agent.implementMode',
-    title: 'Switch to Implement mode',
+    title: 'Switch to Ask-before-edits mode',
     section: 'Agent',
     inPalette: true,
-    run: () => setDefaultMode('implement'),
+    run: () => setDefaultMode('default'),
   },
   {
     id: 'plan.approve',

--- a/src/renderer/lib/planOutline.ts
+++ b/src/renderer/lib/planOutline.ts
@@ -1,0 +1,242 @@
+/**
+ * Plan outline parser — turns the agent's plan Markdown into the hierarchical
+ * phase/task structure the Task Panel visualizes.
+ *
+ * The Claude Code harness only streams flat `TodoWrite` items (`{ content,
+ * status }`); it does NOT emit phases, per-task files, or rationale. Rather than
+ * invent that structure, we DERIVE it from the plan Markdown the agent already
+ * writes: headings become phases, list items become tasks, indented lines and
+ * following prose become notes, and path-like code spans become affected files.
+ * Live execution status is then layered on by fuzzy-matching each derived task
+ * against the harness `TaskItem[]`.
+ *
+ * Pure + dependency-free (renderer-side): the same Markdown always yields the
+ * same outline, so it is safe to run on every streamed delta.
+ */
+import type { TaskItem, TaskStatus } from '@shared/types';
+
+/** Execution status shown per task. Extends the harness statuses with derived ones. */
+export type TaskExecStatus =
+  | 'pending'
+  | 'active'
+  | 'completed'
+  | 'waiting' // a permission prompt is open on the active task
+  | 'failed'; // the run errored while this task was active
+
+export interface OutlineTask {
+  id: string;
+  title: string;
+  /** Global 1-based execution order across all phases. */
+  order: number;
+  /** Indented bullet lines / following prose that elaborate the task. */
+  notes: string[];
+  /** Path-like references discovered in the task text (best-effort). */
+  files: string[];
+  status: TaskExecStatus;
+}
+
+export interface OutlinePhase {
+  id: string;
+  title: string;
+  tasks: OutlineTask[];
+}
+
+export interface PlanOutline {
+  phases: OutlinePhase[];
+  taskCount: number;
+  completed: number;
+}
+
+const HEADING = /^(#{1,6})\s+(.*)$/;
+const LIST_ITEM = /^(\s*)(?:[-*+]|\d+[.)])\s+(.+)$/;
+// A code span that looks like a file path: has a slash or a dotted extension.
+const PATH_IN_CODE = /`([^`]+)`/g;
+const LOOKS_LIKE_PATH = /[\w.-]+\/[\w./-]+|[\w-]+\.[a-z]{1,5}\b/i;
+
+/** Strip Markdown emphasis/links/code for a clean, comparable task title. */
+function cleanInline(text: string): string {
+  return text
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** Extract path-like code spans from a line. */
+function filesIn(line: string): string[] {
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  PATH_IN_CODE.lastIndex = 0;
+  while ((m = PATH_IN_CODE.exec(line))) {
+    const inner = m[1].trim();
+    if (LOOKS_LIKE_PATH.test(inner) && inner.length <= 120) out.push(inner);
+  }
+  return out;
+}
+
+/** Normalize a label for fuzzy matching (lowercase alphanumerics only). */
+function norm(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+/**
+ * Parse plan Markdown into phases + tasks. Fenced code blocks are skipped so a
+ * `- item` inside a shell snippet is not mistaken for a task.
+ */
+export function parsePlanOutline(markdown: string): PlanOutline {
+  const phases: OutlinePhase[] = [];
+  let current: OutlinePhase | null = null;
+  let lastTask: OutlineTask | null = null;
+  let order = 0;
+  let inFence = false;
+
+  const ensurePhase = (): OutlinePhase => {
+    if (!current) {
+      current = { id: `phase_${phases.length}`, title: 'Plan', tasks: [] };
+      phases.push(current);
+    }
+    return current;
+  };
+
+  const lines = markdown.split(/\r?\n/);
+  for (const raw of lines) {
+    const line = raw;
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+
+    const heading = HEADING.exec(line);
+    if (heading) {
+      const title = cleanInline(heading[2]);
+      if (title) {
+        current = { id: `phase_${phases.length}`, title, tasks: [] };
+        phases.push(current);
+        lastTask = null;
+      }
+      continue;
+    }
+
+    const item = LIST_ITEM.exec(line);
+    if (item) {
+      const indent = item[1].replace(/\t/g, '  ').length;
+      const text = item[2].trim();
+      // Deeply-indented bullets elaborate the preceding task instead of becoming
+      // their own row (keeps the tree shallow and readable).
+      if (indent >= 2 && lastTask) {
+        lastTask.notes.push(cleanInline(text));
+        lastTask.files.push(...filesIn(text));
+        continue;
+      }
+      const phase = ensurePhase();
+      order += 1;
+      lastTask = {
+        id: `${phase.id}_task_${phase.tasks.length}`,
+        title: cleanInline(text),
+        order,
+        notes: [],
+        files: filesIn(text),
+        status: 'pending',
+      };
+      phase.tasks.push(lastTask);
+      continue;
+    }
+
+    // Prose directly under a task becomes a note; a blank line ends the run.
+    const prose = line.trim();
+    if (prose && lastTask && !HEADING.test(line)) {
+      lastTask.notes.push(cleanInline(prose));
+      lastTask.files.push(...filesIn(prose));
+    } else if (!prose) {
+      lastTask = null;
+    }
+  }
+
+  // De-dup files per task.
+  for (const p of phases) {
+    for (const t of p.tasks) t.files = Array.from(new Set(t.files)).slice(0, 8);
+  }
+
+  const taskCount = phases.reduce((n, p) => n + p.tasks.length, 0);
+  return { phases, taskCount, completed: 0 };
+}
+
+export interface OutlineRuntime {
+  /** Live harness todos (drives per-task status). */
+  tasks: TaskItem[];
+  /** True while a permission prompt is open for this session. */
+  awaitingPermission?: boolean;
+  /** True if the last run for this session ended in error. */
+  failed?: boolean;
+  /** True while implementation is actively running. */
+  running?: boolean;
+}
+
+const STATUS_RANK: Record<TaskStatus, number> = { pending: 0, in_progress: 1, completed: 2 };
+
+/**
+ * Overlay live execution status from the harness `TaskItem[]` onto a parsed
+ * outline by fuzzy title match. When the outline can't be matched (no plan text),
+ * callers fall back to rendering the flat checklist instead.
+ */
+export function applyRuntime(outline: PlanOutline, runtime: OutlineRuntime): PlanOutline {
+  const todos = runtime.tasks ?? [];
+  const normedTodos = todos.map((t) => ({ n: norm(t.label), status: t.status ?? (t.done ? 'completed' : 'pending') }));
+
+  const match = (title: string): TaskStatus | undefined => {
+    const n = norm(title);
+    if (!n) return undefined;
+    let best: { status: TaskStatus; rank: number } | undefined;
+    for (const td of normedTodos) {
+      if (!td.n) continue;
+      if (td.n === n || td.n.includes(n) || n.includes(td.n)) {
+        const rank = STATUS_RANK[td.status];
+        if (!best || rank > best.rank) best = { status: td.status, rank };
+      }
+    }
+    return best?.status;
+  };
+
+  let completed = 0;
+  const phases = outline.phases.map((p) => ({
+    ...p,
+    tasks: p.tasks.map((t) => {
+      const live = match(t.title);
+      let status: TaskExecStatus =
+        live === 'completed' ? 'completed' : live === 'in_progress' ? 'active' : 'pending';
+      // Layer session-level signals onto the currently-active task only.
+      if (status === 'active' && runtime.awaitingPermission) status = 'waiting';
+      if (status === 'active' && runtime.failed) status = 'failed';
+      if (status === 'completed') completed += 1;
+      return { ...t, status };
+    }),
+  }));
+
+  return { phases, taskCount: outline.taskCount, completed };
+}
+
+/** Serialize an outline to a stable JSON structure for the Export → JSON action. */
+export function outlineToJson(outline: PlanOutline, title: string): string {
+  return JSON.stringify(
+    {
+      title,
+      taskCount: outline.taskCount,
+      completed: outline.completed,
+      phases: outline.phases.map((p) => ({
+        title: p.title,
+        tasks: p.tasks.map((t) => ({
+          order: t.order,
+          title: t.title,
+          status: t.status,
+          files: t.files,
+          notes: t.notes,
+        })),
+      })),
+    },
+    null,
+    2,
+  );
+}

--- a/src/renderer/stores/useAgentStore.ts
+++ b/src/renderer/stores/useAgentStore.ts
@@ -18,14 +18,15 @@ import type {
   AgentEvent,
   AgentInstall,
   AgentLifecycleStatus,
-  AgentMode,
   AgentSessionSnapshot,
   ChatMessage,
   ClarificationRequest,
   FileChange,
   PermissionRequest,
+  PlanRevision,
   RateLimitInfo,
   RequestState,
+  SessionPermissionMode,
 } from '@shared/types';
 import { useUIStore } from './useUIStore';
 
@@ -68,7 +69,7 @@ interface AgentStoreState {
   hydrate: () => Promise<void>;
   loadSession: (sessionId: string) => Promise<void>;
   loadDiagnostics: (sessionId?: string | null) => Promise<void>;
-  send: (sessionId: string, prompt: string, mode?: AgentMode) => Promise<void>;
+  send: (sessionId: string, prompt: string, mode?: SessionPermissionMode) => Promise<void>;
   stop: (sessionId: string) => void;
   clear: (sessionId: string) => void;
   clearRateLimit: () => void;
@@ -79,9 +80,12 @@ interface AgentStoreState {
     answers: Record<string, string | string[]>,
     response?: string,
   ) => void;
-  approvePlan: (sessionId: string) => void;
+  approvePlan: (sessionId: string, execMode?: SessionPermissionMode) => void;
   rejectPlan: (sessionId: string) => void;
   regeneratePlan: (sessionId: string, extra?: string) => void;
+  setPlanPinned: (sessionId: string, pinned: boolean) => void;
+  listPlanRevisions: (sessionId: string) => Promise<PlanRevision[]>;
+  restorePlanRevision: (sessionId: string, revisionId: string) => void;
 }
 
 export const useAgentStore = create<AgentStoreState>((set, get) => {
@@ -402,10 +406,10 @@ export const useAgentStore = create<AgentStoreState>((set, get) => {
       }));
     },
 
-    approvePlan: (sessionId) => {
+    approvePlan: (sessionId, execMode) => {
       const api = window.limboo?.agent;
       if (!api?.approvePlan) return;
-      api.approvePlan(sessionId).catch((err: unknown) => {
+      api.approvePlan(sessionId, execMode).catch((err: unknown) => {
         useUIStore.getState().addToast({
           title: 'Could not start implementation',
           description: err instanceof Error ? err.message : String(err),
@@ -420,6 +424,24 @@ export const useAgentStore = create<AgentStoreState>((set, get) => {
 
     regeneratePlan: (sessionId, extra) => {
       void window.limboo?.agent?.regeneratePlan?.(sessionId, extra);
+    },
+
+    setPlanPinned: (sessionId, pinned) => {
+      void window.limboo?.agent?.setPlanPinned?.(sessionId, pinned);
+    },
+
+    listPlanRevisions: async (sessionId) => {
+      const api = window.limboo?.agent;
+      if (!api?.listPlanRevisions) return [];
+      try {
+        return await api.listPlanRevisions(sessionId);
+      } catch {
+        return [];
+      }
+    },
+
+    restorePlanRevision: (sessionId, revisionId) => {
+      void window.limboo?.agent?.restorePlanRevision?.(sessionId, revisionId);
     },
   };
 });

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,7 +1,7 @@
 import type { AppSettings, WorkspaceConfig } from './types';
 
 /** Bumped whenever the {@link AppSettings} shape changes incompatibly. */
-export const SETTINGS_VERSION = 8;
+export const SETTINGS_VERSION = 9;
 
 /** The agent providers Limboo can show a glyph for (Claude Code = Anthropic). */
 export type AgentProvider = 'anthropic';
@@ -164,6 +164,13 @@ export const DEFAULT_SETTINGS: AppSettings = {
       showReasoning: true,
       highlightRisk: true,
       archiveCompleted: false,
+      showTaskDurations: true,
+      showCheckpointsOnTasks: true,
+      retainPlanHistory: true,
+      historyLimit: 20,
+      savePlansToMemory: false,
+      allowManualReorder: false,
+      notifyOnPhaseComplete: false,
     },
     terminal: {
       shell: '',
@@ -220,7 +227,7 @@ export function clamp(value: number, min: number, max: number): number {
 /* ------------------------------------------------------------------ */
 
 /** Bumped whenever the workspace DB schema changes incompatibly. */
-export const WORKSPACE_SCHEMA_VERSION = 6;
+export const WORKSPACE_SCHEMA_VERSION = 7;
 
 /** Input caps the main process enforces on renderer-supplied session values. */
 export const SESSION_LIMITS = {
@@ -287,6 +294,8 @@ export const DEFAULT_WORKSPACE_CONFIG: WorkspaceConfig = {
   ignoredDirs: [...DEFAULT_IGNORED_DIRS],
   approveTerminalCommands: true,
   preferredShell: '',
+  // Undefined = inherit the global agent.plan.defaultMode.
+  planDefaultMode: undefined,
 };
 
 /**

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -71,6 +71,9 @@ export const IpcChannels = {
   agentApprovePlan: 'agent:approvePlan',
   agentRejectPlan: 'agent:rejectPlan',
   agentRegeneratePlan: 'agent:regeneratePlan',
+  agentSetPlanPinned: 'agent:setPlanPinned',
+  agentListPlanRevisions: 'agent:listPlanRevisions',
+  agentRestorePlanRevision: 'agent:restorePlanRevision',
 
   // File System Layer (Phase 4) — read + watch + index foundation.
   fsIndex: 'fs:index',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -133,8 +133,8 @@ export interface AppSettings {
      * a plan before touching the repository. None of these touch credentials.
      */
     plan: {
-      /** Composer default when a session has no remembered mode. */
-      defaultMode: AgentMode;
+      /** Composer default permission mode when a session has no remembered mode. */
+      defaultMode: SessionPermissionMode;
       /** Stream the task checklist incrementally as the plan is built. */
       streamIncrementally: boolean;
       /** Auto-expand newly generated task rows in the panel. */
@@ -153,6 +153,20 @@ export interface AppSettings {
       highlightRisk: boolean;
       /** Archive a plan once its implementation completes. */
       archiveCompleted: boolean;
+      /** Show per-task execution durations once implementation runs. */
+      showTaskDurations: boolean;
+      /** Surface a Git-checkpoint hint next to tasks during execution. */
+      showCheckpointsOnTasks: boolean;
+      /** Keep previous plan revisions so iterations can be compared/restored. */
+      retainPlanHistory: boolean;
+      /** Max plan revisions kept per session (older ones are pruned). */
+      historyLimit: number;
+      /** Save a completed plan into the Local Memory system for future retrieval. */
+      savePlansToMemory: boolean;
+      /** Allow manual reordering of tasks after approval (best-effort UI only). */
+      allowManualReorder: boolean;
+      /** Fire a desktop notification when a plan phase completes. */
+      notifyOnPhaseComplete: boolean;
     };
     /**
      * Integrated-terminal preferences. Appearance + behavior knobs for the
@@ -317,8 +331,22 @@ export type SessionStatus = 'active' | 'idle' | 'done';
 /**
  * Composer execution mode. `plan` runs the agent read-only to propose an
  * implementation strategy for review; `implement` lets it modify the repository.
+ * Internal to the main process (plan lifecycle, run bookkeeping); the renderer +
+ * IPC speak {@link SessionPermissionMode} instead.
  */
 export type AgentMode = 'plan' | 'implement';
+
+/**
+ * The harness-aligned permission mode the composer exposes as a single selector,
+ * matching Claude Code's `Shift+Tab` cycle vocabulary:
+ * - `plan`        → read-only analysis; the agent proposes a plan (SDK `plan`).
+ * - `default`     → asks before edits/commands (SDK `default`).
+ * - `acceptEdits` → auto-approves file edits; commands still prompt (SDK `acceptEdits`).
+ * `bypassPermissions` is intentionally NOT exposed (this is a local, safety-first
+ * app). The coarser auto/approve-all knobs live in Settings › Agent as advanced
+ * enforcement layered on top by `canUseTool`.
+ */
+export type SessionPermissionMode = 'plan' | 'default' | 'acceptEdits';
 
 /**
  * A development workspace — the primary unit of software engineering in Limboo.
@@ -345,8 +373,8 @@ export interface Session {
   archived: boolean;
   /** Epoch ms when soft-deleted (moved to trash), or null when live. */
   deletedAt: number | null;
-  /** Last composer mode used for this session (drives the Plan/Implement switch). */
-  mode?: AgentMode;
+  /** Last composer permission mode used for this session (drives the selector). */
+  mode?: SessionPermissionMode;
 }
 
 /** Renderer-supplied patch for a session update (rename / pin / archive). */
@@ -725,6 +753,12 @@ export interface WorkspaceConfig {
   approveTerminalCommands: boolean;
   /** Preferred shell for terminal sessions (empty = OS default). */
   preferredShell: string;
+  /**
+   * Permission mode every new session in this workspace starts in. Overrides the
+   * global `agent.plan.defaultMode`. The desktop equivalent of a repo's
+   * `.claude/settings.json` `permissions.defaultMode`. Undefined = inherit global.
+   */
+  planDefaultMode?: SessionPermissionMode;
 }
 
 /** Groundable repository statistics (no indexing/search engine required yet). */
@@ -1249,6 +1283,26 @@ export interface SessionPlan {
   approvedAt?: number;
   /** Pinned plans are preserved even after a new plan begins. */
   pinned?: boolean;
+}
+
+/**
+ * A historical snapshot of a {@link SessionPlan}, captured whenever the plan is
+ * regenerated or re-captured. Lets the user compare and restore across iterative
+ * planning cycles. Persisted to the `plan_revisions` table.
+ */
+export interface PlanRevision {
+  /** Stable id for this revision row. */
+  id: string;
+  sessionId: string;
+  /** Monotonic revision number within the session (1-based). */
+  rev: number;
+  /** The plan status at the moment it was snapshotted. */
+  status: PlanStatus;
+  title: string;
+  markdown: string;
+  meta: PlanMeta;
+  /** Epoch ms the revision was recorded. */
+  createdAt: number;
 }
 
 /** Everything the renderer needs to render a session when it (re)mounts. */


### PR DESCRIPTION
…anded and how it was verified.

<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how agent runs are authorized (including auto-accepting file edits) and extends plan approval IPC; inputs are validated but behavior shifts are security-relevant for local repo writes.
> 
> **Overview**
> **Plan Mode** is expanded into a first-class **Explore → Plan → Approve → Execute** workflow. The composer and IPC no longer use `plan` / `implement`; they use **`SessionPermissionMode`** (`plan`, `default`, `acceptEdits`) mapped directly to the Claude Code SDK, with legacy `implement` coerced to `default`. Approving a plan can start execution in **ask-before-edits** or **accept-edits** mode.
> 
> **Persistence & agent behavior:** Adds a `plan_revisions` table and snapshots the current plan on regenerate/restore (pruned by settings). New IPC/preload APIs cover **pin**, **list revisions**, and **restore**. Completed plans can optionally be saved to Local Memory.
> 
> **UI:** `PlanPanel` derives a phased task outline from plan markdown (`planOutline.ts`), overlays live todo status, and adds search/filter, export/print, history compare/restore, and a richer approval bar. Settings gain a **Plan & Tasks** section and per-workspace **start sessions in** override; the composer mode switch replaces the old Plan/Build toggle and drops the duplicate approval-policy mini-select.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d9e439bcf04111fcf7eaf322253a823d9b1d8ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plan revision history, including browsing and restoring previous plan versions.
  * Introduced workspace-level and session-level permission modes for starting sessions.
  * Expanded plan and task settings with more controls for display, notifications, history retention, and memory saving.

* **Bug Fixes**
  * Improved handling of older saved mode values for sessions, workspaces, and plan settings.
  * Kept plan history limits within a safe range for more predictable behavior.

* **UI Improvements**
  * Updated the plan view with search, filtering, export, print, pinning, and richer task progress display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->