### PR TITLE
release: v1.2.5 — bump version; guard tag↔version in CI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,6 @@
   ],
   "parser": "@typescript-eslint/parser",
   "rules": {
-    "import/no-unresolved": ["error", { "ignore": ["^@/", "^@shared/", "\\?url$"] }]
+    "import/no-unresolved": ["error", { "ignore": ["^@/", "^@shared/", "\\?url$", "\\?raw$"] }]
   }
 }

--- a/ci/scripts/check-manifest.mjs
+++ b/ci/scripts/check-manifest.mjs
@@ -46,6 +46,28 @@ async function main() {
   if (/^\d+\.\d+\.\d+/.test(pkg.version ?? '')) ok(`version: ${pkg.version}`);
   else fail(`package.json version is not semver: ${pkg.version}`);
 
+  // On a release (v* tag) pipeline, the build derives every artifact — the app's
+  // app.getVersion() and electron-builder's latest.yml — from package.json, while
+  // the GitHub/GitLab Release is tagged from the git tag. If the two disagree the
+  // Release ships mislabeled binaries and electron-updater never detects the new
+  // version. Fail fast here (validate stage, before the expensive package stage).
+  // Only enforced when a release tag is present, so ordinary commit pipelines are
+  // unaffected. Reads either CI's tag env (GitLab: CI_COMMIT_TAG; GitHub Actions:
+  // GITHUB_REF_NAME when GITHUB_REF_TYPE=tag).
+  const releaseTag =
+    process.env.CI_COMMIT_TAG ||
+    (process.env.GITHUB_REF_TYPE === 'tag' ? process.env.GITHUB_REF_NAME : '') ||
+    '';
+  if (releaseTag) {
+    const tagVersion = releaseTag.replace(/^v/, '');
+    if (tagVersion === pkg.version) ok(`release tag ${releaseTag} matches package.json version`);
+    else
+      fail(
+        `release tag ${releaseTag} (=${tagVersion}) does not match package.json version ` +
+          `${pkg.version} — bump package.json (and commit) before tagging`,
+      );
+  }
+
   for (const s of ['start', 'package', 'make', 'lint']) {
     if (pkg.scripts?.[s]) ok(`script "${s}" present`);
     else fail(`package.json is missing the "${s}" script`);

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' 'unsafe-inline' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: http: https:; img-src 'self' data: blob:; object-src 'none'; frame-src 'none';"
+      content="default-src 'self' 'unsafe-inline' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; connect-src 'self' ws: http: https:; img-src 'self' data: blob:; object-src 'none'; frame-src 'none';"
     />
     <title>Limboo</title>
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "limboo",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "limboo",
-      "version": "1.2.3",
+      "version": "1.2.5",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.195",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "limboo",
   "productName": "limboo",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "description": "My Electron application description",
   "main": ".vite/build/main.js",
   "private": true,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -244,12 +244,20 @@ function hardenSession(): void {
   const isDev = !!devUrl || !app.isPackaged;
   const policy = isDev
     ? "default-src 'self' 'unsafe-inline' data: blob:; " +
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; " +
       "style-src 'self' 'unsafe-inline'; " +
+      "worker-src 'self' blob:; " +
       "connect-src 'self' ws: http: https:; img-src 'self' data: blob:;"
     : "default-src 'self'; " +
-      "script-src 'self'; " +
+      // blob: on script-src is what actually permits the voice capture
+      // AudioWorklet: Chromium checks worklet module loads against
+      // script-src-elem, which falls back to script-src. The worklet source is
+      // inlined (see capture.ts) and loaded from a same-origin Blob URL; page/
+      // script loading otherwise stays locked to 'self'. worker-src is kept as
+      // defensive, spec-compliant coverage.
+      "script-src 'self' blob:; " +
       "style-src 'self' 'unsafe-inline'; " +
+      "worker-src 'self' blob:; " +
       // media-src is defensive: voice playback uses Web Audio AudioBuffers (no
       // <audio> element), but a blob-backed fallback must never be CSP-broken.
       "img-src 'self' data:; media-src 'self' blob:; connect-src 'self';";

--- a/src/renderer/lib/voice/assets.d.ts
+++ b/src/renderer/lib/voice/assets.d.ts
@@ -1,5 +1,11 @@
-/** Vite `?url` asset imports (the AudioWorklet module is loaded by URL). */
+/** Vite `?url` asset imports. */
 declare module '*?url' {
   const url: string;
   export default url;
+}
+
+/** Vite `?raw` string imports (the AudioWorklet module is inlined as source). */
+declare module '*?raw' {
+  const src: string;
+  export default src;
 }

--- a/src/renderer/lib/voice/capture.ts
+++ b/src/renderer/lib/voice/capture.ts
@@ -7,7 +7,7 @@
  * Also exposes the live AnalyserNode so the composer Waveform can render real
  * mic levels without a second audio graph.
  */
-import workletUrl from './pcmWorklet.js?url';
+import workletSource from './pcmWorklet.js?raw';
 
 export interface CaptureHandle {
   /** Live frequency/time-domain analyser for the waveform visualization. */
@@ -41,10 +41,18 @@ export async function startCapture(options: {
   };
   const stream = await navigator.mediaDevices.getUserMedia(constraints);
   const ctx = new AudioContext();
-  // Vite emits `workletUrl` relative to the app base (`./assets/…`). Resolve it
-  // against the document base URL so it loads under the `file://` protocol used
-  // by the packaged app, not just the dev server's http origin.
-  await ctx.audioWorklet.addModule(new URL(workletUrl, document.baseURI).href);
+  // Load the worklet from an inlined Blob rather than a `?url` asset. `?raw`
+  // bundles the processor source straight into the JS chunk, so there is no
+  // separate asset file to emit and no base/`file://` path resolution to get
+  // wrong — it behaves identically under the dev server and the packaged app.
+  // (The production CSP allows this via `worker-src 'self' blob:`.)
+  const blob = new Blob([workletSource], { type: 'application/javascript' });
+  const workletUrl = URL.createObjectURL(blob);
+  try {
+    await ctx.audioWorklet.addModule(workletUrl);
+  } finally {
+    URL.revokeObjectURL(workletUrl);
+  }
 
   const source = ctx.createMediaStreamSource(stream);
   const worklet = new AudioWorkletNode(ctx, 'limboo-pcm-capture', {


### PR DESCRIPTION
<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production CSP is tightened around blob worklets (intentional, voice-critical); release CI gate only runs on tag pipelines. Version bump is routine.
> 
> **Overview**
> **Release v1.2.5** bumps `package.json` / lockfile and adds a **validate-stage guard** so tagged release pipelines fail when the git tag (e.g. `v1.2.5`) does not match `package.json` version—avoiding mislabeled artifacts and broken auto-update detection.
> 
> **Voice capture** no longer loads the PCM AudioWorklet via a separate `?url` asset (which could break under packaged `file://`). The worklet source is **inlined with `?raw`**, registered through a short-lived **Blob URL**, with ESLint ignoring `?raw` imports.
> 
> **CSP** (main process + `index.html` fallback) adds **`blob:`** on `script-src` and **`worker-src 'self' blob:`** so production can load that worklet while keeping page scripts on `'self'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9580a17fdd4cf59853e71f15e1f71201e0c7c82f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved voice capture handling so audio processing can load more reliably across environments.
  * Updated browser security settings to support the app’s voice-processing workflow.

* **Bug Fixes**
  * Fixed an issue that could prevent certain imported assets from resolving correctly.
  * Added a release/version consistency check to help catch mismatched tagged builds earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->