### PR TITLE
Fix/voice capture stuck listening

### DIFF
--- a/src/main/managers/AgentManager.ts
+++ b/src/main/managers/AgentManager.ts
@@ -67,8 +67,10 @@ import {
   ACTIVITY_LIMITS,
   AGENT_LIMITS,
   AGENT_MODELS,
+  ANTHROPIC_MODEL_ID_RE,
   CURSOR_MODEL_ID_RE,
   CURSOR_RESUME_ID_RE,
+  DEFAULT_SETTINGS,
   GIT_LIMITS,
   RESUME_LIMITS,
   providerForModel,
@@ -2807,9 +2809,18 @@ export class AgentManager {
     permMode: SessionPermissionMode,
     injectedContext?: string,
   ): Options {
+    // The model id is persisted user data riding into the SDK spawn — charset-
+    // validate it before use (mirrors runCursorOnce's model gate; unknown-but-
+    // well-formed ids are allowed so newer Anthropic models keep working).
+    const model = ANTHROPIC_MODEL_ID_RE.test(agent.model)
+      ? agent.model
+      : DEFAULT_SETTINGS.agent.model;
+    if (model !== agent.model) {
+      logger.warn(`agent: rejected malformed model id (${agent.model.slice(0, 80)}); using default`);
+    }
     const options: Options = {
       cwd,
-      model: agent.model,
+      model,
       // The composer's permission mode maps onto the SDK's:
       //   plan        → read-only; agent presents a plan via ExitPlanMode.
       //   ask         → SDK `default`; read-only enforced by decideToolUse (SDK

--- a/src/main/managers/voice/VoiceManager.ts
+++ b/src/main/managers/voice/VoiceManager.ts
@@ -134,6 +134,15 @@ export class VoiceManager {
     // Barge-in: starting to talk interrupts playback per the user's preference.
     this.applyInterruption();
 
+    // Claim the capture session BEFORE the async model-load gap below. A late
+    // worker `tts-done` (e.g. the ack of the barge-in cancel above) would
+    // otherwise hit `setIdlePhase()` mid-start and broadcast `idle`, which the
+    // renderer takes as "release the mic" — leaving the session stuck listening
+    // to a closed microphone. With the id set, `setIdlePhase` defers to the
+    // capture flow; the worker still drops audio until `capture-start` is posted.
+    this.captureSessionId = sessionId;
+    this.captureMode = mode;
+
     this.setState({ phase: 'starting', sessionId, error: undefined });
     const activation = voice.input.activation;
     try {
@@ -143,6 +152,9 @@ export class VoiceManager {
       // so it needs neither VAD nor STT to begin — start listening instantly.
       if (activation === 'auto') await this.ensureLoaded('vad');
     } catch (err) {
+      // Release the claim, or the TTS pump (which holds while a capture session
+      // exists) would be locked out forever by a failed start.
+      this.captureSessionId = null;
       this.setState({ phase: 'unavailable', error: String(err) });
       throw err;
     }
@@ -156,8 +168,6 @@ export class VoiceManager {
       void this.ensureLoaded('vad').catch(() => undefined);
     }
 
-    this.captureSessionId = sessionId;
-    this.captureMode = mode;
     this.post({ t: 'capture-start', mode: activation === 'auto' ? 'auto' : 'manual' });
     this.setState({ phase: activation === 'auto' ? 'listening' : 'recording', sessionId });
     this.touchActivity();
@@ -631,6 +641,10 @@ export class VoiceManager {
   /* ---------------------------------------------------------------- */
 
   private setIdlePhase(): void {
+    // A live (or starting) capture session owns the phase — a late `tts-done`
+    // or an explicit stopSpeaking() must not stomp listening/recording to idle.
+    // Every path that legitimately ends a capture nulls `captureSessionId` first.
+    if (this.captureSessionId) return;
     if (this.currentJob || this.ttsQueue.length > 0) return;
     this.setState({ phase: 'idle', sessionId: this.captureSessionId });
     this.touchActivity();

--- a/src/renderer/features/activity/panels.tsx
+++ b/src/renderer/features/activity/panels.tsx
@@ -50,7 +50,15 @@ export function FilesPanel() {
   const activeId = useWorkspaceStore((s) => s.activeId);
   const tree = useFileSystemStore((s) => (activeId ? s.treeByWs[activeId] : undefined));
   const progress = useFileSystemStore((s) => (activeId ? s.progressByWs[activeId] : undefined));
+  const fetchTree = useFileSystemStore((s) => s.fetchTree);
   const indexing = !!progress && progress.phase !== 'done';
+
+  // Self-heal: the tree normally arrives via the `fs:tree-changed` push, but the
+  // boot-time index can broadcast before this renderer subscribed. Pull the
+  // current tree (or trigger the first index) whenever the panel has none.
+  useEffect(() => {
+    if (activeId && !tree) void fetchTree(activeId);
+  }, [activeId, tree, fetchTree]);
 
   if (!activeId) {
     return (

--- a/src/renderer/features/workspace/ComposerVoiceOverlay.tsx
+++ b/src/renderer/features/workspace/ComposerVoiceOverlay.tsx
@@ -9,14 +9,16 @@ import { Check, X } from 'lucide-react';
 import type { VoicePhase } from '@shared/types';
 import { cn } from '@/renderer/lib/cn';
 import { Spinner, Waveform } from '@/renderer/components/ui';
-import { activeCapture } from '@/renderer/lib/voice/capture';
 import { useVoiceStore } from '@/renderer/stores/useVoiceStore';
 
 export function ComposerVoiceOverlay({ phase }: { phase: VoicePhase }) {
   const stopVoice = useVoiceStore((s) => s.stopVoice);
   const cancelVoice = useVoiceStore((s) => s.cancelVoice);
   const transcribing = phase === 'transcribing';
-  const analyser = activeCapture()?.analyser ?? null;
+  // Subscribed (not read from `activeCapture()` at render time): the mic graph
+  // finishes opening after this overlay mounts, and only a store update
+  // re-renders the Waveform with the live analyser.
+  const analyser = useVoiceStore((s) => s.analyser);
 
   return (
     <div className="flex min-h-[36px] flex-1 items-center gap-2">

--- a/src/renderer/features/workspace/ConversationView.tsx
+++ b/src/renderer/features/workspace/ConversationView.tsx
@@ -21,6 +21,7 @@ import { Spinner } from '@/renderer/components/ui';
 import { DiffStat } from '@/renderer/components/ui/DiffStat';
 import { cn } from '@/renderer/lib/cn';
 import { useAgentStore, EMPTY_SNAPSHOT } from '@/renderer/stores/useAgentStore';
+import { phaseLabel } from '@/renderer/features/agent/status';
 import { useLayoutStore } from '@/renderer/stores/useLayoutStore';
 import { useGitStore } from '@/renderer/stores/useGitStore';
 import { useAttachmentStore } from '@/renderer/stores/useAttachmentStore';
@@ -200,6 +201,7 @@ export function ConversationView({ sessionId }: { sessionId: string }) {
       {turns.map((turn) => (
         <TurnView
           key={turn.key}
+          sessionId={sessionId}
           turn={turn}
           // The pending approval / clarification wait docks inside the most recent
           // turn's assistant block, immediately beneath the latest streamed content.
@@ -219,7 +221,15 @@ export function ConversationView({ sessionId }: { sessionId: string }) {
         <AssistantBlock blocks={[]} trailing={<WaitingForDecision />} />
       )}
       {!turns.length && !approval && !clarifying && thinking && (
-        <AssistantBlock blocks={[]} trailing={<MessageSkeleton />} />
+        <AssistantBlock
+          blocks={[]}
+          trailing={
+            <>
+              <LiveStatusRow sessionId={sessionId} />
+              <MessageSkeleton />
+            </>
+          }
+        />
       )}
       {/* Scroll anchor — a small bottom margin keeps the last line off the very
           edge when auto-scrolling (honored by scrollIntoView). The composer is
@@ -245,11 +255,13 @@ function findScrollParent(node: HTMLElement | null): HTMLElement | null {
 // props (their `turn` object keeps identity across rebuilds, and approval/waiting/
 // thinking are only truthy for the last turn) and skip re-rendering entirely.
 const TurnView = memo(function TurnView({
+  sessionId,
   turn,
   approval,
   waiting,
   thinking,
 }: {
+  sessionId: string;
   turn: Turn;
   approval: PermissionRequest | null;
   waiting?: boolean;
@@ -266,14 +278,20 @@ const TurnView = memo(function TurnView({
   const showGapPulse =
     !!thinking && turn.blocks.length > 0 && !hasStreamingText && !hasRunningTool;
   const showAssistant = turn.blocks.length > 0 || !!approval || !!waiting || showSkeleton;
+  // While the run is active and no text is visibly streaming, the live status
+  // row names what the agent is doing right now (phase- and tool-aware) beside
+  // the shimmer/pulse. It stays mounted across skeleton → gap → tool
+  // transitions so its elapsed clock never resets mid-run.
+  const live = !!thinking && !hasStreamingText;
   const trailing = approval ? (
     <InlineApproval request={approval} />
   ) : waiting ? (
     <WaitingForDecision />
-  ) : showSkeleton ? (
-    <MessageSkeleton />
-  ) : showGapPulse ? (
-    <ThinkingPulse />
+  ) : live ? (
+    <>
+      <LiveStatusRow sessionId={sessionId} />
+      {showSkeleton ? <MessageSkeleton /> : showGapPulse ? <ThinkingPulse /> : null}
+    </>
   ) : null;
   return (
     <div className="flex flex-col gap-4">
@@ -302,16 +320,53 @@ function sameBlocks(a: Block[], b: Block[]): boolean {
 /** memo comparator for {@link TurnView}: skip re-render when nothing this turn
  *  depends on changed by identity. This is what keeps streaming cheap. */
 function turnsEqual(
-  prev: { turn: Turn; approval: PermissionRequest | null; waiting?: boolean; thinking?: boolean },
-  next: { turn: Turn; approval: PermissionRequest | null; waiting?: boolean; thinking?: boolean },
+  prev: { sessionId: string; turn: Turn; approval: PermissionRequest | null; waiting?: boolean; thinking?: boolean },
+  next: { sessionId: string; turn: Turn; approval: PermissionRequest | null; waiting?: boolean; thinking?: boolean },
 ): boolean {
   return (
+    prev.sessionId === next.sessionId &&
     prev.approval === next.approval &&
     prev.waiting === next.waiting &&
     prev.thinking === next.thinking &&
     prev.turn.key === next.turn.key &&
     prev.turn.user === next.turn.user &&
     sameBlocks(prev.turn.blocks, next.turn.blocks)
+  );
+}
+
+/**
+ * Live "working" indicator shown alongside the shimmer/pulse while a run is
+ * active: a pulsing accent dot, the current phase (tool-aware — "Searching the
+ * web…", "Running a command…", …), and elapsed time. Subscribes to the agent
+ * store directly so phase/tool changes tick through live even though the
+ * surrounding TurnView is memoized on coarser props.
+ */
+function LiveStatusRow({ sessionId }: { sessionId: string }) {
+  const phase = useAgentStore((s) => s.requestsBySession[sessionId]?.phase ?? 'idle');
+  const toolName = useAgentStore((s) => {
+    const calls = s.bySession[sessionId]?.toolCalls;
+    if (!calls) return undefined;
+    for (let i = calls.length - 1; i >= 0; i--) {
+      if (calls[i].status === 'running') return calls[i].name;
+    }
+    return undefined;
+  });
+  // RequestState carries no start timestamp, so elapsed counts from when this
+  // indicator appeared — it mounts with the run and stays put until text streams.
+  const startedAt = useRef(Date.now());
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const t = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(t);
+  }, []);
+  const secs = Math.max(0, Math.round((now - startedAt.current) / 1000));
+  const elapsed = secs >= 60 ? `${Math.floor(secs / 60)}m ${secs % 60}s` : `${secs}s`;
+  return (
+    <div className="flex items-center gap-2 text-[12px] text-muted animate-fade-in" aria-live="polite">
+      <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-accent animate-pulse" />
+      <span>{phaseLabel(phase, toolName)}</span>
+      {secs >= 3 && <span className="tabular-nums text-faint">{elapsed}</span>}
+    </div>
   );
 }
 

--- a/src/renderer/features/workspace/Markdown.tsx
+++ b/src/renderer/features/workspace/Markdown.tsx
@@ -15,7 +15,7 @@
  * we render the whole text in one pass so the final output is always exact
  * (loose lists, multi-block list items, etc. are never affected).
  */
-import { memo, useMemo } from 'react';
+import { memo, useDeferredValue, useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
@@ -70,12 +70,21 @@ function buildComponents(streaming: boolean): Components {
 const COMPONENTS_STATIC = buildComponents(false);
 const COMPONENTS_STREAMING = buildComponents(true);
 
+/** Streaming split result: every settled block plus the growing tail. */
+interface StreamingBlocks {
+  blocks: string[];
+  /** True when the LAST block is a still-open fenced code region. */
+  openFence: boolean;
+}
+
 /**
  * Split markdown into top-level blocks on blank lines, treating fenced code
  * regions (``` or ~~~) as atomic so a blank line *inside* a fence never splits
- * it. Used only while streaming, purely for render memoization.
+ * it. Used only while streaming, purely for render memoization. Also reports
+ * whether the final block is an unclosed fence so the tail can render through
+ * CodeBlock directly (no per-delta remark parse of a growing code region).
  */
-function splitBlocks(text: string): string[] {
+function splitBlocks(text: string): StreamingBlocks {
   const lines = text.split('\n');
   const blocks: string[] = [];
   let current: string[] = [];
@@ -111,7 +120,33 @@ function splitBlocks(text: string): string[] {
     current.push(line);
   }
   flush();
-  return blocks;
+  return { blocks, openFence: fence !== null };
+}
+
+/**
+ * The growing tail of a streamed message, when it is an OPEN fenced code block.
+ * remark-parsing a fence that can run to hundreds of lines on every delta is the
+ * dominant O(n²) cost of streaming code — instead the fence renders straight
+ * through CodeBlock (plain text while streaming; Shiki only once settled), which
+ * is O(append) per delta. The fence line itself is stripped here.
+ */
+function StreamingFenceTail({ text }: { text: string }) {
+  const nl = text.indexOf('\n');
+  const opener = nl === -1 ? text : text.slice(0, nl);
+  const code = nl === -1 ? '' : text.slice(nl + 1);
+  const lang = /^\s*(?:```+|~~~+)\s*([\w-]+)/.exec(opener)?.[1];
+  return <CodeBlock code={code} lang={lang} streaming />;
+}
+
+/**
+ * The growing tail when it is ordinary markdown (paragraph, list, heading…).
+ * Parsing is deferred (React 19 `useDeferredValue`) so a burst of deltas never
+ * blocks the frame — the tail catches up at low priority while settled blocks
+ * and the caret stay perfectly smooth.
+ */
+function StreamingTail({ text }: { text: string }) {
+  const deferred = useDeferredValue(text);
+  return <MarkdownBlock text={deferred} />;
 }
 
 /** One memoized markdown block. Re-renders only when its own text changes. */
@@ -135,14 +170,21 @@ export const Markdown = memo(function Markdown({
   streaming?: boolean;
 }) {
   // While streaming, render block-by-block so only the last (growing) block
-  // re-parses per delta. Once settled, render the whole document in one pass so
-  // the final output is always exact.
-  const blocks = useMemo(() => (streaming ? splitBlocks(text) : null), [streaming, text]);
+  // updates per delta: settled blocks are byte-identical between renders and
+  // skip via memo; an open code fence streams through CodeBlock (no remark);
+  // an ordinary tail parses at deferred priority. Once settled, render the
+  // whole document in one pass so the final output is always exact.
+  const split = useMemo(() => (streaming ? splitBlocks(text) : null), [streaming, text]);
 
   return (
     <div className="limboo-md text-[13.5px] leading-relaxed text-fg">
-      {blocks ? (
-        blocks.map((block, i) => <MarkdownBlock key={i} text={block} />)
+      {split ? (
+        split.blocks.map((block, i) => {
+          const isTail = i === split.blocks.length - 1;
+          if (isTail && split.openFence) return <StreamingFenceTail key={i} text={block} />;
+          if (isTail) return <StreamingTail key={i} text={block} />;
+          return <MarkdownBlock key={i} text={block} />;
+        })
       ) : (
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}

--- a/src/renderer/features/workspace/WorkspaceCreatePanel.tsx
+++ b/src/renderer/features/workspace/WorkspaceCreatePanel.tsx
@@ -11,7 +11,7 @@
  * form only does light, friendly pre-checks to guide input.
  */
 import { useMemo, useState } from 'react';
-import { ArrowLeft, FolderSearch, GitBranch, FolderPlus } from 'lucide-react';
+import { ArrowLeft, FolderOpen, FolderSearch, GitBranch, FolderPlus } from 'lucide-react';
 import { cn } from '@/renderer/lib/cn';
 import { Logo } from '@/renderer/components/brand/Logo';
 import { useWorkspaceStore } from '@/renderer/stores/useWorkspaceStore';
@@ -36,6 +36,7 @@ function nameError(name: string): string | null {
 export function WorkspaceCreatePanel() {
   const pickDirectory = useWorkspaceStore((s) => s.pickDirectory);
   const createNew = useWorkspaceStore((s) => s.createNew);
+  const openWorkspace = useWorkspaceStore((s) => s.open);
   const setLauncherView = useWorkspaceStore((s) => s.setLauncherView);
   const addToast = useUIStore((s) => s.addToast);
 
@@ -81,6 +82,26 @@ export function WorkspaceCreatePanel() {
     }
   };
 
+  /** The "I already have a project" path: pick the folder itself and open it
+   *  through the validated `workspace:open` pipeline (files index immediately). */
+  const openExisting = async () => {
+    if (busy) return;
+    try {
+      const dir = await pickDirectory();
+      if (!dir) return;
+      setBusy(true);
+      await openWorkspace(dir);
+      // On success the store flips activeId and the shell replaces this screen.
+    } catch (e) {
+      addToast({
+        title: 'Could not open folder',
+        description: e instanceof Error ? e.message : String(e),
+        tone: 'danger',
+      });
+      setBusy(false);
+    }
+  };
+
   return (
     <div className="mx-auto flex h-full w-full max-w-xl flex-col justify-center gap-6 py-8">
       <button
@@ -97,7 +118,8 @@ export function WorkspaceCreatePanel() {
         <div className="flex flex-col gap-1">
           <h1 className="text-lg font-semibold tracking-tight text-fg">Create a workspace</h1>
           <p className="text-[12px] text-muted">
-            Limboo creates the project folder, then profiles it automatically.
+            Limboo creates a new, empty project folder inside the location you pick. Already
+            have a project with files? Open its folder instead — its files show up right away.
           </p>
         </div>
       </div>
@@ -188,6 +210,23 @@ export function WorkspaceCreatePanel() {
           </WorkspaceActionButton>
         </div>
       </form>
+
+      {/* Escape hatch for the most common mix-up: picking a folder that already
+          contains a project. Opening indexes its files immediately. */}
+      <div className="flex items-center gap-3">
+        <span className="h-px flex-1 bg-line" />
+        <span className="text-[11px] uppercase tracking-wide text-faint">or</span>
+        <span className="h-px flex-1 bg-line" />
+      </div>
+      <button
+        type="button"
+        onClick={() => void openExisting()}
+        disabled={busy}
+        className="flex items-center justify-center gap-2 rounded-lg border border-line bg-surface-2 px-3 py-2.5 text-[13px] text-fg transition-colors hover:border-line-strong disabled:opacity-50"
+      >
+        <FolderOpen size={15} className="text-muted" />
+        Open an existing folder…
+      </button>
     </div>
   );
 }

--- a/src/renderer/lib/voice/capture.ts
+++ b/src/renderer/lib/voice/capture.ts
@@ -41,6 +41,9 @@ export async function startCapture(options: {
   };
   const stream = await navigator.mediaDevices.getUserMedia(constraints);
   const ctx = new AudioContext();
+  // A suspended context renders the whole graph silent (no worklet chunks, no
+  // analyser levels) with zero errors — resume defensively, mirroring playback.ts.
+  if (ctx.state === 'suspended') await ctx.resume().catch(() => undefined);
   // Load the worklet from an inlined Blob rather than a `?url` asset. `?raw`
   // bundles the processor source straight into the JS chunk, so there is no
   // separate asset file to emit and no base/`file://` path resolution to get

--- a/src/renderer/lib/voice/pcmWorklet.js
+++ b/src/renderer/lib/voice/pcmWorklet.js
@@ -1,8 +1,9 @@
 /**
  * AudioWorkletProcessor that converts the mic input (context rate, usually
  * 48 kHz float) into 16 kHz mono Int16 PCM chunks for the STT pipeline.
- * Loaded as a same-origin static asset (imported with `?url` in capture.ts) so
- * it works under the strict production CSP (`script-src 'self'`).
+ * Inlined into the bundle (imported with `?raw` in capture.ts) and loaded from
+ * a same-origin Blob URL, which the production CSP allows (`script-src 'self'
+ * blob:`).
  */
 const TARGET_RATE = 16000;
 /** Samples per posted chunk (64 ms at 16 kHz → 2048 bytes of Int16). */

--- a/src/renderer/stores/useFileSystemStore.ts
+++ b/src/renderer/stores/useFileSystemStore.ts
@@ -16,6 +16,13 @@ interface FileSystemState {
   progressByWs: Record<string, IndexProgress>;
   hydrated: boolean;
   hydrate: () => void;
+  /**
+   * Pull the current tree for a workspace from main. Self-heal for a missed
+   * `fs:tree-changed` push — the boot-time index can broadcast before this
+   * renderer subscribed, which used to leave the Files panel permanently on its
+   * empty state. Falls back to a fresh index pass when main has no tree yet.
+   */
+  fetchTree: (workspaceId: string) => Promise<void>;
   /** Trigger a fresh index pass for a workspace (progress arrives via events). */
   reindex: (workspaceId: string) => Promise<void>;
   /** Read a workspace-relative file through the guarded main-process reader. */
@@ -79,6 +86,25 @@ export const useFileSystemStore = create<FileSystemState>((set, get) => ({
     api.onTreeChanged((tree) =>
       set((s) => ({ treeByWs: { ...s.treeByWs, [tree.workspaceId]: tree } })),
     );
+  },
+
+  fetchTree: async (workspaceId) => {
+    const api = fsApi();
+    if (!api) return;
+    try {
+      const tree = await api.getTree(workspaceId);
+      if (tree) {
+        set((s) => ({ treeByWs: { ...s.treeByWs, [workspaceId]: tree } }));
+        return;
+      }
+      // Main has no tree for this workspace yet (never indexed, or indexing was
+      // interrupted) — kick a full pass. The result is applied directly AND
+      // arrives via the `fs:tree-changed` push.
+      const indexed = await api.index(workspaceId);
+      set((s) => ({ treeByWs: { ...s.treeByWs, [workspaceId]: indexed } }));
+    } catch {
+      /* non-fatal — the push subscription remains the primary source */
+    }
   },
 
   reindex: async (workspaceId) => {

--- a/src/renderer/stores/useVoiceStore.ts
+++ b/src/renderer/stores/useVoiceStore.ts
@@ -16,6 +16,13 @@ interface VoiceStoreState {
   hydrated: boolean;
   /** Last user-facing error (mic denied, models missing, …). */
   error: string | null;
+  /**
+   * Live analyser of the active mic capture, for the composer Waveform. Held in
+   * the store (not read from `activeCapture()` at render time) because the
+   * capture graph finishes opening AFTER the phase flips to listening — a
+   * non-reactive read would leave the waveform driven by `null` forever.
+   */
+  analyser: AnalyserNode | null;
 
   hydrate: () => Promise<void>;
   startVoice: (sessionId: string, mode: SessionPermissionMode) => Promise<void>;
@@ -48,6 +55,7 @@ export const useVoiceStore = create<VoiceStoreState>((set, get) => ({
   models: [],
   hydrated: false,
   error: null,
+  analyser: null,
 
   hydrate: async () => {
     if (get().hydrated) return;
@@ -62,8 +70,14 @@ export const useVoiceStore = create<VoiceStoreState>((set, get) => ({
 
     api.onState((next) => {
       // The main process ended the capture (VAD auto-stop, error, cancel) —
-      // release the mic as soon as the phase leaves listening/recording.
-      if (!MIC_PHASES.has(next.phase)) stopCapture();
+      // release the mic when the phase LEAVES listening/recording. This is a
+      // transition check on purpose: unrelated broadcasts that are simply not
+      // in a mic phase (`starting` while the worker warms, TTS housekeeping)
+      // must not tear down a mic that is still opening.
+      if (MIC_PHASES.has(get().state.phase) && !MIC_PHASES.has(next.phase)) {
+        stopCapture();
+        set({ analyser: null });
+      }
       set({ state: next, error: next.error ?? get().error });
     });
 
@@ -86,7 +100,9 @@ export const useVoiceStore = create<VoiceStoreState>((set, get) => ({
   startVoice: async (sessionId, mode) => {
     const api = window.limboo?.voice;
     if (!api) return;
-    set({ error: null });
+    // Drop any analyser left over from a previous run so the overlay never
+    // renders levels from a closed audio graph while the new mic opens.
+    set({ error: null, analyser: null });
 
     // Open the mic in parallel with the main-side start so getUserMedia + the
     // AudioWorklet warm up while the worker forks and models load, instead of
@@ -135,7 +151,17 @@ export const useVoiceStore = create<VoiceStoreState>((set, get) => ({
     }
 
     try {
-      await capturePromise;
+      const capture = await capturePromise;
+      const phase = get().state.phase;
+      if (phase === 'starting' || MIC_PHASES.has(phase)) {
+        // Publish the live analyser so the composer Waveform (a store
+        // subscriber) starts rendering real levels the moment the mic opens.
+        set({ analyser: capture.analyser });
+      } else {
+        // The capture ended (cancel/error) while the mic was still opening —
+        // nothing will broadcast another teardown, so release it here.
+        capture.stop();
+      }
     } catch (err) {
       // Mic denied / missing: abandon the main-side capture session too.
       await api.cancel().catch(() => undefined);
@@ -147,12 +173,14 @@ export const useVoiceStore = create<VoiceStoreState>((set, get) => ({
   stopVoice: async () => {
     const api = window.limboo?.voice;
     stopCapture();
+    set({ analyser: null });
     await api?.stop().catch(() => undefined);
   },
 
   cancelVoice: async () => {
     const api = window.limboo?.voice;
     stopCapture();
+    set({ analyser: null });
     await api?.cancel().catch(() => undefined);
   },
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -11,14 +11,34 @@ export const SETTINGS_VERSION = 15;
  */
 export type AgentProvider = 'anthropic' | 'cursor';
 
-/** Selectable agent models (id + short label + provider). */
+/**
+ * Selectable agent models (id + short label + provider). The Anthropic ids are
+ * the current catalog aliases (most capable first) — aliases track the latest
+ * snapshot server-side, so no date suffixes except where the settings default
+ * historically shipped one (Haiku 4.5, kept for persisted-settings compat).
+ */
 export const AGENT_MODELS = [
+  { value: 'claude-fable-5', label: 'Fable 5', provider: 'anthropic' },
   { value: 'claude-opus-4-8', label: 'Opus 4.8', provider: 'anthropic' },
+  { value: 'claude-opus-4-7', label: 'Opus 4.7', provider: 'anthropic' },
+  { value: 'claude-opus-4-6', label: 'Opus 4.6', provider: 'anthropic' },
+  { value: 'claude-opus-4-5', label: 'Opus 4.5', provider: 'anthropic' },
+  { value: 'claude-sonnet-5', label: 'Sonnet 5', provider: 'anthropic' },
   { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6', provider: 'anthropic' },
+  { value: 'claude-sonnet-4-5', label: 'Sonnet 4.5', provider: 'anthropic' },
   { value: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', provider: 'anthropic' },
   { value: 'composer-2', label: 'Composer 2', provider: 'cursor' },
   { value: 'composer-2.5', label: 'Composer 2.5', provider: 'cursor' },
 ] as const;
+
+/**
+ * Charset guard for an Anthropic model id before it reaches the Agent SDK.
+ * Settings normally only ever hold picker values, but the model string is
+ * persisted user data — never trust it verbatim (CLAUDE.md §6 input
+ * validation). Lowercase alphanumerics plus `.-` and a bounded length cover
+ * every published Claude id without hardcoding the catalog.
+ */
+export const ANTHROPIC_MODEL_ID_RE = /^[a-z0-9][a-z0-9.-]{2,63}$/;
 
 /**
  * Cursor model ids discovered at runtime via `cursor-agent models`. Each


### PR DESCRIPTION
<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Voice and agent spawn paths change runtime behavior users rely on; model validation and capture lifecycle fixes are low-risk individually but touch session-critical flows.
> 
> **Overview**
> **Voice capture** no longer drops into a broken “listening with no mic” state: the main process claims `captureSessionId` before async model load and refuses late `tts-done` / `setIdlePhase` from clearing an active capture; the renderer only tears down the mic when voice phase **leaves** listening/recording, publishes the waveform `analyser` via the voice store, and resumes a suspended `AudioContext` on capture open.
> 
> **Agent** Anthropic model strings from settings are charset-validated before SDK spawn (malformed ids fall back to default); the model picker catalog grows with more Claude aliases.
> 
> **UI/UX:** the conversation shows a **live status row** (phase + running tool + elapsed time) beside the thinking shimmer; streaming **markdown** routes open code fences through `CodeBlock` and defers parsing the growing tail; the **Files** panel pulls or indexes a tree when boot-time push was missed; workspace **create** adds **Open an existing folder** and clearer copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 647c9e0fa5e0c250033f782d7ad18ef80f3040e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->