### PR TITLE
ci: guard against re-tagging an already-tagged commit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,6 +65,9 @@ compliance:
     # with the tag version BEFORE check-manifest, so its tag<->version guard verifies
     # the applied version instead of demanding a manual pre-bump. No-op off a tag.
     - node ci/scripts/apply-tag-version.mjs
+    # Fail fast if this v* tag re-tags an already-tagged commit (the v1.2.8==v1.2.9
+    # mistake that ships a release with zero new code).
+    - node ci/scripts/check-tag-unique.mjs
     - node ci/scripts/check-licenses.mjs
     - node ci/scripts/check-electron-security.mjs
     - node ci/scripts/check-manifest.mjs

--- a/ci/scripts/check-tag-unique.mjs
+++ b/ci/scripts/check-tag-unique.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * check-tag-unique.mjs — refuse a release that re-tags an already-tagged commit.
+ *
+ * The failure mode this prevents: v1.2.8 and v1.2.9 were both created on the SAME
+ * commit, so v1.2.9's release was byte-for-byte identical to v1.2.8 and shipped ZERO
+ * new code. A stale/duplicate tag silently produces an "empty" release. This gate
+ * fails FAST (in the validate stage, before the expensive build) when the commit
+ * being released already carries another v* tag.
+ *
+ * Provider-neutral (Node builtins only). Runs only on a release (v* tag) pipeline;
+ * a no-op (exit 0) on ordinary commit pipelines and branch dry-runs. Tag source and
+ * matching mirror ci/scripts/apply-tag-version.mjs.
+ *
+ * Usage: node ci/scripts/check-tag-unique.mjs [tag]
+ */
+import { execFileSync } from 'node:child_process';
+
+// vMAJOR.MINOR.PATCH with an optional -prerelease / +build suffix.
+const TAG_RE = /^v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+
+function resolveTag() {
+  const explicit = process.argv[2]?.trim();
+  if (explicit) return explicit;
+  if (process.env.CI_COMMIT_TAG?.trim()) return process.env.CI_COMMIT_TAG.trim();
+  if (process.env.GITHUB_REF_TYPE === 'tag' && process.env.GITHUB_REF_NAME?.trim())
+    return process.env.GITHUB_REF_NAME.trim();
+  return '';
+}
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
+function main() {
+  const tag = resolveTag();
+  if (!tag) {
+    console.log('[check-tag-unique] no release tag in context — nothing to check.');
+    return;
+  }
+  if (!TAG_RE.test(tag)) {
+    console.log(`[check-tag-unique] "${tag}" is not a vX.Y.Z tag — skipping.`);
+    return;
+  }
+
+  // Make sure every tag is available locally — CI checkouts of a single tag ref
+  // don't fetch the rest of the tag namespace, which we need to detect collisions.
+  try {
+    git(['fetch', '--tags', '--force']);
+  } catch (e) {
+    // Non-fatal: fall back to whatever tags are already present locally.
+    console.log(`[check-tag-unique] warning: 'git fetch --tags' failed (${e.message.split('\n')[0]}); using local tags only.`);
+  }
+
+  // Resolve the commit the release is built from. CI exposes it directly; otherwise
+  // dereference the tag (or HEAD) to its underlying commit.
+  let sha;
+  try {
+    const ref = process.env.CI_COMMIT_SHA?.trim() || tag;
+    sha = git(['rev-parse', `${ref}^{commit}`]);
+  } catch {
+    sha = git(['rev-parse', 'HEAD^{commit}']);
+  }
+
+  // Every v* tag pointing at this exact commit, other than the one being released.
+  const others = git(['tag', '--points-at', sha])
+    .split('\n')
+    .map((t) => t.trim())
+    .filter((t) => t && t !== tag && TAG_RE.test(t));
+
+  if (others.length) {
+    console.error(
+      `\n[check-tag-unique] FAIL: commit ${sha.slice(0, 12)} is already tagged by ` +
+        `${others.join(', ')}.\n` +
+        `Releasing ${tag} here would ship a build identical to ${others[0]} (no new code) — ` +
+        `the exact v1.2.8/v1.2.9 mistake.\n` +
+        `Tag a commit that carries the changes you intend to release (usually the tip of main).`,
+    );
+    process.exit(1);
+  }
+
+  console.log(`[check-tag-unique] OK: ${tag} points at ${sha.slice(0, 12)}, not shared with any other v* tag.`);
+}
+
+try {
+  main();
+} catch (err) {
+  console.error('check-tag-unique failed:', err.message || err);
+  process.exit(1);
+}

--- a/docs/ci/release-process.md
+++ b/docs/ci/release-process.md
@@ -5,6 +5,30 @@ its pipeline runs automatically on every `v*` tag and publishes the **same build
 both a GitLab Release and a GitHub Release. GitHub Actions' `release.yml` is a manual
 fallback (dispatch-only, no tag trigger).
 
+## 0. Checklist — cutting a release (avoid the empty-release trap)
+
+A release only ever contains **the code at the tagged commit**. Two mistakes ship a
+release with *no new code*: tagging an old commit, or reusing a commit that already
+has a tag (this is exactly how `v1.2.8` and `v1.2.9` ended up identical). Run through
+this every time:
+
+1. Merge the work into `main` and let CI go green.
+2. `git fetch origin && git checkout main && git pull` — make sure your local `main`
+   is **not stale** (it must equal `origin/main`).
+3. Confirm the intended tip: `git log --oneline -1 origin/main` shows the commit you
+   expect to ship.
+4. Pick the **next unused** `vX.Y.Z` (`git tag -l | sort -V | tail`), and check the
+   tip isn't already tagged: `git tag --points-at origin/main` must be empty.
+5. Tag that commit and push (see §2).
+6. Watch the GitLab pipeline (Project → Build → Pipelines) run
+   `validate → build → test → package → secure → release`.
+7. Verify **both** Releases carry installers + `latest*.yml` (see §5).
+
+Never reuse a version, never tag an old commit, never hand-edit `package.json`. The
+`compliance` job runs [`check-tag-unique.mjs`](../../ci/scripts/check-tag-unique.mjs),
+which **fails the pipeline** if the tagged commit already carries another `v*` tag —
+so a duplicate tag can no longer silently ship an empty release.
+
 ## 1. Pre-flight
 
 - The GitLab project is set up: `GH_TOKEN` is a masked+protected CI/CD variable, the
@@ -20,7 +44,7 @@ fallback (dispatch-only, no tag trigger).
 ## 2. Tag
 
 ```bash
-git tag v1.2.0
+git tag -a v1.2.0 -m "Limboo v1.2.0"   # tag the tip of an up-to-date main
 git push origin v1.2.0
 ```
 


### PR DESCRIPTION
v1.2.8 and v1.2.9 were created on the same commit (921efb3), so the v1.2.9 release was byte-for-byte identical to v1.2.8 and shipped zero new code. Add ci/scripts/check-tag-unique.mjs and run it in the GitLab compliance job so any v* tag that points at a commit already carrying another v* tag fails fast, before the build. Document the correct release checklist in docs/ci/release-process.md.

<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only validation and documentation; no application runtime or release artifact logic changes beyond failing bad tags before build.
> 
> **Overview**
> Adds a **validate-stage gate** so a `v*` release cannot point at a commit that already carries another `v*` tag—the failure mode that produced identical `v1.2.8` / `v1.2.9` builds with no new code.
> 
> The new `ci/scripts/check-tag-unique.mjs` runs in the GitLab **`compliance`** job immediately after `apply-tag-version.mjs`. On tag pipelines it resolves the release tag (same env/argv pattern as the other CI scripts), optionally `git fetch --tags`, then uses `git tag --points-at` to fail the pipeline if any other semver `v*` tag shares that commit. Non-tag pipelines no-op.
> 
> **`docs/ci/release-process.md`** gains a §0 release checklist (fresh `main`, `git tag --points-at` empty, pipeline stages) and documents that `check-tag-unique` blocks duplicate-tag empty releases; the tag example now uses an annotated tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d944dd0cee769380e0952e7d86b1da3d3340c77a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a release safeguard to prevent creating a version tag that points to a commit already used by another release tag.

* **Documentation**
  * Updated release instructions with a checklist to help avoid empty or duplicate releases.
  * Clarified the recommended way to create version tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->