### PR TITLE
feat(ui): add five-bar SessionSpinner for active session indicators

### DIFF
--- a/src/renderer/components/ui/SessionSpinner.tsx
+++ b/src/renderer/components/ui/SessionSpinner.tsx
@@ -1,0 +1,54 @@
+/**
+ * Five-bar radial spinner for session "agent run in flight" indicators. Uses
+ * staggered `animate-spin` layers; honors reduced-motion via the global
+ * stylesheet when `data-reduced-motion="true"` is set on <html>.
+ */
+import type { ComponentProps } from 'react';
+import { cn } from '@/renderer/lib/cn';
+
+interface SessionSpinnerProps extends ComponentProps<'div'> {
+  size?: number;
+  invert?: boolean;
+  disabled?: boolean;
+}
+
+export function SessionSpinner({
+  size = 16,
+  invert,
+  disabled,
+  className,
+  ...props
+}: SessionSpinnerProps) {
+  if (disabled) return null;
+
+  const sizePx = `${size}px`;
+  const barWidth = `${(size * 0.2).toFixed(2)}px`;
+  const barHeight = `${(size * 0.075).toFixed(2)}px`;
+
+  return (
+    <div
+      role="status"
+      aria-label="Loading"
+      className={cn('relative inline-block', className)}
+      style={{ width: sizePx, height: sizePx }}
+      {...props}
+    >
+      {[...Array(5)].map((_, i) => (
+        <div
+          key={i}
+          className="absolute inset-0 flex animate-spin justify-center"
+          style={{ animationDelay: `${i * 100}ms` }}
+        >
+          <div
+            style={{
+              backgroundColor: invert ? 'var(--color-base)' : 'var(--color-accent)',
+              width: barWidth,
+              height: barHeight,
+              borderRadius: '9999px',
+            }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/renderer/components/ui/index.ts
+++ b/src/renderer/components/ui/index.ts
@@ -5,6 +5,7 @@ export { EmptyState } from './EmptyState';
 export { Badge } from './Badge';
 export { Kbd } from './Kbd';
 export { Spinner } from './Spinner';
+export { SessionSpinner } from './SessionSpinner';
 export { SuccessCheck } from './SuccessCheck';
 export { CircularProgress } from './CircularProgress';
 export { Waveform } from './Waveform';

--- a/src/renderer/features/sessions/SessionRow.tsx
+++ b/src/renderer/features/sessions/SessionRow.tsx
@@ -14,7 +14,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { CircleDot, GitBranch, Pin, Archive, MoreHorizontal } from 'lucide-react';
 import type { Session, SessionStatus } from '@shared/types';
-import { Badge, DiffStat, IconButton, Spinner } from '@/renderer/components/ui';
+import { Badge, DiffStat, IconButton, SessionSpinner } from '@/renderer/components/ui';
 import { cn } from '@/renderer/lib/cn';
 import { relativeTime } from '@/renderer/lib/format';
 import { useSessionStore } from '@/renderer/stores/useSessionStore';
@@ -96,7 +96,7 @@ export function SessionRow({
             <span className="h-2 w-2 animate-pulse rounded-full bg-accent" />
           </span>
         ) : running ? (
-          <Spinner size={13} />
+          <SessionSpinner size={13} />
         ) : (
           <CircleDot size={13} className={STATUS_COLOR[session.status]} />
         )}

--- a/src/renderer/features/sessions/WorktreeTabs.tsx
+++ b/src/renderer/features/sessions/WorktreeTabs.tsx
@@ -12,7 +12,7 @@
  */
 import { AlertTriangle, GitBranch, X } from 'lucide-react';
 import type { Session } from '@shared/types';
-import { Badge, Spinner } from '@/renderer/components/ui';
+import { Badge, SessionSpinner } from '@/renderer/components/ui';
 import { cn } from '@/renderer/lib/cn';
 import { useSessionStore } from '@/renderer/stores/useSessionStore';
 import { useIsSessionRunning } from './useSessionRunning';
@@ -93,7 +93,7 @@ function WorktreeTab({
       )}
     >
       {running ? (
-        <Spinner size={11} />
+        <SessionSpinner size={11} />
       ) : missing ? (
         <AlertTriangle size={11} className="shrink-0 text-warning" />
       ) : (

--- a/src/renderer/features/workspace/CenterWorkspace.tsx
+++ b/src/renderer/features/workspace/CenterWorkspace.tsx
@@ -13,7 +13,7 @@
  */
 import { useEffect, useState } from 'react';
 import { AlertTriangle, CircleDot, GitBranch, Plus, TerminalSquare } from 'lucide-react';
-import { DiffStat, IconButton, Spinner } from '@/renderer/components/ui';
+import { DiffStat, IconButton, SessionSpinner, Spinner } from '@/renderer/components/ui';
 import { useIsSessionRunning } from '@/renderer/features/sessions/useSessionRunning';
 import { WorktreeTabs } from '@/renderer/features/sessions/WorktreeTabs';
 import { ServicesStrip } from '@/renderer/features/sessions/ServicesStrip';
@@ -200,7 +200,7 @@ function SessionHeader({
   const revalidating = useResumeStore((s) => s.bySession[sessionId]?.phase === 'checking');
   return (
     <div className="flex h-9 shrink-0 items-center gap-2 border-b border-line px-4">
-      {running ? <Spinner size={12} /> : <CircleDot size={12} className="text-success" />}
+      {running ? <SessionSpinner size={12} /> : <CircleDot size={12} className="text-success" />}
       <span className="text-[13px] font-medium">{title}</span>
       <span className="text-[11px] text-faint">{branch}</span>
       <DiffStat adds={adds} dels={dels} className="ml-2" />


### PR DESCRIPTION
## Summary
- Add SessionSpinner for session running indicators
- Wire into SessionRow, WorktreeTabs, and CenterWorkspace header
- Keep existing ring Spinner elsewhere

## Test plan
- [x] vite renderer build
- [x] npm run lint

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new loading indicator for active sessions with a smoother multi-segment spinner animation.
  * Updated session and workspace views to use the new spinner for running states.

* **Accessibility**
  * The loading indicator now includes status labeling for better assistive technology support.

* **Visual Improvements**
  * Spinner appearance adapts to different UI themes and supports sizing options for consistent display across screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->