### PR TITLE
Fixed and verified. The prefix rule correctly excepts every platform …

### DIFF
--- a/ci/scripts/check-licenses.mjs
+++ b/ci/scripts/check-licenses.mjs
@@ -25,13 +25,15 @@ const DEFAULT_ALLOWED = [
 
 // Packages whose license is non-SPDX ("SEE LICENSE IN ...") or otherwise needs a
 // reviewed, name-scoped exception. The Anthropic Agent SDK is a first-party
-// dependency the whole app is built around. Extend via PACKAGE_EXCEPTIONS env.
+// dependency the whole app is built around; it ships one optional native package
+// per platform (`-linux-x64`, `-linux-x64-musl`, `-linux-arm64`,
+// `-linux-arm64-musl`, `-darwin-x64`, `-darwin-arm64`, `-win32-x64`, …) that npm
+// installs selectively, so we except the whole family by PREFIX rather than
+// enumerating every OS/libc/arch combo (which drifts as new variants ship).
+// Each entry matches the package itself and any `<entry>-*` platform variant.
+// Extend via PACKAGE_EXCEPTIONS env.
 const DEFAULT_PACKAGE_EXCEPTIONS = [
   '@anthropic-ai/claude-agent-sdk',
-  '@anthropic-ai/claude-agent-sdk-linux-x64',
-  '@anthropic-ai/claude-agent-sdk-darwin-x64',
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64',
-  '@anthropic-ai/claude-agent-sdk-win32-x64',
 ];
 
 const allowed = new Set(
@@ -41,6 +43,18 @@ const packageExceptions = new Set([
   ...DEFAULT_PACKAGE_EXCEPTIONS,
   ...(process.env.PACKAGE_EXCEPTIONS?.split(',').map((s) => s.trim()).filter(Boolean) ?? []),
 ]);
+
+/**
+ * A package is excepted if its name equals an exception entry OR is a platform
+ * variant of one (`<entry>-*`) — e.g. `@anthropic-ai/claude-agent-sdk-linux-x64-musl`
+ * matches the `@anthropic-ai/claude-agent-sdk` entry.
+ */
+function isExcepted(name) {
+  for (const ex of packageExceptions) {
+    if (name === ex || name.startsWith(`${ex}-`)) return true;
+  }
+  return false;
+}
 
 /** Pull a comparable license string out of a package.json `license`/`licenses`. */
 function licenseOf(pkg) {
@@ -89,7 +103,7 @@ async function main() {
   let count = 0;
   for await (const pkg of packages('node_modules')) {
     count++;
-    if (packageExceptions.has(pkg.name)) continue;
+    if (isExcepted(pkg.name)) continue;
     const lic = licenseOf(pkg);
     if (lic === 'UNKNOWN' || !isAllowed(lic)) {
       violations.push(`${pkg.name}@${pkg.version ?? '?'}: ${lic}`);


### PR DESCRIPTION
…variant of the Anthropic SDK — including the `-linux-x64-musl` package that was failing CI — while still license-checking unrelated packages like `@anthropic-ai/sdk` and everything else.

## What I changed in [check-licenses.mjs](ci/scripts/check-licenses.mjs)

The exception list only enumerated a few fixed platform variants (`-linux-x64`, `-darwin-x64`, `-darwin-arm64`, `-win32-x64`). The Anthropic Agent SDK ships **one optional native package per OS/libc/arch**, and npm installs whichever matches the runner — so the glibc-vs-`musl` and arm64 variants slipped through the gate.

Instead of chasing every combination, I switched to a **prefix match**:
- Collapsed `DEFAULT_PACKAGE_EXCEPTIONS` to the single family root `@anthropic-ai/claude-agent-sdk`.
- Added `isExcepted(name)` which matches an exception entry exactly **or** as a `<entry>-*` platform variant, and used it in the scan loop instead of the exact-match `Set.has`.

This covers `-linux-x64-musl`, `-linux-arm64`, `-linux-arm64-musl`, and any future variants automatically — the `PACKAGE_EXCEPTIONS` / `ALLOWED_LICENSES` env overrides still work, and the gate stays meaningful for all third-party packages (it doesn't blanket-allow everything).

Verified: `node ci/scripts/check-licenses.mjs` now scans all 1133 packages and exits 0, and a direct test confirms the exact failing package name is excepted while unrelated packages are still checked.

<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/CI tooling only; narrows false positives for one reviewed package family without changing runtime app behavior.
> 
> **Overview**
> Fixes CI license failures when npm installs Anthropic Agent SDK **platform-specific optional packages** (e.g. `@anthropic-ai/claude-agent-sdk-linux-x64-musl`) that were not on the old hard-coded exception list.
> 
> **`ci/scripts/check-licenses.mjs`** now keeps a single family root in `DEFAULT_PACKAGE_EXCEPTIONS` (`@anthropic-ai/claude-agent-sdk`) and skips packages via **`isExcepted`**: exact name match or any `<entry>-*` variant. The scan loop uses that helper instead of `packageExceptions.has(pkg.name)`. Comments document why prefix matching is used; `PACKAGE_EXCEPTIONS` / `ALLOWED_LICENSES` env overrides are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1e2305f16b7c7acd3eb80eb2361b9f47778fbf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->