### PR TITLE
build: pin electron-builder to 26.13.0; bump to 1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "limboo",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "limboo",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.195",
@@ -52,7 +52,7 @@
         "@typescript-eslint/parser": "^5.62.0",
         "@vitejs/plugin-react": "^4.7.0",
         "electron": "42.5.0",
-        "electron-builder": "26.13.1",
+        "electron-builder": "26.13.0",
         "eslint": "^8.57.1",
         "eslint-plugin-import": "^2.32.0",
         "opentype.js": "^1.3.4",
@@ -527,6 +527,58 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@develar/schema-utils": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
+      "integrity": "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.0",
+        "ajv-keywords": "^3.4.1"
+      },
+      "engines": {
+        "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@develar/schema-utils/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@develar/schema-utils/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/@develar/schema-utils/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@electron-forge/cli": {
       "version": "7.11.2",
@@ -5477,12 +5529,13 @@
       "license": "MIT"
     },
     "node_modules/app-builder-lib": {
-      "version": "26.13.1",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.13.1.tgz",
-      "integrity": "sha512-LKwQ8uGRUGfanCgEfz7rSrMjf3EMO+rEihnOW3NUd5X3YysRaS1/pbZAa/dCvp4Ql5L9nrO52ySweDt5Ehs83Q==",
+      "version": "26.13.0",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.13.0.tgz",
+      "integrity": "sha512-TcXLWoGBSmepntgRyoJdS6af4QJ9SNk6nrHGdsLLzrVbRT7hS4syYpZlah6NFc6C5Ho843vf6Qmg1rWzBJCCJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@develar/schema-utils": "~2.6.5",
         "@electron/asar": "3.4.1",
         "@electron/fuses": "^1.8.0",
         "@electron/get": "^3.0.0",
@@ -5493,7 +5546,6 @@
         "@malept/flatpak-bundler": "^0.4.0",
         "@peculiar/webcrypto": "^1.7.1",
         "@types/fs-extra": "9.0.13",
-        "ajv": "^8.18.0",
         "asn1js": "^3.0.10",
         "async-exit-hook": "^2.0.1",
         "builder-util": "26.13.0",
@@ -5528,8 +5580,8 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "dmg-builder": "26.13.1",
-        "electron-builder-squirrel-windows": "26.13.1"
+        "dmg-builder": "26.13.0",
+        "electron-builder-squirrel-windows": "26.13.0"
       }
     },
     "node_modules/app-builder-lib/node_modules/@electron/rebuild": {
@@ -7758,13 +7810,13 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "26.13.1",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.13.1.tgz",
-      "integrity": "sha512-lJsGG5bQfqGlQbK2P8v3p5M/9VTFAdBYcJPp9RDDM+8uG/AgzktA5DsPH25v1m4UXo6GmyopUov3z5gx4YeFOA==",
+      "version": "26.13.0",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.13.0.tgz",
+      "integrity": "sha512-9kXNS8GOZYPiLORiGwHObRPDpkaSv9n5CMyroG2jJloi6Lxz3xTM2QplRSF7+oNTjirDEO8yyGfFu/Z7RqkjgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.13.1",
+        "app-builder-lib": "26.13.0",
         "builder-util": "26.13.0",
         "fs-extra": "^10.1.0",
         "iconv-lite": "^0.6.2",
@@ -7996,18 +8048,18 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "26.13.1",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.13.1.tgz",
-      "integrity": "sha512-OvlgLHCc/sN4g5aP0HI0bYW8ulknAdtwY6oJWjpwbcmMIyHXz2K9Rvm4P3EJg6Z408eDjW7Mw4vVXJ0b6Lfm0g==",
+      "version": "26.13.0",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.13.0.tgz",
+      "integrity": "sha512-FmFIFrUyXL8W2+e8RPveQ4thTQ+apSghkQHI1euEgXDUHzLGCAvo/ACsQCCJG4vYakAh0cLqfbteiARDtzzVMg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.13.1",
+        "app-builder-lib": "26.13.0",
         "builder-util": "26.13.0",
         "builder-util-runtime": "9.6.3",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
-        "dmg-builder": "26.13.1",
+        "dmg-builder": "26.13.0",
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "simple-update-notifier": "2.0.0",
@@ -8022,14 +8074,14 @@
       }
     },
     "node_modules/electron-builder-squirrel-windows": {
-      "version": "26.13.1",
-      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.13.1.tgz",
-      "integrity": "sha512-3X0p7twf0L/2zwrWK7QAm1FUx7l4D2BBgyDBAVKCJQxtqD9km2Gqd7bOyRAiKmShylE9zjBo/TnjZ5xk2dsN3A==",
+      "version": "26.13.0",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.13.0.tgz",
+      "integrity": "sha512-luR/r+u5IFca39M00BcEU55aaHV4L8lw5kAtP9LW/oUWaQG3UWy8neP3jL0oglvB7w5xEsDClDt2RZpUh2IR/w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "app-builder-lib": "26.13.1",
+        "app-builder-lib": "26.13.0",
         "builder-util": "26.13.0",
         "electron-winstaller": "5.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "limboo",
   "productName": "limboo",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "My Electron application description",
   "main": ".vite/build/main.js",
   "private": true,
@@ -50,7 +50,7 @@
     "@typescript-eslint/parser": "^5.62.0",
     "@vitejs/plugin-react": "^4.7.0",
     "electron": "42.5.0",
-    "electron-builder": "26.13.1",
+    "electron-builder": "26.13.0",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.32.0",
     "opentype.js": "^1.3.4",


### PR DESCRIPTION
Fixes two release-pipeline crashes in the package/dist stage:

- ERR_REQUIRE_ESM on @noble/hashes/blake2.js: app-builder-lib >= 26.14.0 builds blockmaps in JS via require("@noble/hashes/blake2.js"), but @noble/hashes v2 is ESM-only, so require() throws. 26.13.0 builds blockmaps with the native app-builder-bin binary (no @noble/hashes dep).

- "spawnAndWriteWithOutput is not a function" NSIS crash: the 26.13.1 release is internally inconsistent (app-builder-lib@26.13.1 calls a builder-util export that its pinned builder-util@26.13.0 lacks). 26.13.0 is the last fully self-consistent, pre-regression release.

Also bump version 1.0.0 -> 1.2.3 so electron-builder stamps installers and latest*.yml to match the release tag (v1.2.2 was already burned by the failed pipeline).

<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only devDependency and version fields change; no runtime or security-sensitive application code is touched.
> 
> **Overview**
> **Release tooling fix:** `electron-builder` is pinned from **26.13.1** to **26.13.0** in `package.json`, with the lockfile updated so the whole `app-builder-lib` / `dmg-builder` / NSIS stack stays on that line. That avoids newer regressions (ESM `require` on `@noble/hashes` in 26.14+, and the broken `spawnAndWriteWithOutput` pairing in 26.13.1) that were breaking `npm run dist` in CI.
> 
> **Version bump:** App version goes **1.2.2 → 1.2.3** so installers and `latest*.yml` match the release tag after a failed 1.2.2 pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b135d025b4e4005f37f4e6261c5dee5654f630ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->