### PR TITLE
All fixes are implemented and verified. Here's what each issue was an…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,22 +67,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.197.tgz",
-      "integrity": "sha512-XNIi8W1tb+QfMkcK+5kepOC6BsxG8wtupd72H+pIPzIJypVQhHy7FoX+KBMtTRYwtl+5dsjKyABhjWXebeUilw==",
+      "version": "0.3.201",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.201.tgz",
+      "integrity": "sha512-InT1XLmf2QpldWdtznKDWEoGJT4p+sXh24yxbeBQ++lMJCzMrI0W27MEmmmDWx0otpa+ubdHCF5YQ6oiNt7cmg==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.197",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.197",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.197",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.197",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.197",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.197",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.197",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.197"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.201",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.201",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.201",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.201",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.201",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.201",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.201",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.201"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -91,9 +91,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.197.tgz",
-      "integrity": "sha512-jC6WvH5Hr6APTfbMjo4nC6LlyMMqbpCMwiHXIw7/AsQXIHQhZ+cRRMesQlV6UFI1l3O53gLZHzsG9cXwfrPHKw==",
+      "version": "0.3.201",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.201.tgz",
+      "integrity": "sha512-8Mcb3BDyKUGfJWFFTWwt+at37lbDH3ZwVtUNPWGG1toZ75RDCJry5U4kXRvQ2xokvJQlA0E+eNp6keWe5ZH22Q==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +104,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.197.tgz",
-      "integrity": "sha512-ZQNvGkMrTyatBlHTIQ4w2i2aLBuvq355UP/FDLnVXIH8l23RsL1x/0w9P+dqB7EmY9OZi/cPxSrpskpo+dZWLA==",
+      "version": "0.3.201",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.201.tgz",
+      "integrity": "sha512-TFR2bu0+ml3RHoMrtsgD0qDK5Oknw8kYGBV7qpQHn+IWmE96gnHhogG1LpJwpHtni08XkJIjfWk1DdlsUYtRkQ==",
       "cpu": [
         "x64"
       ],
@@ -117,9 +117,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.197.tgz",
-      "integrity": "sha512-pWhQgCtAft4EGM4Zn24HRad1a/k2u6oA+2uM/KCdjehfKtooDiHfMNd1yzXY/n9AEBWP0RHB2Vz3mJ30X2pVAg==",
+      "version": "0.3.201",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.201.tgz",
+      "integrity": "sha512-mShTo3MwF0gkN4dDw78wWJiB6aBDVRkl81cnApvoBofpdyUBYgm9Gw16CCjDTgelMKeBFqN6ErJpwjI3wbP00A==",
       "cpu": [
         "arm64"
       ],
@@ -130,9 +130,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.197.tgz",
-      "integrity": "sha512-VuIGXsLGK/aqSQ0tTBqqPVNzjefWS5SWnK8mlYyQitT4s5UDzHXJm0UZBTGxRtlcS0e2+QAHKwbGBCq1ZKSXjg==",
+      "version": "0.3.201",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.201.tgz",
+      "integrity": "sha512-EiqbpfJIpChfkn+8Uj061Qjyw0eaRcOXtdrvVuHANyj8ZErVOr8HlH6op9PSeIUa9TX0m2+tNgKPQvOGseQckA==",
       "cpu": [
         "arm64"
       ],
@@ -143,9 +143,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.197.tgz",
-      "integrity": "sha512-AUccrbdcv4Hy/GteP/gYLjG/zDP+fe2BFtDMctEfRFVz40DazYDcOyW1+nIgSTQtxf5jSTAVVf3cNuXB2CZwlw==",
+      "version": "0.3.201",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.201.tgz",
+      "integrity": "sha512-jrJBrRWrSuoFKIgjyqxHqmfd6Pb3Bs5Bvakg0knXCTC4fbUXGnC9Q6u7gdDwgXohUNP6/DD+s8U7bivvvVv0dg==",
       "cpu": [
         "x64"
       ],
@@ -156,9 +156,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.197.tgz",
-      "integrity": "sha512-3Tuy7XhD4UIKE4A4RPmKJcbL7Q/3dcB1hEWQt2lKP7c/DlixeEv+tRzvpnFZKhFX2hy0tkBk3QjkozSAacMC/w==",
+      "version": "0.3.201",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.201.tgz",
+      "integrity": "sha512-IbxnzO5UCbqbm2TnzCHkSyJorAFw2isdKdIsFCTxJJjSs3ZC+v3LC1QSUiVCx0qi+CV6w3MKx6mLI11mrvhbbQ==",
       "cpu": [
         "x64"
       ],
@@ -169,9 +169,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.197.tgz",
-      "integrity": "sha512-Wx8uiAKBenDuL8lWQmrqnX5ppljaH5unQ9cKiCz2/9Kgf09dgnrwbX8n/FhndCZR8PmYw539eWwYVrSVc/bl6w==",
+      "version": "0.3.201",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.201.tgz",
+      "integrity": "sha512-UsoytRJ/037uHpb3ATrIoe+AgwTf+PwKuFLGjddHAV/11wERJs0hlrnSmcnp43kf0PFxoSNinngme96YYASmQg==",
       "cpu": [
         "arm64"
       ],
@@ -182,9 +182,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.197.tgz",
-      "integrity": "sha512-ZXJO/VvR3SI4G0gwthWeFXWdHB5RXPu3rtfGRcKZ/YgtDeW17rQ+LZIJTk2ywzbLb8EvlghR5JPgn293hC179Q==",
+      "version": "0.3.201",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.201.tgz",
+      "integrity": "sha512-PhalN/0cWcqDfbx7iwoLNR2gurjTiqhBk1G6K+NRScxEcQjWuu5xKXCcdbX8ePVpT+nbEMmFEFpn2y+8V8hIdA==",
       "cpu": [
         "x64"
       ],

--- a/src/main/ipc/attachmentHandlers.ts
+++ b/src/main/ipc/attachmentHandlers.ts
@@ -53,6 +53,9 @@ export function registerAttachmentHandlers(attachments: AttachmentManager): void
         if (typeof p !== 'string' || p.length === 0 || p.length > ATTACHMENT_LIMITS.pathMax) {
           throw new Error('Invalid path');
         }
+        if (p.includes('\0')) {
+          throw new Error('Invalid path');
+        }
       }
       return attachments.addFromPaths(id, paths, 'drop');
     },

--- a/src/main/managers/AgentManager.ts
+++ b/src/main/managers/AgentManager.ts
@@ -1221,6 +1221,7 @@ export class AgentManager {
     permMode: SessionPermissionMode,
   ): Promise<void> {
     let attempt = 0;
+    let resumeDropped = false;
     for (;;) {
       try {
         await this.runOnce(sessionId, prompt, abort, permMode);
@@ -1250,6 +1251,28 @@ export class AgentManager {
           return;
         }
         const raw = err instanceof Error ? err.message : String(err);
+
+        // Corrupted-resume self-heal: the CLI's `[ede_diagnostic] … stop_reason=
+        // tool_use` result means the resumed transcript ends in a tool_use with
+        // no tool_result (a prior run died mid-tool). Resuming it fails the same
+        // way every turn, so drop the stored SDK session id once and retry with
+        // a fresh SDK session (Limboo's own transcript/history is unaffected).
+        const resumeCorrupted =
+          raw.includes('ede_diagnostic') ||
+          (raw.includes('returned an error result') && raw.includes('stop_reason=tool_use'));
+        if (resumeCorrupted && !resumeDropped && this.loadSdkSession(sessionId)) {
+          resumeDropped = true;
+          this.forgetSdkSession(sessionId);
+          this.diag(
+            'recovery',
+            'warning',
+            'Resumed transcript was corrupted — starting a fresh SDK session',
+            redact(raw),
+            sessionId,
+          );
+          continue; // retry — buildOptions no longer finds a resume id
+        }
+
         const cls = classifyAgentError(redact(raw));
         this.diag('recovery', cls.recoverable ? 'warning' : 'error', `Run error (${cls.outcome})`, redact(raw), sessionId);
 
@@ -2321,6 +2344,16 @@ export class AgentManager {
         'INSERT OR REPLACE INTO agent_session_meta (session_id, sdk_session_id, updated_at) VALUES (?, ?, ?)',
       )
       .run(sessionId, sdkSessionId, Date.now());
+  }
+
+  /**
+   * Drop the stored SDK session id so the next run starts a fresh SDK session
+   * instead of resuming. Used when the resumed transcript is corrupted (e.g. it
+   * ends in a tool_use with no tool_result after a mid-tool kill) — resuming it
+   * would fail identically on every turn.
+   */
+  private forgetSdkSession(sessionId: string): void {
+    getDb().prepare('DELETE FROM agent_session_meta WHERE session_id = ?').run(sessionId);
   }
 
   /* ---------------------------------------------------------------- */

--- a/src/main/managers/voice/VoiceManager.ts
+++ b/src/main/managers/voice/VoiceManager.ts
@@ -51,6 +51,8 @@ export class VoiceManager {
   private worker: UtilityProcess | null = null;
   private workerReady = false;
   private workerRestarts = 0;
+  /** Set when WE asked the worker to shut down, so its exit is not a crash. */
+  private expectedExit = false;
   private readonly loadedKinds = new Set<VoiceWorkerModelKind>();
   private readonly loading = new Map<VoiceWorkerModelKind, Promise<void>>();
   /** Signature of the VAD tuning the worker was loaded with. */
@@ -423,12 +425,16 @@ export class VoiceManager {
     });
     this.worker = proc;
     this.workerReady = false;
+    this.expectedExit = false;
     this.loadedKinds.clear();
     this.loading.clear();
 
     proc.on('message', (msg: VoiceWorkerResponse) => this.onWorkerMessage(msg));
     proc.on('exit', (code) => {
-      logger.warn(`voice: worker exited with code ${code}`);
+      const expected = this.expectedExit && code === 0;
+      this.expectedExit = false;
+      if (expected) logger.info('voice: worker exited cleanly');
+      else logger.warn(`voice: worker exited with code ${code}`);
       const wasReady = this.workerReady;
       this.worker = null;
       this.workerReady = false;
@@ -638,6 +644,7 @@ export class VoiceManager {
         this.captureSessionId !== null || this.currentJob !== null || this.ttsQueue.length > 0;
       if (!busy && this.worker) {
         logger.info('voice: shutting down idle speech worker');
+        this.expectedExit = true;
         this.post({ t: 'shutdown' });
       }
     }, WORKER_IDLE_MS);
@@ -666,6 +673,7 @@ export class VoiceManager {
     this.unsubscribeAgent?.();
     this.ttsQueue.length = 0;
     if (this.worker) {
+      this.expectedExit = true;
       this.post({ t: 'shutdown' });
       this.worker = null;
     }


### PR DESCRIPTION
…d what changed:

The handler is correctly registered at HEAD ([voiceHandlers.ts:42](src/main/ipc/voiceHandlers.ts:42), wired last in [ipc/index.ts:72](src/main/ipc/index.ts:72), window created after registration — no race, no duplicate channels). The channel was added in your latest commit, and the errors came from a **stale main-process build**: Vite hot-reloads the renderer/preload, but the running main process kept the old bundle without the handler. The fresh `npm start` I ran booted cleanly with the handler registered. Related cleanup: the misleading `[WARN] voice: worker exited with code 0` after an *intentional* idle shutdown now logs as info (`expectedExit` flag in [VoiceManager.ts](src/main/managers/voice/VoiceManager.ts)); a real crash still warns.

Added the `\0` rejection to the per-path loop in [attachmentHandlers.ts:56](src/main/ipc/attachmentHandlers.ts:56), matching the guards already in `fsHandlers`/`workspaceHandlers`. Note this was defense-in-depth, not an exploitable bypass — `AttachmentManager.stageOne` already rejects NUL bytes before touching the filesystem, and pasted filenames are neutralized by `sanitizeName`.

That message is generated *inside* the Agent SDK when the CLI dies with a pending error result; the diagnostic means the **resumed transcript ends in a `tool_use` with no `tool_result`** (a prior run was killed mid-tool-call). Since Limboo always resumes the stored SDK session, the session failed the same way on every turn. Two fixes:
- [AgentManager.ts](src/main/managers/AgentManager.ts) now detects this error in `runWithRecovery`, drops the corrupted `sdk_session_id` (new `forgetSdkSession`), logs a "starting a fresh SDK session" recovery diagnostic, and retries once — your chat history in Limboo is untouched; only the SDK-side conversation restarts.
- Updated `@anthropic-ai/claude-agent-sdk` 0.3.195 → **0.3.201**, which includes upstream fixes for the "tool_use ids without tool_result blocks" resume bugs.

- `npx vite build --config vite.renderer.config.mts` — built clean in 30.7s.
- `npm run lint` — no findings.
- Booted the app (`npm start`): main/preload/voice-worker all rebuilt, `Limboo main process ready`, workspace + search indexed, zero errors in the log; test instance shut down cleanly afterward.

Sources: [electron#26495 — "No handler registered" from stale builds](https://github.com/electron/electron/issues/26495), [Claude stop reasons — tool_use must be followed by tool_result](https://platform.claude.com/docs/en/build-with-claude/handling-stop-reasons), [Claude Code changelog — tool_use/resume fixes](https://claudefa.st/blog/guide/changelog).

<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are localized recovery, logging, IPC validation, and a patch-level SDK bump; agent retry is bounded to one resume drop per run.
> 
> **Overview**
> Fixes three reliability and hardening issues.
> 
> **Agent:** When a resumed Claude SDK session fails because the transcript ends in `tool_use` without a matching `tool_result` (e.g. a prior run was killed mid-tool), `runWithRecovery` now detects that error pattern, clears the stored `sdk_session_id` via new `forgetSdkSession`, logs a recovery diagnostic, and retries once with a fresh SDK session. Limboo’s own chat transcript is unchanged. **`@anthropic-ai/claude-agent-sdk`** is bumped **0.3.197 → 0.3.201** in the lockfile.
> 
> **Voice:** Intentional worker shutdown (idle timer or `dispose`) sets an **`expectedExit`** flag so exit code 0 is logged at **info** instead of **warn**, while real crashes still warn and can trigger restart.
> 
> **Attachments:** **`attachmentAddPaths`** rejects paths containing **NUL** (`\0`) in the IPC handler, aligned with other path handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ef8a690fd381ba6e40cf830d72bab31ee36f03a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path validation when adding attachments by rejecting invalid path strings that contain null characters.
  * Made session recovery more resilient by automatically retrying with a fresh session when a corrupted resume is detected.
  * Reduced noisy error logging for voice worker shutdowns, so normal shutdowns are treated as expected instead of crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->