### PR TITLE
feat: AI commit-message sub-agent with live streaming + commit bar controls

### DIFF
--- a/src/main/ipc/gitHandlers.ts
+++ b/src/main/ipc/gitHandlers.ts
@@ -8,6 +8,7 @@
 import { IpcChannels } from '@shared/ipc-channels';
 import { GIT_LIMITS } from '@shared/constants';
 import type {
+  GenerateCommitMessageResult,
   GitBlameLine,
   GitBranch,
   GitCheckoutResult,
@@ -23,6 +24,7 @@ import type {
 } from '@shared/types';
 import { handle } from './registry';
 import type { GitManager } from '../managers/GitManager';
+import type { AgentManager } from '../managers/AgentManager';
 
 function assertId(id: unknown, label = 'id'): asserts id is string {
   if (typeof id !== 'string' || id.length === 0 || id.length > 128) {
@@ -55,7 +57,7 @@ function assertText(value: unknown, max: number, label: string): asserts value i
   }
 }
 
-export function registerGitHandlers(git: GitManager): void {
+export function registerGitHandlers(git: GitManager, agent: AgentManager): void {
   handle<[string], GitStatus>(IpcChannels.gitStatus, (_e, wsId) => {
     assertId(wsId, 'workspaceId');
     return git.status(wsId);
@@ -98,6 +100,26 @@ export function registerGitHandlers(git: GitManager): void {
     assertId(wsId, 'workspaceId');
     assertText(message, GIT_LIMITS.commitMessageMax, 'commit message');
     return git.commit(wsId, message);
+  });
+
+  // AI commit-message generation: the ONLY renderer input is the workspace id —
+  // all git context (status / staged diff / recent subjects) is assembled in the
+  // main process by GitManager and size-capped by GIT_LIMITS.commitGen. The
+  // sub-agent run is tool-less and only proposes text; it never commits.
+  handle<[string], GenerateCommitMessageResult>(
+    IpcChannels.gitCommitMessageGenerate,
+    async (_e, wsId) => {
+      assertId(wsId, 'workspaceId');
+      const ctx = await git.buildCommitContext(wsId);
+      if (!ctx) return { ok: false, reason: 'error', error: 'Not a git repository' };
+      if (ctx.files.length === 0) return { ok: false, reason: 'no-staged' };
+      return agent.generateCommitMessage(wsId, ctx);
+    },
+  );
+
+  handle<[string], void>(IpcChannels.gitCommitMessageCancel, (_e, wsId) => {
+    assertId(wsId, 'workspaceId');
+    agent.cancelCommitMessage(wsId);
   });
 
   handle<[string, { limit?: number; offset?: number }?], GitCommit[]>(

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -59,7 +59,7 @@ export function registerAllIpc(deps: IpcDeps): void {
   registerAgentHandlers(deps.agent);
   registerFsHandlers(deps.fs);
   registerTerminalHandlers(deps.terminal);
-  registerGitHandlers(deps.git);
+  registerGitHandlers(deps.git, deps.agent);
   registerWorktreeHandlers(deps.worktree);
   registerServiceHandlers(deps.services);
   registerMemoryHandlers(deps.memory);

--- a/src/main/managers/AgentManager.ts
+++ b/src/main/managers/AgentManager.ts
@@ -44,6 +44,9 @@ import type {
   DiagnosticSeverity,
   FileChange,
   FileChangeStatus,
+  GenerateCommitMessageResult,
+  GitCommitContext,
+  GitCommitMessageStreamEvent,
   PermissionDecision,
   PermissionRequest,
   PlanMeta,
@@ -59,7 +62,7 @@ import type {
   TerminalCommandRecord,
   ToolRisk,
 } from '@shared/types';
-import { ACTIVITY_LIMITS, AGENT_LIMITS } from '@shared/constants';
+import { ACTIVITY_LIMITS, AGENT_LIMITS, GIT_LIMITS } from '@shared/constants';
 import { IpcEvents } from '@shared/ipc-channels';
 import { getDb } from '../db/database';
 import { logger } from '../logger';
@@ -171,6 +174,26 @@ const IDLE_REQUEST: RequestState = {
  */
 const DELTA_FLUSH_CHARS = 24;
 const DELTA_FLUSH_MS = 16;
+
+/* ------------------------------------------------------------------ */
+/* Git commit-message sub-agent — an isolated, tool-less one-shot run. */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Pinned haiku-class model for utility one-shots (commit messages). Deliberately
+ * NOT the user's configured chat model: summarizing a staged diff into a ≤72-char
+ * subject is fast-model work, and pinning keeps latency/cost predictable.
+ */
+const COMMIT_MESSAGE_MODEL = 'claude-haiku-4-5-20251001';
+
+const COMMIT_SYSTEM_PROMPT =
+  'You write git commit messages. Output ONLY the commit message text — no ' +
+  'preamble, no explanations, no code fences, no surrounding quotes. First ' +
+  'line: an imperative-mood subject of at most 72 characters. If the change ' +
+  'needs explanation, add one blank line then a short body wrapped at ~72 ' +
+  'columns. If the repository\'s recent commit subjects follow a consistent ' +
+  'convention (e.g. "feat:", "fix(scope):"), match it; otherwise use a plain ' +
+  'imperative subject.';
 
 function classifyTool(name: string): ToolRisk {
   if (WRITE_TOOLS.has(name)) return 'write';
@@ -350,6 +373,15 @@ export class AgentManager {
    * whichever session most recently touched the state.
    */
   private readonly requests = new Map<string, RequestState>();
+  /**
+   * One in-flight commit-message generation per workspace. Kept fully apart
+   * from {@link runs}: these one-shots never touch lifecycle, transcripts,
+   * plans, or the conversation event stream.
+   */
+  private readonly commitGenRuns = new Map<
+    string,
+    { abort: AbortController; query: { close?: () => void } | null }
+  >();
   /** Pending permission prompts awaiting a renderer decision, keyed by request id. */
   private readonly pending = new Map<
     string,
@@ -858,9 +890,200 @@ export class AgentManager {
   /** Abort every active run + stop all supervision timers. Called on quit. */
   cleanup(): void {
     for (const sessionId of [...this.runs.keys()]) this.stop(sessionId);
+    for (const workspaceId of [...this.commitGenRuns.keys()]) this.cancelCommitMessage(workspaceId);
     this.stopHeartbeat();
     this.clearRateLimitTimer();
     this.clearIdleTimer();
+  }
+
+  /* ---------------------------------------------------------------- */
+  /* Git commit-message sub-agent (isolated one-shot)                 */
+  /* ---------------------------------------------------------------- */
+
+  /**
+   * Generate a commit message for the staged changes described by `ctx` (built
+   * main-side by GitManager — never renderer-supplied). Runs an isolated,
+   * tool-less, single-turn SDK query and streams the text to the renderer over
+   * `IpcEvents.gitCommitMessageStream`. It only PROPOSES a message: nothing here
+   * ever calls `git commit`. The run never touches lifecycle, transcripts,
+   * memory/search context, MCP servers, or the conversation event stream.
+   */
+  async generateCommitMessage(
+    workspaceId: string,
+    ctx: GitCommitContext,
+  ): Promise<GenerateCommitMessageResult> {
+    const install = this.getInstall();
+    if (!install.installed) {
+      return { ok: false, reason: 'agent-unavailable', error: install.error };
+    }
+    if (this.state.lifecycle === 'rate-limited') {
+      return {
+        ok: false,
+        reason: 'rate-limited',
+        error: this.state.rateLimit?.message ?? 'The agent is rate limited right now.',
+      };
+    }
+    if (this.commitGenRuns.has(workspaceId)) {
+      return { ok: false, reason: 'busy', error: 'A commit message is already being generated.' };
+    }
+
+    const requestId = newId();
+    const abort = new AbortController();
+    const run: { abort: AbortController; query: { close?: () => void } | null } = {
+      abort,
+      query: null,
+    };
+    this.commitGenRuns.set(workspaceId, run);
+
+    const emit = (ev: Omit<GitCommitMessageStreamEvent, 'workspaceId' | 'requestId'>): void => {
+      const payload: GitCommitMessageStreamEvent = { workspaceId, requestId, ...ev };
+      this.broadcastChannel(IpcEvents.gitCommitMessageStream, payload);
+    };
+
+    // Coalesced-delta state, mirroring runOnce's DELTA_FLUSH_* pattern.
+    let pendingDelta = '';
+    let flushTimer: NodeJS.Timeout | null = null;
+    const flushDelta = (): void => {
+      if (flushTimer) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+      }
+      if (pendingDelta.length === 0) return;
+      const text = pendingDelta;
+      pendingDelta = '';
+      emit({ kind: 'delta', text });
+    };
+    const queueDelta = (text: string): void => {
+      pendingDelta += text;
+      if (pendingDelta.length >= DELTA_FLUSH_CHARS) flushDelta();
+      else if (!flushTimer) flushTimer = setTimeout(flushDelta, DELTA_FLUSH_MS);
+    };
+
+    try {
+      const prompt = buildCommitPrompt(ctx);
+      if (prompt.length > AGENT_LIMITS.promptMax) {
+        // Belt + braces: GitManager's commitGen caps keep us far below this.
+        throw new Error('Commit context too large.');
+      }
+      const sdk = await loadSdk();
+      const options = this.buildUtilityOptions(ctx.root, abort);
+      const q = sdk.query({ prompt, options }) as unknown as AsyncIterable<SDKMessage> & {
+        close?: () => void;
+      };
+      run.query = q;
+
+      let finalText = '';
+      let resultOk: boolean | null = null;
+      let resultText = '';
+      for await (const msg of q) {
+        if (abort.signal.aborted) break;
+        switch (msg.type) {
+          case 'stream_event': {
+            const ev = msg.event as unknown as {
+              type?: string;
+              delta?: { type?: string; text?: string };
+            };
+            if (ev?.type === 'content_block_delta' && ev.delta?.type === 'text_delta' && ev.delta.text) {
+              queueDelta(ev.delta.text);
+            }
+            break;
+          }
+          case 'assistant': {
+            if (msg.error) throw new Error(String(msg.error));
+            const content = (msg.message?.content ?? []) as unknown as Array<Record<string, unknown>>;
+            const text = content
+              .filter((b) => b.type === 'text' && typeof b.text === 'string')
+              .map((b) => b.text as string)
+              .join('');
+            if (text.trim().length > 0) finalText = text;
+            break;
+          }
+          case 'result': {
+            resultOk = msg.subtype === 'success';
+            resultText = 'result' in msg && typeof msg.result === 'string' ? msg.result : '';
+            break;
+          }
+          default:
+            break;
+        }
+      }
+      flushDelta();
+
+      if (abort.signal.aborted) {
+        emit({ kind: 'canceled' });
+        return { ok: false, reason: 'canceled' };
+      }
+      if (resultOk === false) {
+        throw new Error(resultText || 'The commit-message run ended with errors.');
+      }
+      const message = polishCommitMessage(finalText || resultText);
+      if (!message) throw new Error('The model returned an empty commit message.');
+      emit({ kind: 'done', text: message });
+      return { ok: true, message };
+    } catch (err) {
+      if (abort.signal.aborted) {
+        emit({ kind: 'canceled' });
+        return { ok: false, reason: 'canceled' };
+      }
+      const raw = err instanceof Error ? err.message : String(err);
+      const safe = redact(raw);
+      logger.warn('[claude:commit-msg] generation failed', safe);
+      const cls = classifyAgentError(raw);
+      const reason: GenerateCommitMessageResult['reason'] =
+        cls.outcome === 'auth-required'
+          ? 'agent-unavailable'
+          : cls.outcome === 'rate-limited'
+            ? 'rate-limited'
+            : 'error';
+      emit({ kind: 'error', error: safe });
+      return { ok: false, reason, error: safe };
+    } finally {
+      if (flushTimer) clearTimeout(flushTimer);
+      this.commitGenRuns.delete(workspaceId);
+    }
+  }
+
+  /** Abort an in-flight commit-message generation for a workspace. */
+  cancelCommitMessage(workspaceId: string): void {
+    const run = this.commitGenRuns.get(workspaceId);
+    if (!run) return;
+    run.abort.abort();
+    try {
+      run.query?.close?.();
+    } catch {
+      /* already closed */
+    }
+  }
+
+  /**
+   * Options for utility one-shots — deliberately parallel to (not shared with)
+   * {@link buildOptions}; the divergence list is the point: tool-less
+   * (`allowedTools: []` AND a deny-all canUseTool, belt + braces), single-turn,
+   * no thinking, plain-string system prompt (no claude_code preset, no
+   * memory/search append), no settings sources, no resume, no MCP servers.
+   * The model can only emit text.
+   */
+  private buildUtilityOptions(cwd: string, abort: AbortController): Options {
+    const options: Options = {
+      cwd,
+      model: COMMIT_MESSAGE_MODEL,
+      maxTurns: 1,
+      includePartialMessages: true,
+      abortController: abort,
+      thinking: { type: 'disabled' },
+      systemPrompt: COMMIT_SYSTEM_PROMPT,
+      allowedTools: [],
+      canUseTool: async () => ({
+        behavior: 'deny' as const,
+        message: 'Tools are disabled for commit-message generation.',
+      }),
+      settingSources: [],
+      env: { ...process.env, CLAUDE_CODE_ENABLE_TASKS: '0' },
+      stderr: (data: string) => logger.warn('[claude:commit-msg]', redact(data)),
+    };
+    const claudeExe = resolveClaudeExecutable();
+    if (claudeExe) options.pathToClaudeCodeExecutable = claudeExe;
+    return options;
   }
 
   /**
@@ -2240,6 +2463,49 @@ export class AgentManager {
 /* ------------------------------------------------------------------ */
 /* Pure helpers                                                        */
 /* ------------------------------------------------------------------ */
+
+/** Render the main-side git context into the sub-agent's user prompt. */
+function buildCommitPrompt(ctx: GitCommitContext): string {
+  const parts: string[] = [];
+  if (ctx.branch) parts.push(`Branch: ${ctx.branch}`);
+
+  const fileLines = ctx.files.map((f) => {
+    const counts =
+      f.binary
+        ? ' (binary)'
+        : typeof f.adds === 'number' || typeof f.dels === 'number'
+          ? ` (+${f.adds ?? 0} -${f.dels ?? 0})`
+          : '';
+    return `- ${f.status}: ${f.path}${counts}`;
+  });
+  parts.push(`Staged files (${ctx.files.length}):\n${fileLines.join('\n')}`);
+
+  if (ctx.recentSubjects.length > 0) {
+    parts.push(`Recent commit subjects (newest first):\n${ctx.recentSubjects.map((s) => `- ${s}`).join('\n')}`);
+  } else {
+    parts.push("This is the repository's first commit.");
+  }
+
+  if (ctx.diff.trim().length > 0) {
+    parts.push(
+      `Staged diff${ctx.diffTruncated ? ' (truncated)' : ''}:\n\`\`\`diff\n${ctx.diff}\n\`\`\``,
+    );
+  }
+
+  parts.push('Write the commit message for these staged changes.');
+  return parts.join('\n\n');
+}
+
+/** Normalize the model's output into a clean, size-capped commit message. */
+function polishCommitMessage(raw: string): string {
+  let text = (raw ?? '').trim();
+  // Strip a single wrapping code fence the model may have added despite orders.
+  const fence = /^```[a-z]*\n([\s\S]*?)\n?```$/i.exec(text);
+  if (fence) text = fence[1].trim();
+  // Strip one pair of wrapping quotes.
+  if (/^"[\s\S]*"$/.test(text) || /^'[\s\S]*'$/.test(text)) text = text.slice(1, -1).trim();
+  return text.slice(0, GIT_LIMITS.commitGen.messageMax);
+}
 
 function mapThinking(thinking: 'off' | 'on' | 'adaptive'): Options['thinking'] {
   if (thinking === 'off') return { type: 'disabled' };

--- a/src/main/managers/GitManager.ts
+++ b/src/main/managers/GitManager.ts
@@ -28,6 +28,7 @@ import type {
   GitCheckoutResult,
   GitCheckpoint,
   GitCommit,
+  GitCommitContext,
   GitCommitDetail,
   GitFileChange,
   GitFileDiff,
@@ -279,6 +280,71 @@ export class GitManager {
       });
     }
     return commit;
+  }
+
+  /**
+   * Assemble the size-capped, redacted context the AI commit-message sub-agent
+   * prompts with. Read-only: entirely `runGit` output, nothing renderer-supplied
+   * beyond the workspace id, and no `notifyChanged`. Returns null for non-repos;
+   * a repo with nothing staged returns `files: []` (the handler maps that to a
+   * `no-staged` result before any model run starts).
+   */
+  async buildCommitContext(workspaceId: string): Promise<GitCommitContext | null> {
+    const root = await this.resolveRoot(workspaceId);
+    if (!root) return null;
+    const caps = GIT_LIMITS.commitGen;
+
+    const status = await this.status(workspaceId);
+    const stagedFiles = status.files.filter((f) => f.staged).slice(0, caps.filesMax);
+    if (stagedFiles.length === 0) {
+      return { root, branch: status.branch, files: [], diff: '', diffTruncated: false, recentSubjects: [] };
+    }
+
+    // Binary detection: numstat prints `-` for binary files, which parseNumstat
+    // skips — a staged file with zero adds+dels and a non-empty diff is binary
+    // for our purposes; re-check via `--numstat` directly for accuracy.
+    const numstat = await runGit(root, ['diff', '--cached', '--numstat', '-z']);
+    const binaryPaths = new Set<string>();
+    for (const entry of numstat.stdout.split('\0')) {
+      const m = /^-\t-\t(.+)$/.exec(entry);
+      if (m) binaryPaths.add(m[1]);
+    }
+
+    const diffRes = await runGit(root, ['diff', '--cached', '--no-color', '--no-ext-diff'], {
+      maxBuffer: GIT_LIMITS.diffBytesMax + 1024,
+    });
+    const rawDiff = diffRes.stdout;
+    const diffTruncated = rawDiff.length > caps.diffCharsMax;
+    const diff = redactRemote(diffTruncated ? rawDiff.slice(0, caps.diffCharsMax) : rawDiff);
+
+    // Recent subjects for style inference (unborn repo → empty list).
+    const subjectsRes = await runGit(root, [
+      'log',
+      '-n',
+      String(caps.subjectsMax),
+      '--pretty=format:%s',
+    ]);
+    const recentSubjects = subjectsRes.ok
+      ? subjectsRes.stdout
+          .split('\n')
+          .map((s) => redactRemote(s).trim())
+          .filter(Boolean)
+      : [];
+
+    return {
+      root,
+      branch: status.branch,
+      files: stagedFiles.map((f) => ({
+        path: f.path,
+        status: f.status,
+        adds: f.adds,
+        dels: f.dels,
+        binary: binaryPaths.has(f.path) || undefined,
+      })),
+      diff,
+      diffTruncated,
+      recentSubjects,
+    };
   }
 
   /** `-c user.name/email` overrides from settings (blank = inherit git config). */
@@ -748,7 +814,7 @@ function classifyPullError(out: string): Partial<GitPullResult> {
 }
 
 /** Strip any embedded credentials from a remote URL before it reaches the UI/log. */
-function redactRemote(text: string): string {
+export function redactRemote(text: string): string {
   if (typeof text !== 'string') return '';
   return text.replace(/(https?:\/\/)[^/@\s]+@/gi, '$1');
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -25,12 +25,14 @@ import type {
   FileHistoryEntry,
   FileReadResult,
   FileTree,
+  GenerateCommitMessageResult,
   GitBlameLine,
   GitBranch,
   GitCheckoutResult,
   GitCheckpoint,
   GitCommit,
   GitCommitDetail,
+  GitCommitMessageStreamEvent,
   GitFileChange,
   GitFileDiff,
   GitPullResult,
@@ -365,6 +367,10 @@ const gitApi = {
     ipcRenderer.invoke(IpcChannels.gitDiscard, workspaceId, path),
   commit: (workspaceId: string, message: string): Promise<GitCommit | null> =>
     ipcRenderer.invoke(IpcChannels.gitCommit, workspaceId, message),
+  generateCommitMessage: (workspaceId: string): Promise<GenerateCommitMessageResult> =>
+    ipcRenderer.invoke(IpcChannels.gitCommitMessageGenerate, workspaceId),
+  cancelCommitMessage: (workspaceId: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.gitCommitMessageCancel, workspaceId),
   log: (workspaceId: string, opts?: { limit?: number; offset?: number }): Promise<GitCommit[]> =>
     ipcRenderer.invoke(IpcChannels.gitLog, workspaceId, opts),
   commitDetail: (workspaceId: string, hash: string): Promise<GitCommitDetail | null> =>
@@ -418,6 +424,8 @@ const gitApi = {
     subscribe<{ workspaceId: string }>(IpcEvents.gitChanged, cb),
   onCheckpointsChanged: (cb: (payload: { sessionId: string }) => void): (() => void) =>
     subscribe<{ sessionId: string }>(IpcEvents.gitCheckpointsChanged, cb),
+  onCommitMessageStream: (cb: (ev: GitCommitMessageStreamEvent) => void): (() => void) =>
+    subscribe<GitCommitMessageStreamEvent>(IpcEvents.gitCommitMessageStream, cb),
 };
 
 const memoryApi = {

--- a/src/renderer/features/git/GitPanel.tsx
+++ b/src/renderer/features/git/GitPanel.tsx
@@ -16,14 +16,18 @@ import {
   GitBranch,
   History,
   ListChecks,
+  Minus,
+  Plus,
   RefreshCw,
   Save,
+  Sparkles,
   UploadCloud,
   X,
 } from 'lucide-react';
 import type { GitFileChange } from '@shared/types';
 import { EmptyState, IconButton, Spinner } from '@/renderer/components/ui';
 import { cn } from '@/renderer/lib/cn';
+import { useAgentStore } from '@/renderer/stores/useAgentStore';
 import { useGitStore, type GitView } from '@/renderer/stores/useGitStore';
 import { useLayoutStore } from '@/renderer/stores/useLayoutStore';
 import { useSettingsStore } from '@/renderer/stores/useSettingsStore';
@@ -301,14 +305,20 @@ function ChangesView() {
   const stageAll = useGitStore((s) => s.stageAll);
   const unstageAll = useGitStore((s) => s.unstageAll);
   const commit = useGitStore((s) => s.commit);
+  const message = useGitStore((s) => s.commitMessage);
+  const setMessage = useGitStore((s) => s.setCommitMessage);
+  const generating = useGitStore((s) => s.generatingMessage);
+  const generateMessage = useGitStore((s) => s.generateCommitMessage);
+  const cancelGenerate = useGitStore((s) => s.cancelCommitMessage);
+  const agentReady = useAgentStore((s) => s.install.installed);
   const template = useSettingsStore((s) => s.settings.git.commitMessageTemplate);
   const addToast = useUIStore((s) => s.addToast);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
-  const [message, setMessage] = useState('');
   const [committing, setCommitting] = useState(false);
 
   useEffect(() => {
-    setMessage((m) => (m === '' && template ? template : m));
+    const { commitMessage, setCommitMessage } = useGitStore.getState();
+    if (commitMessage === '' && template) setCommitMessage(template);
   }, [template]);
 
   const { staged, unstaged } = useMemo(() => splitFiles(status?.files ?? []), [status?.files]);
@@ -322,7 +332,7 @@ function ChangesView() {
 
   const doCommit = async () => {
     const trimmed = message.trim();
-    if (!trimmed) return;
+    if (!trimmed || generating) return;
     setCommitting(true);
     try {
       const ok = await commit(trimmed);
@@ -414,22 +424,73 @@ function ChangesView() {
         <textarea
           value={message}
           onChange={(e) => setMessage(e.target.value)}
-          placeholder="Commit message"
+          readOnly={generating}
+          placeholder={generating ? 'Generating commit message…' : 'Commit message'}
           rows={3}
           onKeyDown={(e) => {
             if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') void doCommit();
           }}
           className="w-full resize-y rounded-md border border-line bg-surface-2 px-2 py-1.5 text-[12px] text-fg placeholder:text-faint focus:border-line-strong focus:outline-none"
         />
-        <button
-          type="button"
-          disabled={staged.length === 0 || !message.trim() || committing}
-          onClick={() => void doCommit()}
-          className="flex items-center justify-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-[12px] font-semibold text-base transition-opacity hover:opacity-90 disabled:opacity-40"
-        >
-          <Check size={13} />
-          {committing ? 'Committing…' : `Commit ${staged.length} file${staged.length === 1 ? '' : 's'}`}
-        </button>
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            disabled={staged.length === 0 || !message.trim() || committing || generating}
+            onClick={() => void doCommit()}
+            title={`Commit ${staged.length} staged file${staged.length === 1 ? '' : 's'}`}
+            className="flex shrink-0 items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-[12px] font-semibold text-base transition-opacity hover:opacity-90 disabled:opacity-40"
+          >
+            <Check size={13} />
+            {committing ? 'Committing…' : `Commit ${staged.length}`}
+          </button>
+          <button
+            type="button"
+            disabled={unstaged.length === 0}
+            onClick={() => void stageAll()}
+            title="Stage all changes"
+            className="flex items-center gap-1 rounded-md border border-line bg-surface-2 px-2 py-1.5 text-[12px] text-muted transition-colors hover:text-fg disabled:opacity-40"
+          >
+            <Plus size={12} />
+            Stage all
+          </button>
+          <button
+            type="button"
+            disabled={staged.length === 0}
+            onClick={() => void unstageAll()}
+            title="Unstage all changes"
+            className="flex items-center gap-1 rounded-md border border-line bg-surface-2 px-2 py-1.5 text-[12px] text-muted transition-colors hover:text-fg disabled:opacity-40"
+          >
+            <Minus size={12} />
+            Unstage all
+          </button>
+          <div className="flex-1" />
+          {generating ? (
+            <button
+              type="button"
+              onClick={cancelGenerate}
+              title="Cancel generation"
+              className="flex items-center gap-1 rounded-md border border-line bg-surface-2 px-2 py-1.5 text-[12px] text-muted transition-colors hover:text-fg"
+            >
+              <X size={12} />
+              Cancel
+            </button>
+          ) : (
+            <button
+              type="button"
+              disabled={staged.length === 0 || !agentReady || committing}
+              onClick={() => void generateMessage()}
+              title={
+                agentReady
+                  ? 'Generate a commit message with the agent'
+                  : 'Claude Code is not available — sign in to generate commit messages'
+              }
+              className="flex items-center gap-1 rounded-md border border-line bg-surface-2 px-2 py-1.5 text-[12px] text-accent transition-colors hover:border-line-strong disabled:opacity-40"
+            >
+              <Sparkles size={12} />
+              Generate
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/stores/useGitStore.ts
+++ b/src/renderer/stores/useGitStore.ts
@@ -41,8 +41,15 @@ interface GitState {
   /** Drives which sub-view + file the GitPanel reveals (activity-card jumps). */
   focus: GitFocus | null;
   hydrated: boolean;
+  /** The commit composer's draft (streams live during AI generation). */
+  commitMessage: string;
+  /** True while the commit-message sub-agent is streaming a proposal. */
+  generatingMessage: boolean;
 
   hydrate: () => void;
+  setCommitMessage: (text: string) => void;
+  generateCommitMessage: () => Promise<void>;
+  cancelCommitMessage: () => void;
   refresh: () => Promise<void>;
   loadDiff: (path: string, staged: boolean) => Promise<GitFileDiff | null>;
   stage: (path: string) => Promise<void>;
@@ -79,6 +86,14 @@ function activeSession(): string | null {
   return useSessionStore.getState().selectedId;
 }
 
+/**
+ * Generation-scoped bookkeeping (module-local, not store state): the user's
+ * pre-generation draft — restored when a run errors/cancels before any text
+ * arrived — and whether the in-flight run produced at least one delta.
+ */
+let draftBackup = '';
+let sawDelta = false;
+
 export const useGitStore = create<GitState>((set, get) => ({
   status: null,
   log: [],
@@ -89,6 +104,8 @@ export const useGitStore = create<GitState>((set, get) => ({
   loading: false,
   focus: null,
   hydrated: false,
+  commitMessage: '',
+  generatingMessage: false,
 
   hydrate: () => {
     if (get().hydrated) return;
@@ -106,13 +123,82 @@ export const useGitStore = create<GitState>((set, get) => ({
     api.onCheckpointsChanged(({ sessionId }) => {
       if (sessionId === activeSession()) void get().loadCheckpoints();
     });
+    api.onCommitMessageStream?.((ev) => {
+      if (ev.workspaceId !== activeWs()) return;
+      if (ev.kind === 'delta') {
+        sawDelta = true;
+        set((s) => ({ commitMessage: s.commitMessage + (ev.text ?? '') }));
+      } else if (ev.kind === 'done') {
+        // The done frame carries the full authoritative message — replace.
+        set({ commitMessage: ev.text ?? get().commitMessage, generatingMessage: false });
+      } else {
+        // error / canceled: a failed run must not eat the user's draft.
+        set({
+          generatingMessage: false,
+          ...(sawDelta ? {} : { commitMessage: draftBackup }),
+        });
+      }
+    });
 
     // Initial pull + follow active-workspace switches.
     void get().refresh();
     window.limboo?.workspace.onChanged(() => {
-      set({ diffs: {}, log: [], branches: [], tags: [] });
+      get().cancelCommitMessage();
+      set({ diffs: {}, log: [], branches: [], tags: [], commitMessage: '', generatingMessage: false });
       void get().refresh();
     });
+  },
+
+  setCommitMessage: (text) => set({ commitMessage: text }),
+
+  generateCommitMessage: async () => {
+    const api = gitApi();
+    const wsId = activeWs();
+    const toast = useUIStore.getState().addToast;
+    if (!api?.generateCommitMessage || !wsId || get().generatingMessage) return;
+    draftBackup = get().commitMessage;
+    sawDelta = false;
+    set({ generatingMessage: true, commitMessage: '' });
+    try {
+      const r = await api.generateCommitMessage(wsId);
+      if (!r.ok && r.reason !== 'canceled') {
+        if (r.reason === 'no-staged') {
+          toast({ title: 'Nothing staged', description: 'Stage changes first.', tone: 'warning' });
+        } else if (r.reason === 'agent-unavailable') {
+          toast({
+            title: 'Claude Code unavailable',
+            description: r.error ?? 'Sign in to Claude Code to generate commit messages.',
+            tone: 'danger',
+          });
+        } else if (r.reason === 'busy') {
+          toast({ title: 'Already generating', description: 'A commit message is being generated.', tone: 'warning' });
+        } else if (r.reason === 'rate-limited') {
+          toast({ title: 'Rate limited', description: r.error, tone: 'warning' });
+        } else {
+          toast({ title: 'Generation failed', description: r.error, tone: 'danger' });
+        }
+      }
+    } catch (err) {
+      toast({
+        title: 'Generation failed',
+        description: err instanceof Error ? err.message : String(err),
+        tone: 'danger',
+      });
+    } finally {
+      // Backstop — the stream's terminal frame normally clears this first; if it
+      // never arrived (e.g. an early invoke error), restore the user's draft.
+      if (get().generatingMessage) {
+        set({
+          generatingMessage: false,
+          ...(sawDelta ? {} : { commitMessage: draftBackup }),
+        });
+      }
+    }
+  },
+
+  cancelCommitMessage: () => {
+    const wsId = activeWs();
+    if (wsId && get().generatingMessage) void gitApi()?.cancelCommitMessage?.(wsId);
   },
 
   refresh: async () => {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -84,6 +84,17 @@ export const GIT_LIMITS = {
   refNameMax: 255,
   /** Timeout (ms) for network git ops (push / pull / fetch). */
   networkTimeoutMs: 120_000,
+  /** Caps for AI commit-message generation context (main-side enforced). */
+  commitGen: {
+    /** Max chars of staged diff text included in the prompt. */
+    diffCharsMax: 60_000,
+    /** Recent log subjects included for commit-style inference. */
+    subjectsMax: 20,
+    /** Max staged file entries listed in the prompt. */
+    filesMax: 200,
+    /** Cap on the final proposed message (post-processed). */
+    messageMax: 2_000,
+  },
 } as const;
 
 /**

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -119,6 +119,8 @@ export const IpcChannels = {
   gitUnstageAll: 'git:unstageAll',
   gitDiscard: 'git:discard',
   gitCommit: 'git:commit',
+  gitCommitMessageGenerate: 'git:commitMessage:generate',
+  gitCommitMessageCancel: 'git:commitMessage:cancel',
   gitLog: 'git:log',
   gitCommitDetail: 'git:commitDetail',
   gitBranches: 'git:branches',
@@ -238,6 +240,8 @@ export const IpcEvents = {
   terminalCommand: 'terminal:command',
   /** The active workspace's git state changed (status/branch/commit/stage). */
   gitChanged: 'git:changed',
+  /** Streaming AI commit-message proposal (delta / done / error / canceled). */
+  gitCommitMessageStream: 'git:commit-message-stream',
   /** A session's git checkpoints changed (created / restored / pruned). */
   gitCheckpointsChanged: 'git:checkpoints-changed',
   /** The set of session worktrees changed (created / removed / pruned / missing). */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -802,6 +802,43 @@ export interface GitPushResult {
   error?: string;
 }
 
+/**
+ * Context assembled in the MAIN process for AI commit-message generation. It is
+ * built entirely from `runGit` output (never renderer-supplied) and size-capped
+ * by `GIT_LIMITS.commitGen` before it reaches the sub-agent prompt.
+ */
+export interface GitCommitContext {
+  /** Resolved repo root (worktree-aware) the one-shot run uses as cwd. */
+  root: string;
+  branch?: string;
+  /** Staged files (capped at commitGen.filesMax). */
+  files: Array<{ path: string; status: GitFileStatus; adds?: number; dels?: number; binary?: boolean }>;
+  /** Staged unified diff, capped at commitGen.diffCharsMax and redacted. */
+  diff: string;
+  diffTruncated: boolean;
+  /** Recent commit subjects (newest first) for style inference, redacted. */
+  recentSubjects: string[];
+}
+
+/** One frame of the streaming AI commit-message proposal. */
+export interface GitCommitMessageStreamEvent {
+  workspaceId: string;
+  requestId: string;
+  kind: 'delta' | 'done' | 'error' | 'canceled';
+  /** delta: appended chunk; done: the FULL authoritative message (replace). */
+  text?: string;
+  /** Set when kind === 'error' (already redacted). */
+  error?: string;
+}
+
+/** Terminal result of a commit-message generation request. */
+export interface GenerateCommitMessageResult {
+  ok: boolean;
+  message?: string;
+  reason?: 'no-staged' | 'agent-unavailable' | 'busy' | 'rate-limited' | 'canceled' | 'error';
+  error?: string;
+}
+
 /** Result of `git pull` — decodes fast-forward / conflict / divergence cases. */
 export interface GitPullResult {
   ok: boolean;


### PR DESCRIPTION
## Summary

Deepens the git integration with a **commit-message sub-agent** driven by the same Claude Agent SDK that powers the main agent, plus a redesigned commit bar — all inside the existing UI/theme and hardened per the repo's security contract.

### Git sub-agent (isolated one-shot, streams live)
- `GitManager.buildCommitContext()` assembles everything **main-side**: staged diff (capped 60 KB), binary-flagged file list, recent commit subjects for style inference — argv-only git, credentials redacted.
- `AgentManager.generateCommitMessage()` runs a single-turn, **tool-less** SDK query (pinned Haiku model, `allowedTools: []` **and** deny-all `canUseTool`, no resume, no transcript, no MCP servers, no lifecycle changes). Deltas stream over a new dedicated `git:commit-message-stream` event straight into the commit textarea; cancelable per workspace.
- The sub-agent **only proposes** — the user's Commit button remains the sole executor.

### Commit bar (same design language)
- Narrow `Commit N` button + bordered **Stage all** / **Unstage all** buttons + **Generate ⇄ Cancel** in one control row; textarea goes read-only while streaming; Cmd/Ctrl+Enter unchanged.
- Draft moved into `useGitStore` (survives tab switches); failed/canceled runs restore the pre-generation draft; workspace switches cancel in-flight runs.

### Security hardening
- New channels go through the sender-validated `handle()` wrapper; only renderer input is a workspace id (`assertId`).
- Size caps in `GIT_LIMITS.commitGen`; prompt double-checked against `AGENT_LIMITS.promptMax`; errors/stderr redacted.

## Test plan
- [x] `npx vite build --config vite.renderer.config.mts` passes
- [x] `npm run lint` clean
- [x] `npm start` boots with all Forge targets built, IPC registered, no errors
- [x] Diff audit: no `dark:`, no gradients, no off-palette hex, no `shell: true`
- [ ] Manual: stage files → Generate streams live → edit → Commit commits the edited text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New agent IPC path sends staged diffs to the model (credentials redacted, tools disabled, no auto-commit), but it expands sensitive code exposure to the LLM and adds concurrent SDK usage beside chat runs.
> 
> **Overview**
> Adds **AI-assisted commit messages** in the Git panel: the renderer only sends a workspace id; the main process builds capped, redacted context from staged changes and runs an isolated, tool-less Claude SDK one-shot that **proposes** text only (Commit still goes through `git commit`).
> 
> **Main process:** `GitManager.buildCommitContext()` gathers staged diff, file list, and recent subjects under `GIT_LIMITS.commitGen`. `AgentManager.generateCommitMessage()` uses a pinned Haiku model, streams deltas on `git:commit-message-stream`, and supports per-workspace cancel without touching session agent lifecycle. New IPC generate/cancel handlers wire `GitManager` + `AgentManager`.
> 
> **Renderer:** Commit draft lives in `useGitStore` with live streaming into the textarea; Generate/Cancel, Stage all/Unstage all, and read-only-while-generating behavior in `GitPanel`. Failed or canceled runs restore the pre-generation draft; workspace switches cancel in-flight generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 954655915ae34fd592cfb88281298c192daa052e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-assisted commit message generation with live streaming and cancel support in the Git workflow.
  * The commit editor now shows generation progress, supports cancel/generate actions, and prevents committing while a message is being generated.
  * The app now uses staged changes and recent commit history to draft commit messages.

* **Bug Fixes**
  * Improved handling for non-repo states and empty staged changes, with clearer failure responses and safer UI reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->