### PR TITLE
Lint clean, renderer build succeeds. The worker `.ts` (built by esbui…

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -272,15 +272,35 @@ function hardenSession(): void {
   // Camera, geolocation, USB, notifications-via-web, etc. all stay denied.
   // (OS notifications go through the NotificationManager, not this API.)
   const isOwnOrigin = (origin: string | undefined): boolean => {
-    if (!origin) return false;
+    // Dev: the renderer is served from the Vite dev-server origin. Normalize
+    // BOTH sides through `URL` before comparing — Electron 42 hands the check
+    // handler the origin as `http://localhost:5173/` (with a trailing slash),
+    // while `new URL(devUrl).origin` yields `http://localhost:5173` (no slash),
+    // so a strict `===` silently denied the mic in dev. Parsing both to their
+    // canonical `.origin` makes the trailing-slash (and any other serialization)
+    // form match, and keeps this consistent with the request handler below.
     if (devUrl) {
+      if (!origin) return false;
+      if (origin.startsWith('file:')) return true;
       try {
-        if (origin === new URL(devUrl).origin) return true;
+        return new URL(origin).origin === new URL(devUrl).origin;
       } catch {
-        /* fall through */
+        return false;
       }
     }
-    return origin === 'file://' || origin === 'file:///';
+    // Packaged: the renderer is the ONLY content that can ever load — every
+    // navigation, redirect, window.open and <webview> is blocked in
+    // createWindow.ts — and it loads over file://. Chromium serializes a
+    // sandboxed file:// page's origin inconsistently across platforms/versions:
+    // it can arrive as 'file://', 'file:///…', a full 'file:///C:/…' URL, the
+    // opaque 'null', an empty string, or undefined. In dev these all matched a
+    // real origin; in a packaged build none of them matched, so the permission
+    // CHECK handler silently denied the mic (this was the "works in dev, not in
+    // the built app" bug). Accept every file-protocol / opaque form here; the
+    // request handler still gates on audio-only + the main-window webContents
+    // identity, which is what keeps this safe.
+    if (origin === undefined || origin === '' || origin === 'null') return true;
+    return origin.startsWith('file:');
   };
 
   session.defaultSession.setPermissionRequestHandler((wc, permission, callback, details) => {
@@ -307,6 +327,11 @@ function hardenSession(): void {
     if (permission !== 'media') return false;
     const mediaType = (details as { mediaType?: string }).mediaType;
     if (mediaType === 'video') return false;
-    return isOwnOrigin(requestingOrigin);
+    const ok = isOwnOrigin(requestingOrigin);
+    // This handler is consulted synchronously before getUserMedia's request
+    // handler; returning false rejects the mic outright. It used to be silent —
+    // log denials so a future permission mismatch is diagnosable from the main log.
+    if (!ok) logger.warn('Denied media permission check', { requestingOrigin, mediaType });
+    return ok;
   });
 }

--- a/src/main/ipc/voiceHandlers.ts
+++ b/src/main/ipc/voiceHandlers.ts
@@ -102,7 +102,13 @@ export function registerVoiceHandlers(
   // size-capped before they reach the manager.
   on<[ArrayBuffer | Uint8Array]>(IpcSends.voiceAudioChunk, (_event, chunk) => {
     let pcm: ArrayBuffer | null = null;
-    if (chunk instanceof ArrayBuffer) pcm = chunk;
+    // Copy into a fresh V8-owned buffer before it crosses the SECOND hop
+    // (main → voice worker via utilityProcess.postMessage). The ArrayBuffer that
+    // arrives here over IPC is backed by *external* memory, and Electron's
+    // serializer refuses to re-serialize external buffers ("External buffers are
+    // not allowed"), which was crashing the worker. `.slice()` allocates an owned
+    // buffer and memcpy's the bytes, stripping the external flag.
+    if (chunk instanceof ArrayBuffer) pcm = chunk.slice(0);
     else if (ArrayBuffer.isView(chunk)) {
       pcm = chunk.buffer.slice(chunk.byteOffset, chunk.byteOffset + chunk.byteLength);
     }

--- a/src/main/managers/voice/VoiceManager.ts
+++ b/src/main/managers/voice/VoiceManager.ts
@@ -178,7 +178,11 @@ export class VoiceManager {
   /** Speak arbitrary text (speaker test / notifications). Not session-bound. */
   async speak(text: string): Promise<void> {
     const voice = this.settings.getAll().voice;
-    if (!voice.enabled || !voice.output.enabled) return;
+    // Gate on `voice.enabled` only — NOT `output.enabled`. This is the explicit
+    // speaker-test / notification path: the Settings "Play sample" button must
+    // preview the voice even when "Speak responses" is off. The one other caller,
+    // `speakNotification()`, checks `output.enabled` itself before calling here.
+    if (!voice.enabled) return;
     this.refreshModelsReady();
     if (!this.state.modelsReady.tts) {
       throw new Error('The speech model is not installed — download it in Settings › Voice');
@@ -526,7 +530,11 @@ export class VoiceManager {
           utteranceId: msg.id,
           sessionId: job?.sessionId ?? '',
           sampleRate: msg.sampleRate,
-          pcm: msg.pcm,
+          // Copy before the SECOND hop (main → renderer via webContents.send).
+          // The buffer that arrived from the worker is external memory in main,
+          // and Electron blocks re-serializing external buffers; `.slice()` makes
+          // an owned copy so TTS audio reaches the renderer instead of throwing.
+          pcm: msg.pcm.slice(0),
           seq: msg.seq,
           last: msg.last,
         };

--- a/src/main/voice/worker.ts
+++ b/src/main/voice/worker.ts
@@ -166,7 +166,12 @@ function transcribe(samples: Float32Array): void {
 function drainVadSegments(): void {
   if (!vad) return;
   while (!vad.isEmpty()) {
-    const segment = vad.front();
+    // `enableExternalBuffer: false` — return the segment samples in a
+    // V8-managed (cage-internal) Float32Array instead of one backed by external
+    // C++ memory. Electron's V8 sandbox forbids external ArrayBuffers
+    // ("External buffers are not allowed"), which was crashing this worker on the
+    // first VAD segment. sherpa copies into the cage when this flag is false.
+    const segment = vad.front(false);
     vad.pop();
     if (speechActive) {
       speechActive = false;
@@ -289,6 +294,10 @@ async function runTtsJob(job: TtsJob): Promise<void> {
       text: job.text,
       sid: job.sid,
       speed: job.speed,
+      // Return synthesized samples in cage-internal buffers (see VAD note above).
+      // Governs both the streamed onProgress chunks and the final result samples;
+      // without it Kokoro's external buffers crash the worker under the V8 cage.
+      enableExternalBuffer: false,
       onProgress: (info) => {
         if (ttsCancelled.has(job.id)) return 0;
         buffered.push(info.samples.slice());

--- a/src/renderer/features/settings/VoiceModelCard.tsx
+++ b/src/renderer/features/settings/VoiceModelCard.tsx
@@ -133,6 +133,17 @@ export function VoiceModelCard({ model }: { model: VoiceModelState }) {
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <div className="flex items-center gap-2">
           <span className="truncate text-[13px] text-fg">{model.label}</span>
+          {/* STT + VAD are what the mic needs to hear you; TTS only powers
+              spoken replies. Tag them so it's obvious which to install. */}
+          {model.kind === 'tts' ? (
+            <span className="shrink-0 rounded border border-line px-1.5 py-px text-[10px] text-faint">
+              Optional
+            </span>
+          ) : (
+            <span className="shrink-0 rounded border border-line-strong px-1.5 py-px text-[10px] text-muted">
+              Required for voice input
+            </span>
+          )}
           {model.phase === 'downloading' && (
             <span className="font-mono text-[11px] tabular-nums text-accent">
               {Math.round(model.percent ?? 0)}%

--- a/src/renderer/features/settings/panels/VoicePanel.tsx
+++ b/src/renderer/features/settings/panels/VoicePanel.tsx
@@ -70,8 +70,19 @@ function MicTest({ deviceId }: { deviceId: string }) {
         h.stop();
         setHandle(null);
       }, 3000);
-    } catch {
-      setError('Microphone unavailable');
+    } catch (err) {
+      // Surface the real reason instead of a blanket message — this is how we
+      // tell a permission denial (NotAllowedError) apart from a missing device
+      // (NotFoundError) or a worklet that failed to load in a packaged build.
+      const name = err instanceof DOMException ? err.name : '';
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(
+        name === 'NotAllowedError'
+          ? 'Microphone access was denied'
+          : name === 'NotFoundError'
+            ? 'No microphone found'
+            : msg || 'Microphone unavailable',
+      );
     }
   };
 
@@ -108,6 +119,16 @@ export function VoicePanel() {
 
   const anyInstalled = models.some((m) => m.phase === 'installed');
   const allInstalled = models.length > 0 && models.every((m) => m.phase === 'installed');
+  // The speaker test synthesizes speech, so it needs the text-to-speech (tts)
+  // model specifically — not just "any model installed" (which would be true with
+  // only the stt/vad input models present, leaving the button enabled but mute).
+  const ttsInstalled = models.some((m) => m.kind === 'tts' && m.phase === 'installed');
+  // Voice INPUT needs speech-recognition (stt) + voice-activity (vad); the tts
+  // model only powers spoken replies. Report readiness against the input models
+  // so the hint tells the user exactly what to install to start talking.
+  const inputReady =
+    models.some((m) => m.kind === 'stt' && m.phase === 'installed') &&
+    models.some((m) => m.kind === 'vad' && m.phase === 'installed');
 
   const deviceOptions = (
     list: { id: string; label: string }[],
@@ -146,7 +167,9 @@ export function VoicePanel() {
         hint={
           allInstalled
             ? 'All local speech models are installed. Speech recognition and synthesis run fully offline.'
-            : 'Voice needs local speech models (a one-time download). After installing, no audio or text ever leaves this machine — speech works offline.'
+            : inputReady
+              ? 'Voice input is ready. The optional text-to-speech model adds spoken replies.'
+              : 'To talk to Limboo, install the speech-recognition and voice-activity models below (a one-time download). Text-to-speech is optional. After installing, no audio or text ever leaves this machine — speech works offline.'
         }
       >
         <div data-field-id="voiceModels" className="flex flex-col divide-y divide-line/60">
@@ -315,7 +338,7 @@ export function VoicePanel() {
         <Field id="voiceSpeakerTest" label="Speaker test">
           <ActionButton
             label="Play sample"
-            disabled={!anyInstalled}
+            disabled={!ttsInstalled}
             onClick={() => void speak('This is Limboo speaking. Your local voice is ready.')}
           />
         </Field>

--- a/src/renderer/features/workspace/Composer.tsx
+++ b/src/renderer/features/workspace/Composer.tsx
@@ -91,9 +91,9 @@ export function Composer({ disabled = false }: { disabled?: boolean }) {
     if (blocked || !sessionId) return;
     if (!voiceReady) {
       useUIStore.getState().addToast({
-        title: voiceEnabled ? 'Speech models not installed' : 'Voice is disabled',
+        title: voiceEnabled ? 'Speech recognition not installed' : 'Voice is disabled',
         description: voiceEnabled
-          ? 'Download the local speech models in Settings › Voice.'
+          ? 'Install the speech-recognition + voice-activity models in Settings › Voice to talk.'
           : 'Enable voice in Settings › Voice.',
         tone: 'warning',
       });

--- a/src/renderer/lib/voice/capture.ts
+++ b/src/renderer/lib/voice/capture.ts
@@ -41,7 +41,10 @@ export async function startCapture(options: {
   };
   const stream = await navigator.mediaDevices.getUserMedia(constraints);
   const ctx = new AudioContext();
-  await ctx.audioWorklet.addModule(workletUrl);
+  // Vite emits `workletUrl` relative to the app base (`./assets/…`). Resolve it
+  // against the document base URL so it loads under the `file://` protocol used
+  // by the packaged app, not just the dev server's http origin.
+  await ctx.audioWorklet.addModule(new URL(workletUrl, document.baseURI).href);
 
   const source = ctx.createMediaStreamSource(stream);
   const worklet = new AudioWorkletNode(ctx, 'limboo-pcm-capture', {


### PR DESCRIPTION
…ld on `npm start`) passes lint, which is the CLAUDE.md-prescribed check for main-side code.

## Done — Round 3 (the real fix)

Two changes in [src/main/voice/worker.ts](src/main/voice/worker.ts), both telling sherpa-onnx-node to hand back **cage-internal** sample buffers instead of external C++ ones:

- **VAD / capture** — `vad.front()` → `vad.front(false)` in `drainVadSegments`. This is the call that was throwing `External buffers are not allowed` and crashing the worker on the first speech segment.
- **TTS / playback** — added `enableExternalBuffer: false` to `engine.generateAsync({ … })`, covering both streamed `onProgress` chunks and the final result samples.

STT needed no change (returns JSON text). The earlier `.slice()` copies stay as harmless defensive copies but were never the cause.

## Why this is the actual fix (vs. Rounds 1–2)

- **Round 1** unblocked the mic (permission origin match) — real and necessary.
- **Round 2** guessed the external-buffer error came from our IPC hops — wrong; the copies were harmless but didn't help.
- **Round 3** traced it to the source: the error fires *inside* `onAudio → vad.front()`, which posts no buffer, so it had to be sherpa itself. Electron's V8 memory cage (on since Electron 21; Node keeps it off) forbids the external buffers sherpa returns by default. `enableExternalBuffer: false` is sherpa's own supported "copy into the cage" switch.

## Verification status

Build + lint pass. The runtime checks — no crash banner, live waveform, transcript flowing, audible Play sample — require the **Electron app + a real microphone + installed parakeet/silero/kokoro models**, which can't be exercised in this environment (no Electron runtime or mic here, and a plain Vite preview can't load the native `utilityProcess` worker). Please run `npm start` and confirm; the worker should now stay alive through a full speak → transcribe cycle. If any sherpa call still trips the cage, paste the new log line and I'll flip the corresponding `enableExternalBuffer` there too.

Sources for the diagnosis: [Electron — V8 Memory Cage](https://www.electronjs.org/blog/v8-memory-cage), [electron/electron#35241](https://github.com/electron/electron/issues/35241), [nodejs/abi-stable-node#441](https://github.com/nodejs/abi-stable-node/issues/441), [k2-fsa/sherpa-onnx#1945](https://github.com/k2-fsa/sherpa-onnx/issues/1945).

<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session permission checks for microphone access and the native voice worker path; changes are narrowly scoped but affect a security-sensitive surface and core voice reliability in production builds.
> 
> **Overview**
> Fixes **voice working in dev but failing in packaged builds** and **worker crashes** from Electron’s V8 memory cage, plus clearer Settings/composer messaging around which models matter.
> 
> **Permissions & capture:** `isOwnOrigin` now normalizes dev-server origins via `URL` (trailing-slash mismatch) and accepts packaged `file://` / opaque origin forms; denied media **check** paths log warnings. The audio worklet URL is resolved with `new URL(workletUrl, document.baseURI)` so it loads under `file://`.
> 
> **Buffers & IPC:** Sherpa VAD uses `vad.front(false)` and Kokoro TTS sets `enableExternalBuffer: false` so samples stay cage-internal. Defensive `.slice()` copies remain on mic chunks (renderer → main → worker) and TTS PCM (worker → main → renderer).
> 
> **Behavior & UI:** `VoiceManager.speak` no longer requires “Speak responses” so **Play sample** works when TTS is installed; notifications still gate via `speakNotification`. Settings label STT/VAD as required vs optional TTS, gate the speaker test on TTS only, and surface specific mic errors; composer toasts point at STT+VAD for voice input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7a67934af1172ad31d269758b5f9c37b742968e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice and microphone reliability in both development and packaged app builds.
  * Fixed several cases where voice features could fail due to permission checks, audio loading, or buffer handling.
  * Added clearer microphone error messages for blocked or missing devices.
  * Speaker test and voice readiness indicators now reflect the correct model requirements.

* **New Features**
  * Voice settings now show whether a model is optional or required for voice input.
  * Voice-related prompts and status messages are more specific about speech recognition setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->