### PR TITLE
ci: add Bitbucket Pipelines mirror of the GitLab release pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,9 +340,13 @@ Releases: **GitLab is the single source of truth and primary publisher.** Pushin
 `v*` tag triggers the GitLab `release` stage (`.gitlab-ci.yml`), which packages all-OS
 installers and publishes the same build to **both** a GitLab Release and a GitHub
 Release. The GitHub repo is kept in sync by GitLab push mirroring, and `git push
-origin` is configured to fan out to both `github.com` and
-`gitlab.com/BotCoder254/limboo`. GitHub Actions' `release.yml` is a manual fallback
-only. See `docs/ci/release-process.md` and `docs/ci/gitlab-ci.md`.
+origin` is configured to fan out to `github.com`, `gitlab.com/BotCoder254/limboo`,
+and `bitbucket.org/limboo_/limboo`. GitHub Actions' `release.yml` is a manual fallback
+only. **Bitbucket Pipelines** (`bitbucket-pipelines.yml`) mirrors the GitLab pipeline
+on the Bitbucket repo via the same `ci/scripts/*.mjs`: CI on every push/PR, and on
+`v*` tags a Linux packaging pass that co-publishes the GitHub Release (see
+`docs/ci/bitbucket-pipelines.md`). See `docs/ci/release-process.md` and
+`docs/ci/gitlab-ci.md`.
 
 **Versioning is TAG-DRIVEN — never hand-bump `package.json` before tagging.** Every CI
 job that reads the version first runs `ci/scripts/apply-tag-version.mjs`, which stamps the

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,0 +1,288 @@
+# Limboo — Bitbucket Pipelines
+#
+# A deep mirror of the primary GitLab pipeline (.gitlab-ci.yml): the SAME logical
+# pipeline (see ci/pipeline.yml) implemented with the SAME provider-neutral
+# ci/scripts/*.mjs, in the SAME order:
+#
+#   validate -> build -> test -> package(linux) -> secure -> release
+#
+# Role: co-equal Linux pipeline + GitHub Release CO-PUBLISHER. GitLab remains the
+# single source of truth and the sole GitLab-Release publisher; on every `v*` tag
+# BOTH pipelines run — GitLab packages all 3 OSes, Bitbucket packages Linux and
+# publishes the GitHub Release with the same idempotent create-or-clobber logic as
+# GitLab's release:github job. Identical asset names mean the last finisher's
+# upload wins (by design; GitLab's multi-OS pipeline normally finishes last).
+# Bitbucket cloud runners are Linux-only, so Windows/macOS packaging stays on the
+# GitLab SaaS runners.
+#
+# Versioning is TAG-DRIVEN: every job that reads the version first runs
+# ci/scripts/apply-tag-version.mjs (which also understands BITBUCKET_TAG), so all
+# artifacts match the tag. Never hand-bump package.json before tagging.
+#
+# Secrets MUST be provided as SECURED repository variables (Repository settings ->
+# Repository variables), never in this file:
+#   GITHUB_TOKEN            (required) GitHub PAT, repo scope on BotCoder254/limboo —
+#                           used by the release-github step and the manual
+#                           sync-github custom pipeline.
+#   BITBUCKET_ACCESS_TOKEN  (optional) repository access token; when present the
+#                           release also uploads installers to Bitbucket Downloads,
+#                           otherwise that step skips cleanly.
+# See docs/ci/bitbucket-pipelines.md and docs/ci/release-process.md.
+
+image: node:22-bookworm   # Electron 42 requires Node >= 22.12 (ERR_REQUIRE_ESM otherwise)
+
+clone:
+  depth: full   # full history + tags: release-note diffs and check-tag-unique need them
+
+definitions:
+  caches:
+    npm: .npm   # same lockfile-driven npm cache location as .gitlab-ci.yml
+
+  steps:
+    # ----------------------------------------------------------------- validate
+    - step: &lint
+        name: "validate: lint"
+        caches: [npm]
+        script:
+          - apt-get update && apt-get install -y build-essential python3
+          - npm ci --cache .npm --prefer-offline
+          - npm run lint
+
+    - step: &compliance
+        name: "validate: compliance"
+        caches: [npm]
+        script:
+          - apt-get update && apt-get install -y build-essential python3
+          - npm ci --cache .npm --prefer-offline
+          # Tag-driven versioning: on a v* tag pipeline, stamp package.json (+ lockfile)
+          # with the tag version BEFORE check-manifest (mirrors the GitLab compliance
+          # job). No-op off a tag. BITBUCKET_TAG is read by the scripts themselves.
+          - node ci/scripts/apply-tag-version.mjs
+          # Fail fast if this v* tag re-tags an already-tagged commit.
+          - node ci/scripts/check-tag-unique.mjs
+          - node ci/scripts/check-licenses.mjs
+          - node ci/scripts/check-electron-security.mjs
+          - node ci/scripts/check-manifest.mjs
+
+    - step: &audit
+        name: "validate: audit (non-blocking)"
+        caches: [npm]
+        script:
+          - apt-get update && apt-get install -y build-essential python3
+          - npm ci --cache .npm --prefer-offline
+          # Advisories warn; they do not block ordinary commits (same as GitLab).
+          - npm audit --audit-level=high || echo "audit advisories reported (non-blocking)"
+
+    - step: &secret-scan
+        name: "validate: secret-scan"
+        image: zricethezav/gitleaks:latest
+        script:
+          - gitleaks detect --source . --redact --verbose
+
+    # -------------------------------------------------------------------- build
+    - step: &build
+        name: "build"
+        caches: [npm]
+        script:
+          - apt-get update && apt-get install -y build-essential python3
+          - npm ci --cache .npm --prefer-offline
+          - node ci/scripts/apply-tag-version.mjs
+          - npx vite build --config vite.renderer.config.mts
+          - npm run package
+
+    # --------------------------------------------------------------------- test
+    - step: &test
+        name: "test: linux smoke"
+        caches: [npm]
+        script:
+          # Electron needs the full GTK/ATK/CUPS/ALSA stack to launch (the smoke test
+          # boots a real Electron process), not just nss/gbm. The t64 fallback keeps
+          # this working if the base image moves to an Ubuntu 24.04-style t64 set.
+          - apt-get update
+          - apt-get install -y build-essential python3 xvfb libnss3 libdrm2 libgbm1 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libpango-1.0-0 libcairo2
+          - apt-get install -y libatk1.0-0 libatk-bridge2.0-0 libcups2 libgtk-3-0 libasound2 || apt-get install -y libatk1.0-0t64 libatk-bridge2.0-0t64 libcups2t64 libgtk-3-0t64 libasound2t64
+          - npm ci --cache .npm --prefer-offline
+          - xvfb-run -a node ci/scripts/smoke-test.mjs
+
+    # ------------------------------------------------------------------ package
+    # Mirror of GitLab's package:linux — the hybrid build (`npm run dist` = Forge
+    # package + electron-builder --prepackaged), then stage ONLY release-relevant
+    # files into artifacts/linux/ (per-OS dir mirrors the GitLab layout the secure
+    # step flattens).
+    - step: &package-linux
+        name: "package: linux"
+        size: 2x   # Electron packaging needs the larger memory allowance
+        caches: [npm]
+        script:
+          - apt-get update && apt-get install -y build-essential python3 rpm fakeroot dpkg
+          - npm ci --cache .npm --prefer-offline
+          # Stamp the tag version into package.json before building the installers.
+          - node ci/scripts/apply-tag-version.mjs
+          - npm run dist -- --publish never
+          # Pure-npm SBOM from the lockfile — the dependency set is identical on all
+          # OSes, so this one SBOM covers the release (same as GitLab's linux job).
+          - npx --yes @cyclonedx/cyclonedx-npm --omit dev --output-file dist/limboo-sbom.cdx.json
+          - node ci/scripts/verify-signing.mjs dist
+          - |
+            mkdir -p artifacts/linux
+            cp dist/*.AppImage dist/*.deb dist/*.rpm dist/latest-linux.yml artifacts/linux/
+            cp dist/limboo-sbom.cdx.json artifacts/linux/
+            # *.blockmap is optional (electron-updater delta metadata) — copy if present,
+            # but never mask a real error on the required files above.
+            if ls dist/*.blockmap >/dev/null 2>&1; then cp dist/*.blockmap artifacts/linux/; else echo "[stage] no *.blockmap (delta updates disabled?)"; fi
+            # Fail fast if any essential installer / update metadata is missing.
+            for pat in "artifacts/linux/*.AppImage" "artifacts/linux/*.deb" "artifacts/linux/*.rpm" "artifacts/linux/latest-linux.yml"; do
+              ls $pat >/dev/null 2>&1 || { echo "[stage] MISSING required artifact: $pat"; exit 1; }
+            done
+        artifacts:
+          - artifacts/**
+
+    # ------------------------------------------------------------------- secure
+    # Consolidate the staged artifacts into a single dist/, then compute the
+    # release-wide SHA256SUMS (mirror of GitLab's secure job).
+    - step: &secure
+        name: "secure: checksums + signing"
+        script:
+          - |
+            mkdir -p dist
+            cp -r artifacts/*/* dist/ 2>/dev/null || true
+            ls -la dist
+          - node ci/scripts/make-checksums.mjs dist dist/SHA256SUMS
+          - node ci/scripts/verify-signing.mjs dist
+        artifacts:
+          - dist/**
+
+    # ------------------------------------------------------------------ release
+    - step: &release-notes
+        name: "release: notes"
+        script:
+          - node ci/scripts/generate-release-notes.mjs "$BITBUCKET_TAG" RELEASE_NOTES.md
+        artifacts:
+          - RELEASE_NOTES.md
+          - dist/**
+
+    # Publish the GitHub Release — an exact port of GitLab's release:github job
+    # (pinned gh CLI, idempotent create/upload, --prerelease on hyphen tags). The
+    # latest*.yml + *.blockmap files MUST be attached — electron-updater reads them
+    # from the GitHub Release to detect and verify updates. CO-PUBLISHER: GitLab's
+    # release:github runs on the same tag; both use create-or-clobber, so the last
+    # finisher's identically-named assets win (GitLab's all-OS build normally lands
+    # last and stays authoritative).
+    - step: &release-github
+        name: "release: github (co-publish)"
+        image: debian:bookworm-slim
+        script:
+          - |
+            set -eu
+            GH_CLI_VERSION="2.95.0"
+            apt-get update && apt-get install -y curl ca-certificates tar git
+            curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz" | tar xz
+            install "gh_${GH_CLI_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh
+            gh --version
+          - |
+            set -eu
+            : "${GITHUB_TOKEN:?GITHUB_TOKEN must be set as a SECURED repository variable}"
+            export GH_TOKEN="$GITHUB_TOKEN"
+            export GH_REPO=BotCoder254/limboo
+            PRERELEASE=""
+            case "$BITBUCKET_TAG" in *-*) PRERELEASE="--prerelease" ;; esac
+            if gh release view "$BITBUCKET_TAG" >/dev/null 2>&1; then
+              echo "Release $BITBUCKET_TAG already exists — uploading assets with --clobber"
+              gh release upload "$BITBUCKET_TAG" dist/* --clobber
+            else
+              gh release create "$BITBUCKET_TAG" \
+                --title "Limboo $BITBUCKET_TAG" \
+                --notes-file RELEASE_NOTES.md \
+                --verify-tag $PRERELEASE \
+                dist/*
+            fi
+
+    # Upload the installers to Bitbucket Downloads so this host also serves the
+    # binaries. GUARDED: Bitbucket has no CI_JOB_TOKEN equivalent for the Downloads
+    # API, so this runs only when a BITBUCKET_ACCESS_TOKEN secured variable exists —
+    # otherwise it skips cleanly (same idiom as verify-signing on unsigned builds).
+    - step: &release-bitbucket-downloads
+        name: "release: bitbucket downloads (optional)"
+        image: curlimages/curl:latest
+        script:
+          - |
+            set -eu
+            if [ -z "${BITBUCKET_ACCESS_TOKEN:-}" ]; then
+              echo "[downloads] BITBUCKET_ACCESS_TOKEN not set — skipping Bitbucket Downloads upload."
+              exit 0
+            fi
+            for f in dist/*; do
+              [ -f "$f" ] || continue
+              echo "Uploading $(basename "$f") -> Bitbucket Downloads"
+              curl --fail --silent --show-error \
+                --header "Authorization: Bearer ${BITBUCKET_ACCESS_TOKEN}" \
+                -X POST "https://api.bitbucket.org/2.0/repositories/${BITBUCKET_REPO_FULL_NAME}/downloads" \
+                -F files=@"$f"
+            done
+
+pipelines:
+  # CI layer — every branch push: validate -> build -> test (mirror of the GitLab
+  # push pipeline; never produces shippable artifacts).
+  default:
+    - parallel:
+        - step: *lint
+        - step: *compliance
+        - step: *audit
+        - step: *secret-scan
+    - step: *build
+    - step: *test
+
+  # Same CI layer for pull requests.
+  pull-requests:
+    "**":
+      - parallel:
+          - step: *lint
+          - step: *compliance
+          - step: *audit
+          - step: *secret-scan
+      - step: *build
+      - step: *test
+
+  # Release layer — every v* tag runs the full pipeline through release (mirror of
+  # the GitLab tag pipeline, Linux packaging only on Bitbucket cloud runners).
+  tags:
+    "v*":
+      - parallel:
+          - step: *lint
+          - step: *compliance
+          - step: *audit
+          - step: *secret-scan
+      - step: *build
+      - step: *test
+      - step: *package-linux
+      - step: *secure
+      - step: *release-notes
+      - step: *release-github
+      - step: *release-bitbucket-downloads
+
+  custom:
+    # Manual dry-run from the Pipelines UI: package + secure without publishing
+    # (mirror of GitLab's CI_PIPELINE_SOURCE == "web" dry-run).
+    dry-run:
+      - step: *package-linux
+      - step: *secure
+
+    # Manual repository sync Bitbucket -> GitHub using the GITHUB_TOKEN secured
+    # variable. Manual-only so it can never fight GitLab's push mirroring. Uses a
+    # per-invocation http.extraheader (the token is never written to .git/config)
+    # and --force-with-lease against freshly fetched remote-tracking refs — never a
+    # bare --force (project security invariant).
+    sync-github:
+      - step:
+          name: "sync: bitbucket -> github (manual)"
+          script:
+            - |
+              set -eu
+              : "${GITHUB_TOKEN:?GITHUB_TOKEN must be set as a SECURED repository variable}"
+              AUTH="Authorization: Basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 -w0)"
+              git remote add github https://github.com/BotCoder254/limboo.git
+              git -c http.extraheader="$AUTH" fetch github
+              BRANCH="${BITBUCKET_BRANCH:-main}"
+              echo "Pushing HEAD -> github/$BRANCH (--force-with-lease) + tags"
+              git -c http.extraheader="$AUTH" push --force-with-lease github "HEAD:refs/heads/$BRANCH"
+              git -c http.extraheader="$AUTH" push github --tags

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,10 +1,11 @@
 # Limboo — canonical pipeline specification
 #
 # This file is the SINGLE SOURCE OF TRUTH for the logical CI/CD pipeline. It is
-# provider-agnostic by design: GitLab CI (.gitlab-ci.yml) and GitHub Actions
-# (.github/workflows) both implement the `validate -> build -> test` (ci) layer
-# identically, in this exact order, via the same ci/scripts/*.mjs, so any provider
-# can be adopted for ordinary commit validation.
+# provider-agnostic by design: GitLab CI (.gitlab-ci.yml), GitHub Actions
+# (.github/workflows), and Bitbucket Pipelines (bitbucket-pipelines.yml) all
+# implement the `validate -> build -> test` (ci) layer identically, in this exact
+# order, via the same ci/scripts/*.mjs, so any provider can be adopted for
+# ordinary commit validation.
 #
 # The `package`/`secure`/`release` (cd + release) layers are wired up in GitLab, the
 # PRIMARY release publisher and the single source of truth for this repo: its
@@ -15,7 +16,12 @@
 # kept in sync by GitLab push mirroring. GitHub Actions keeps an equivalent, manually
 # dispatched fallback (release.yml + _package.yml — the only path that mints
 # build-provenance/SBOM attestations; GitLab generates its SBOM via
-# @cyclonedx/cyclonedx-npm instead). When you change the pipeline, change THIS file
+# @cyclonedx/cyclonedx-npm instead). Bitbucket Pipelines mirrors the GitLab pipeline
+# on the Bitbucket repo: full CI on every push/PR, and on v* tags a Linux
+# package/secure/release pass that CO-PUBLISHES the GitHub Release with the same
+# idempotent create-or-clobber gh logic (Bitbucket cloud runners are Linux-only, so
+# Windows/macOS packaging stays on GitLab SaaS runners — see
+# docs/ci/bitbucket-pipelines.md). When you change the pipeline, change THIS file
 # first, then update the GitLab implementation (and any other provider you've wired
 # up release credentials for) to match.
 #
@@ -108,6 +114,9 @@ stages:
         from conventional commits + merged-PR labels between the previous tag and HEAD.
       - Publish a GitLab Release (assets via the Generic Package Registry) AND an
         identical GitHub Release with installers + SHA256SUMS + auto-update metadata.
+      - Bitbucket Pipelines co-publishes the GitHub Release from its own Linux build
+        (create-or-clobber, identical job logic); GitLab's all-OS build normally
+        finishes last and stays authoritative.
 
 # Security is a first-class, every-commit concern — never a post-release afterthought.
 security_invariants:

--- a/ci/scripts/apply-tag-version.mjs
+++ b/ci/scripts/apply-tag-version.mjs
@@ -17,6 +17,7 @@
  *   1. process.argv[2]   — explicit (e.g. GitHub Actions `inputs.ref`)
  *   2. CI_COMMIT_TAG     — GitLab
  *   3. GITHUB_REF_NAME   — GitHub Actions, when GITHUB_REF_TYPE=tag
+ *   4. BITBUCKET_TAG     — Bitbucket Pipelines
  *
  * Usage: node ci/scripts/apply-tag-version.mjs [tag]
  */
@@ -32,6 +33,7 @@ function resolveTag() {
   if (process.env.CI_COMMIT_TAG?.trim()) return process.env.CI_COMMIT_TAG.trim();
   if (process.env.GITHUB_REF_TYPE === 'tag' && process.env.GITHUB_REF_NAME?.trim())
     return process.env.GITHUB_REF_NAME.trim();
+  if (process.env.BITBUCKET_TAG?.trim()) return process.env.BITBUCKET_TAG.trim();
   return '';
 }
 

--- a/ci/scripts/check-manifest.mjs
+++ b/ci/scripts/check-manifest.mjs
@@ -54,11 +54,13 @@ async function main() {
   // in the job and stamps the tag version into package.json, so this check is now a
   // post-apply safety net — it verifies the stamp landed rather than demanding a
   // manual pre-bump. Only enforced when a release tag is present, so ordinary commit
-  // pipelines are unaffected. Reads either CI's tag env (GitLab: CI_COMMIT_TAG;
-  // GitHub Actions: GITHUB_REF_NAME when GITHUB_REF_TYPE=tag).
+  // pipelines are unaffected. Reads the CI tag env (GitLab: CI_COMMIT_TAG;
+  // GitHub Actions: GITHUB_REF_NAME when GITHUB_REF_TYPE=tag; Bitbucket
+  // Pipelines: BITBUCKET_TAG).
   const releaseTag =
     process.env.CI_COMMIT_TAG ||
     (process.env.GITHUB_REF_TYPE === 'tag' ? process.env.GITHUB_REF_NAME : '') ||
+    process.env.BITBUCKET_TAG ||
     '';
   if (releaseTag) {
     const tagVersion = releaseTag.replace(/^v/, '');
@@ -99,7 +101,7 @@ async function main() {
   // Docs integrity: index should link the guides that exist.
   if (await exists('docs/ci/README.md')) {
     const idx = await readFile('docs/ci/README.md', 'utf8');
-    for (const g of ['github-actions', 'gitlab-ci', 'release-process', 'security']) {
+    for (const g of ['github-actions', 'gitlab-ci', 'bitbucket-pipelines', 'release-process', 'security']) {
       if (await exists(`docs/ci/${g}.md`)) {
         if (idx.includes(`${g}.md`)) ok(`docs index links ${g}.md`);
         else fail(`docs/ci/README.md does not link ${g}.md`);

--- a/ci/scripts/check-tag-unique.mjs
+++ b/ci/scripts/check-tag-unique.mjs
@@ -25,6 +25,7 @@ function resolveTag() {
   if (process.env.CI_COMMIT_TAG?.trim()) return process.env.CI_COMMIT_TAG.trim();
   if (process.env.GITHUB_REF_TYPE === 'tag' && process.env.GITHUB_REF_NAME?.trim())
     return process.env.GITHUB_REF_NAME.trim();
+  if (process.env.BITBUCKET_TAG?.trim()) return process.env.BITBUCKET_TAG.trim();
   return '';
 }
 
@@ -56,7 +57,7 @@ function main() {
   // dereference the tag (or HEAD) to its underlying commit.
   let sha;
   try {
-    const ref = process.env.CI_COMMIT_SHA?.trim() || tag;
+    const ref = process.env.CI_COMMIT_SHA?.trim() || process.env.BITBUCKET_COMMIT?.trim() || tag;
     sha = git(['rev-parse', `${ref}^{commit}`]);
   } catch {
     sha = git(['rev-parse', 'HEAD^{commit}']);

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -2,10 +2,11 @@
 
 Limboo ships a **provider-agnostic** CI/CD platform. One logical pipeline is defined
 once in [`ci/pipeline.yml`](../../ci/pipeline.yml) and implemented identically for
-three providers, so an organization can adopt whichever CI it already runs without
-changing Limboo's development workflow. All three execute the same stages in the same
-order and produce the same artifacts, because the actual logic lives in
-provider-neutral scripts under [`ci/scripts/`](../../ci/scripts) rather than in YAML.
+three providers — GitLab CI, GitHub Actions, and Bitbucket Pipelines — so an
+organization can adopt whichever CI it already runs without changing Limboo's
+development workflow. All three execute the same stages in the same order and
+produce the same artifacts, because the actual logic lives in provider-neutral
+scripts under [`ci/scripts/`](../../ci/scripts) rather than in YAML.
 
 ## Layered responsibilities
 
@@ -23,7 +24,11 @@ Release and a GitHub Release (credentialed via the masked+protected `GH_TOKEN`
 variable — see [gitlab-ci.md](gitlab-ci.md)). The GitHub repository is kept in sync
 by GitLab push mirroring, and GitHub Releases still host the electron-updater feed.
 **GitHub Actions** retains the CI/Security/CodeQL layers plus a **manual-dispatch
-release fallback** ([github-actions.md](github-actions.md)).
+release fallback** ([github-actions.md](github-actions.md)). **Bitbucket
+Pipelines** runs the same pipeline on the Bitbucket mirror — CI on every push/PR,
+and on `v*` tags a Linux packaging pass that **co-publishes the GitHub Release**
+with the same idempotent create-or-clobber logic
+([bitbucket-pipelines.md](bitbucket-pipelines.md)).
 
 ## Stage order (every provider, fail-fast)
 
@@ -38,6 +43,7 @@ standards.
 
 - [gitlab-ci.md](gitlab-ci.md) — **primary** pipeline and release publisher
 - [github-actions.md](github-actions.md) — CI/Security/CodeQL + manual release fallback
+- [bitbucket-pipelines.md](bitbucket-pipelines.md) — Linux pipeline + GitHub Release co-publisher
 
 ## Process guides
 

--- a/docs/ci/bitbucket-pipelines.md
+++ b/docs/ci/bitbucket-pipelines.md
@@ -1,0 +1,95 @@
+# Bitbucket Pipelines — Linux pipeline + GitHub Release co-publisher
+
+Defined in [`bitbucket-pipelines.yml`](../../bitbucket-pipelines.yml). Bitbucket is
+the third implementation of the canonical pipeline
+([`ci/pipeline.yml`](../../ci/pipeline.yml)): a **deep mirror of the GitLab
+pipeline** running the same stages via the same provider-neutral
+[`ci/scripts/*.mjs`](../../ci/scripts). **GitLab remains the single source of truth
+and the sole GitLab-Release publisher**; Bitbucket is a co-equal Linux pipeline that
+**co-publishes the GitHub Release** on every `v*` tag.
+
+## Stages
+
+`validate` -> `build` -> `test` -> `package` -> `secure` -> `release`
+
+- **validate** (parallel): `lint`, `compliance` (tag-version stamp + tag-unique
+  guard + licenses + Electron invariants + manifest), `audit` (non-blocking),
+  `secret-scan` (gitleaks image).
+- **build**: renderer build + `npm run package`.
+- **test**: the Electron smoke test under `xvfb` (same GTK/ATK/CUPS/ALSA + t64
+  fallback package set as GitLab's `test:linux`).
+- **package**: `package-linux` only — Bitbucket cloud runners are **Linux-only**,
+  so Windows/macOS packaging stays on the GitLab SaaS runners. Runs
+  `npm run dist -- --publish never`, generates the CycloneDX SBOM, verifies
+  signing, and stages `artifacts/linux/`.
+- **secure**: flattens `artifacts/*/* -> dist/`, `SHA256SUMS`, signing check.
+- **release**: `release-notes` -> `release-github` (co-publish) ->
+  `release-bitbucket-downloads` (optional, token-guarded).
+
+## Co-publisher semantics (the race, by design)
+
+On a `v*` tag **both** GitLab and Bitbucket pipelines run. Both GitHub-release jobs
+use the same idempotent logic (create if missing, otherwise upload with
+`--clobber`), so whichever finishes **last** owns the identically-named assets.
+GitLab's all-OS pipeline normally finishes last, keeping its byte-for-byte
+multi-OS build authoritative; Bitbucket guarantees a GitHub Release exists even if
+the GitLab pipeline is unavailable. Tags containing a hyphen (e.g. `v1.4.0-rc.1`)
+publish as **pre-releases**, same as GitLab.
+
+## Repository variables (secrets)
+
+Set under **Repository settings -> Pipelines -> Repository variables**, always
+**Secured** (never in the YAML):
+
+| Variable | Use |
+| -------- | --- |
+| `GITHUB_TOKEN` | **Required.** GitHub PAT (repo scope / Contents: read+write on `BotCoder254/limboo`). Used by `release-github` and the manual `sync-github` custom pipeline. |
+| `BITBUCKET_ACCESS_TOKEN` | Optional repository access token. When present, installers are also uploaded to **Bitbucket Downloads**; when absent that step skips cleanly. |
+
+## Triggers
+
+- Push / pull-request pipelines run `validate` -> `build` -> `test`.
+- A `v*` tag (`BITBUCKET_TAG`) runs the full pipeline through `release`.
+- **Custom (manual) pipelines** from the Pipelines UI:
+  - `dry-run` — package + secure without publishing (mirror of GitLab's web
+    dry-run).
+  - `sync-github` — pushes the current branch + tags to GitHub with
+    `--force-with-lease` (never bare `--force`) using a per-invocation
+    `http.extraheader`; the token is never written to `.git/config`. Manual-only
+    so it can never fight GitLab's push mirroring.
+
+## Tag detection in the shared scripts
+
+Bitbucket exposes `BITBUCKET_TAG` / `BITBUCKET_COMMIT` instead of GitLab's
+`CI_COMMIT_TAG` / `CI_COMMIT_SHA`. The provider-neutral scripts
+(`apply-tag-version.mjs`, `check-tag-unique.mjs`, `check-manifest.mjs`) resolve all
+three providers' envs, so the YAML never has to translate.
+
+## Caching / clone
+
+The npm cache lives in `.npm` (same as GitLab, keyed by the lockfile via `npm ci
+--cache .npm --prefer-offline`). `clone: depth: full` gives
+`generate-release-notes.mjs` and `check-tag-unique.mjs` the full history + tag
+namespace they need.
+
+## First-time setup
+
+1. Add the remote and push (nothing is removed from existing remotes):
+
+   ```bash
+   git remote add bitbucket https://<user>@bitbucket.org/limboo_/limboo.git
+   git remote set-url --add --push origin https://<user>@bitbucket.org/limboo_/limboo.git
+   git push bitbucket main
+   ```
+
+2. Enable Pipelines: **Repository settings -> Pipelines -> Settings -> Enable**.
+3. Add `GITHUB_TOKEN` (Secured) under **Repository settings -> Repository
+   variables**; optionally add `BITBUCKET_ACCESS_TOKEN` for Downloads uploads.
+4. Cut a release exactly as on GitLab — push a `v*` tag (see
+   [release-process.md](release-process.md)); never hand-bump `package.json`.
+
+## Security posture (unchanged invariants)
+
+Secrets only in Secured repository variables; no secrets in YAML; `--force-with-lease`
+only; the same deny-by-default, argv-only, redaction rules as the rest of the
+project (see [security.md](security.md)).


### PR DESCRIPTION
## Summary

Adds **Bitbucket Pipelines** (`bitbucket-pipelines.yml`) as the third implementation of the canonical pipeline (`ci/pipeline.yml`), a deep mirror of the primary GitLab pipeline running the **same stages via the same provider-neutral `ci/scripts/*.mjs`**:

- **CI layer** (every push / PR): parallel `validate` (lint, compliance incl. tag-unique guard, non-blocking audit, gitleaks secret-scan) → `build` (renderer + forge package) → `test` (xvfb Electron smoke test, same GTK/ATK/CUPS/ALSA + t64 fallback set as GitLab).
- **Release layer** (`v*` tags): `package-linux` (`npm run dist`, CycloneDX SBOM, verify-signing, staged `artifacts/linux/`) → `secure` (SHA256SUMS) → `release-notes` → **GitHub Release co-publish** (pinned gh CLI 2.95.0, idempotent create-or-`--clobber`, `--prerelease` on hyphen tags, `latest*.yml` + blockmaps attached for electron-updater) → optional token-guarded Bitbucket Downloads upload.
- **Custom manual pipelines**: `dry-run` (package + secure, no publish) and `sync-github` (`--force-with-lease` only, per-invocation `http.extraheader`, token never written to `.git/config`).

### Supporting changes
- `apply-tag-version.mjs` / `check-tag-unique.mjs` / `check-manifest.mjs` now also resolve Bitbucket's `BITBUCKET_TAG` / `BITBUCKET_COMMIT` env (additive; GitLab/GitHub detection unchanged) — versioning stays **tag-driven**.
- New provider guide `docs/ci/bitbucket-pipelines.md`; linked from `docs/ci/README.md` and link-checked by `check-manifest.mjs`.
- `ci/pipeline.yml` + `CLAUDE.md` updated to document the third provider.

### Invariants preserved
- **GitLab remains the single source of truth** and sole GitLab-Release publisher; on a shared `v*` tag both release jobs are idempotent and GitLab's all-OS build normally finishes last and stays authoritative.
- Secrets only in **Secured repository variables** (`GITHUB_TOKEN` — already configured; optional `BITBUCKET_ACCESS_TOKEN`), never in YAML; `--force-with-lease` only; no app/UI code touched.

### Verification
- `npm run lint` clean; `node ci/scripts/check-manifest.mjs` green (incl. new docs link check); `BITBUCKET_TAG=v9.9.9` resolver dry-run stamps and restores cleanly; YAML parse-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Bitbucket Pipelines support for CI, including build, test, packaging, and release flows.
  * Added a new Bitbucket CI guide with setup, triggers, variables, and release behavior.
  * Expanded shared CI documentation to include Bitbucket as a supported provider.

* **Bug Fixes**
  * Improved release-tag detection and version handling so Bitbucket runs recognize and publish tagged releases correctly.
  * Updated duplicate-tag checks to work reliably with Bitbucket commit and tag metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->