### PR TITLE
fix: restore .circleci/config.yml name; use project env var for GH_TOKEN

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,12 @@ version: 2.1
 # release.yml remains as a manually-dispatched fallback only. See
 # docs/ci/circleci.md and docs/ci/release-process.md.
 #
-# Secrets: the `limboo-release` Context must define GH_TOKEN (fine-grained PAT,
-# Contents: read+write on BotCoder254/limboo). Optional: CIRCLECI_CLI_TOKEN for
-# deploy markers. Never put tokens in this file.
+# Secrets: define GH_TOKEN as a CircleCI project Environment Variable (Project
+# Settings -> Environment Variables) — a fine-grained PAT with Contents:
+# read+write on BotCoder254/limboo. Project env vars are injected into every job,
+# so publish-release picks it up without a Context. (Alternatively, put GH_TOKEN
+# in an org Context and add `context: <name>` back to publish-release.) Optional:
+# CIRCLECI_CLI_TOKEN for deploy markers. Never put tokens in this file.
 #
 # Tag-filter rule: CircleCI never runs a job for a tag unless the job (and every
 # job it `requires`) declares a tags filter — hence the filters on every deploy
@@ -350,6 +353,5 @@ workflows:
       - package-macos:
           filters: *release-filters
       - publish-release:
-          context: limboo-release
           requires: [package-linux, package-windows, package-macos]
           filters: *release-filters


### PR DESCRIPTION
<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tag-triggered GitHub Releases will fail if `GH_TOKEN` is not set as a project env var; release publishing is critical but the change is configuration-only with no app code impact.
> 
> **Overview**
> **Release credential wiring for CircleCI** is updated so `GH_TOKEN` is documented as a **project Environment Variable** (injected into all jobs) rather than requiring the org **`limboo-release` Context**.
> 
> The **`publish-release`** job in the deploy workflow **drops `context: limboo-release`**, relying on that project-level `GH_TOKEN` for `gh` when creating/uploading GitHub Releases. The header comment notes you can still use a Context by re-adding `context` if preferred.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0e57adf6757885f7b3cc510ebcac964707c11e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->