### PR TITLE
fix(voice): capture stuck at listening + dead waveform visualization

### DIFF
--- a/src/main/managers/voice/VoiceManager.ts
+++ b/src/main/managers/voice/VoiceManager.ts
@@ -134,6 +134,15 @@ export class VoiceManager {
     // Barge-in: starting to talk interrupts playback per the user's preference.
     this.applyInterruption();
 
+    // Claim the capture session BEFORE the async model-load gap below. A late
+    // worker `tts-done` (e.g. the ack of the barge-in cancel above) would
+    // otherwise hit `setIdlePhase()` mid-start and broadcast `idle`, which the
+    // renderer takes as "release the mic" — leaving the session stuck listening
+    // to a closed microphone. With the id set, `setIdlePhase` defers to the
+    // capture flow; the worker still drops audio until `capture-start` is posted.
+    this.captureSessionId = sessionId;
+    this.captureMode = mode;
+
     this.setState({ phase: 'starting', sessionId, error: undefined });
     const activation = voice.input.activation;
     try {
@@ -143,6 +152,9 @@ export class VoiceManager {
       // so it needs neither VAD nor STT to begin — start listening instantly.
       if (activation === 'auto') await this.ensureLoaded('vad');
     } catch (err) {
+      // Release the claim, or the TTS pump (which holds while a capture session
+      // exists) would be locked out forever by a failed start.
+      this.captureSessionId = null;
       this.setState({ phase: 'unavailable', error: String(err) });
       throw err;
     }
@@ -156,8 +168,6 @@ export class VoiceManager {
       void this.ensureLoaded('vad').catch(() => undefined);
     }
 
-    this.captureSessionId = sessionId;
-    this.captureMode = mode;
     this.post({ t: 'capture-start', mode: activation === 'auto' ? 'auto' : 'manual' });
     this.setState({ phase: activation === 'auto' ? 'listening' : 'recording', sessionId });
     this.touchActivity();
@@ -631,6 +641,10 @@ export class VoiceManager {
   /* ---------------------------------------------------------------- */
 
   private setIdlePhase(): void {
+    // A live (or starting) capture session owns the phase — a late `tts-done`
+    // or an explicit stopSpeaking() must not stomp listening/recording to idle.
+    // Every path that legitimately ends a capture nulls `captureSessionId` first.
+    if (this.captureSessionId) return;
     if (this.currentJob || this.ttsQueue.length > 0) return;
     this.setState({ phase: 'idle', sessionId: this.captureSessionId });
     this.touchActivity();

--- a/src/renderer/features/workspace/ComposerVoiceOverlay.tsx
+++ b/src/renderer/features/workspace/ComposerVoiceOverlay.tsx
@@ -9,14 +9,16 @@ import { Check, X } from 'lucide-react';
 import type { VoicePhase } from '@shared/types';
 import { cn } from '@/renderer/lib/cn';
 import { Spinner, Waveform } from '@/renderer/components/ui';
-import { activeCapture } from '@/renderer/lib/voice/capture';
 import { useVoiceStore } from '@/renderer/stores/useVoiceStore';
 
 export function ComposerVoiceOverlay({ phase }: { phase: VoicePhase }) {
   const stopVoice = useVoiceStore((s) => s.stopVoice);
   const cancelVoice = useVoiceStore((s) => s.cancelVoice);
   const transcribing = phase === 'transcribing';
-  const analyser = activeCapture()?.analyser ?? null;
+  // Subscribed (not read from `activeCapture()` at render time): the mic graph
+  // finishes opening after this overlay mounts, and only a store update
+  // re-renders the Waveform with the live analyser.
+  const analyser = useVoiceStore((s) => s.analyser);
 
   return (
     <div className="flex min-h-[36px] flex-1 items-center gap-2">

--- a/src/renderer/lib/voice/capture.ts
+++ b/src/renderer/lib/voice/capture.ts
@@ -41,6 +41,9 @@ export async function startCapture(options: {
   };
   const stream = await navigator.mediaDevices.getUserMedia(constraints);
   const ctx = new AudioContext();
+  // A suspended context renders the whole graph silent (no worklet chunks, no
+  // analyser levels) with zero errors — resume defensively, mirroring playback.ts.
+  if (ctx.state === 'suspended') await ctx.resume().catch(() => undefined);
   // Load the worklet from an inlined Blob rather than a `?url` asset. `?raw`
   // bundles the processor source straight into the JS chunk, so there is no
   // separate asset file to emit and no base/`file://` path resolution to get

--- a/src/renderer/lib/voice/pcmWorklet.js
+++ b/src/renderer/lib/voice/pcmWorklet.js
@@ -1,8 +1,9 @@
 /**
  * AudioWorkletProcessor that converts the mic input (context rate, usually
  * 48 kHz float) into 16 kHz mono Int16 PCM chunks for the STT pipeline.
- * Loaded as a same-origin static asset (imported with `?url` in capture.ts) so
- * it works under the strict production CSP (`script-src 'self'`).
+ * Inlined into the bundle (imported with `?raw` in capture.ts) and loaded from
+ * a same-origin Blob URL, which the production CSP allows (`script-src 'self'
+ * blob:`).
  */
 const TARGET_RATE = 16000;
 /** Samples per posted chunk (64 ms at 16 kHz → 2048 bytes of Int16). */

--- a/src/renderer/stores/useVoiceStore.ts
+++ b/src/renderer/stores/useVoiceStore.ts
@@ -16,6 +16,13 @@ interface VoiceStoreState {
   hydrated: boolean;
   /** Last user-facing error (mic denied, models missing, …). */
   error: string | null;
+  /**
+   * Live analyser of the active mic capture, for the composer Waveform. Held in
+   * the store (not read from `activeCapture()` at render time) because the
+   * capture graph finishes opening AFTER the phase flips to listening — a
+   * non-reactive read would leave the waveform driven by `null` forever.
+   */
+  analyser: AnalyserNode | null;
 
   hydrate: () => Promise<void>;
   startVoice: (sessionId: string, mode: SessionPermissionMode) => Promise<void>;
@@ -48,6 +55,7 @@ export const useVoiceStore = create<VoiceStoreState>((set, get) => ({
   models: [],
   hydrated: false,
   error: null,
+  analyser: null,
 
   hydrate: async () => {
     if (get().hydrated) return;
@@ -62,8 +70,14 @@ export const useVoiceStore = create<VoiceStoreState>((set, get) => ({
 
     api.onState((next) => {
       // The main process ended the capture (VAD auto-stop, error, cancel) —
-      // release the mic as soon as the phase leaves listening/recording.
-      if (!MIC_PHASES.has(next.phase)) stopCapture();
+      // release the mic when the phase LEAVES listening/recording. This is a
+      // transition check on purpose: unrelated broadcasts that are simply not
+      // in a mic phase (`starting` while the worker warms, TTS housekeeping)
+      // must not tear down a mic that is still opening.
+      if (MIC_PHASES.has(get().state.phase) && !MIC_PHASES.has(next.phase)) {
+        stopCapture();
+        set({ analyser: null });
+      }
       set({ state: next, error: next.error ?? get().error });
     });
 
@@ -86,7 +100,9 @@ export const useVoiceStore = create<VoiceStoreState>((set, get) => ({
   startVoice: async (sessionId, mode) => {
     const api = window.limboo?.voice;
     if (!api) return;
-    set({ error: null });
+    // Drop any analyser left over from a previous run so the overlay never
+    // renders levels from a closed audio graph while the new mic opens.
+    set({ error: null, analyser: null });
 
     // Open the mic in parallel with the main-side start so getUserMedia + the
     // AudioWorklet warm up while the worker forks and models load, instead of
@@ -135,7 +151,17 @@ export const useVoiceStore = create<VoiceStoreState>((set, get) => ({
     }
 
     try {
-      await capturePromise;
+      const capture = await capturePromise;
+      const phase = get().state.phase;
+      if (phase === 'starting' || MIC_PHASES.has(phase)) {
+        // Publish the live analyser so the composer Waveform (a store
+        // subscriber) starts rendering real levels the moment the mic opens.
+        set({ analyser: capture.analyser });
+      } else {
+        // The capture ended (cancel/error) while the mic was still opening —
+        // nothing will broadcast another teardown, so release it here.
+        capture.stop();
+      }
     } catch (err) {
       // Mic denied / missing: abandon the main-side capture session too.
       await api.cancel().catch(() => undefined);
@@ -147,12 +173,14 @@ export const useVoiceStore = create<VoiceStoreState>((set, get) => ({
   stopVoice: async () => {
     const api = window.limboo?.voice;
     stopCapture();
+    set({ analyser: null });
     await api?.stop().catch(() => undefined);
   },
 
   cancelVoice: async () => {
     const api = window.limboo?.voice;
     stopCapture();
+    set({ analyser: null });
     await api?.cancel().catch(() => undefined);
   },
 


### PR DESCRIPTION
## What

Fixes the composer voice input getting stuck in the listening state and the waveform bars never animating.

## Root causes & changes

**1. Stray `idle` broadcast mid-start killed the mic (the "stuck at listening" bug) — `src/main/managers/voice/VoiceManager.ts`**

`startCapture()` set `phase: 'starting'`, then awaited worker fork + VAD load, and only claimed `captureSessionId` *after* that async gap. A late async worker `tts-done` (e.g. the ack of the barge-in `tts-cancel` issued at mic click) landed inside the gap, drove `setIdlePhase()`, and broadcast `phase: 'idle'` — which the renderer treated as "release the mic". Main then flipped to `listening`, but no audio ever flowed: VAD never fired, phase never advanced.

- The capture session id is now claimed **before** the async gap (and released on start failure so the TTS pump is never locked out).
- `setIdlePhase()` defers to a live capture session (every path that legitimately ends a capture nulls the id first).

**2. Waveform never received the AnalyserNode — `useVoiceStore.ts` / `ComposerVoiceOverlay.tsx`**

The overlay read `activeCapture()?.analyser` at render time via a non-reactive module getter. The mic graph finishes opening *after* the overlay mounts (phase flips to `listening` first), so nothing ever re-rendered with the live analyser — the waveform was driven by `null` forever.

- The analyser now lives in the voice store: published when the capture resolves, cleared on every teardown path; the overlay subscribes to it.
- Mic teardown on state broadcasts is now **transition-based** (mic phase → non-mic phase) instead of level-based, so unrelated broadcasts (`starting`, TTS housekeeping `idle`) can no longer kill a mic that is still opening. A capture that resolves after its session already ended is stopped on the spot (no leaked mic).

**3. Suspended `AudioContext` (defensive) — `src/renderer/lib/voice/capture.ts`**

A suspended context renders the whole capture graph silent with zero errors (same stuck symptom). Now resumed after creation, mirroring the existing guard in `playback.ts`. Also fixed the stale `?url` comment in `pcmWorklet.js` (it is inlined via `?raw` + Blob since the CSP work).

## Not changed

No UI/markup/theme changes, no settings-shape changes, no IPC-surface changes, and no security-posture changes — the audio-only mic permission carve-out in `hardenSession()`, the CSP, and IPC sender validation are untouched.

## Verification

- `npm run lint` — clean.
- `npx vite build --config vite.renderer.config.mts` — clean (the CLAUDE.md-prescribed check; `tsc` is not usable with the pinned TS 4.5).
- Dev boot compiles main/preload/voice-worker; a live end-to-end mic test couldn't run in the authoring session because the packaged Limboo instance held the single-instance lock. Suggested manual pass: click the mic → waveform must animate immediately during listening; speak → transcript lands; regression check: Settings › Voice → "Play sample", then click the mic while it speaks → capture must stay armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches main/renderer voice state synchronization and mic lifecycle; logic is narrow but timing bugs here are easy to regress without manual mic tests.
> 
> **Overview**
> Fixes composer voice input that could stay in **listening** with no audio/STT progress, and a **waveform** that never animated.
> 
> **Main process (`VoiceManager`)** now claims `captureSessionId` **before** the async worker/VAD warmup (and clears it if start fails). **`setIdlePhase()`** no longer forces `idle` while a capture session is active, so a late `tts-done` after barge-in cancel cannot broadcast `idle` mid-start and make the renderer drop the mic while main still shows listening.
> 
> **Renderer** puts the mic **`AnalyserNode`** in **`useVoiceStore`** and the overlay subscribes to it, so the waveform updates when `getUserMedia` finishes after the UI is already in a mic phase. Mic teardown on IPC state is **transition-based** (leaving listening/recording only), and stale captures that open after cancel/error are stopped locally.
> 
> **`capture.ts`** resumes a suspended **`AudioContext`** after creation (same idea as playback). **`pcmWorklet.js`** comment only: documents `?raw` + Blob loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d07f99687427107c9f7f380786e0e3072d2bddde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved voice capture startup reliability and prevented stale events from interrupting an active recording.
  - Fixed microphone state cleanup after failed, stopped, or cancelled captures.
  - Prevented the voice waveform from displaying outdated microphone activity.
  - Improved microphone initialization when audio access begins in a suspended state.
  - Ensured captures that finish during startup release the microphone correctly.

- **UI Improvements**
  - Voice waveform levels now update consistently while recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->