### PR TITLE
fix(agent): Shiki JS-engine highlighting + secret files ask-not-block

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,6 @@
   ],
   "parser": "@typescript-eslint/parser",
   "rules": {
-    "import/no-unresolved": ["error", { "ignore": ["^@/", "^@shared/", "\\?url$", "\\?raw$"] }]
+    "import/no-unresolved": ["error", { "ignore": ["^@/", "^@shared/", "^shiki/", "\\?url$", "\\?raw$"] }]
   }
 }

--- a/src/main/managers/AgentManager.ts
+++ b/src/main/managers/AgentManager.ts
@@ -84,7 +84,7 @@ import { createMcpDispatcher } from './cursor/bridge/toolDispatch';
 import { classifyCursorError, isCursorResumeCorruption } from './cursor/errors';
 import { withSessionHooksJson } from './cursor/hooks';
 import { withSessionMcpJson, type McpBridgeSpec } from './cursor/mcpConfig';
-import { sessionAllowRules, sessionDenyRules, withSessionCliJson } from './cursor/permissions';
+import { sessionAllowRules, sessionAskRules, sessionDenyRules, withSessionCliJson } from './cursor/permissions';
 import { clearHooksVerified, getVerifiedHooksVersion, setHooksVerified } from './cursor/capabilities';
 import { createSessionDir } from './cursor/sessionFile';
 import { executionPostureNote, withSessionContextRule } from './cursor/rules';
@@ -2154,6 +2154,11 @@ export class AgentManager {
       limbooMcp: mcpSpec != null,
       attachmentsStaged: attachmentStaging != null,
     });
+    // Workspace secrets (.env / SSH keys / key-cert material) are ask-for-approval,
+    // not hard-denied: on a hook-verified run the beforeReadFile hook drives the
+    // Limboo prompt (touchesSensitiveFile); `ask` (unlike `deny`) never poisons
+    // other tools on non-hook runs.
+    const askRules = sessionAskRules();
 
     let started = false;
     const runAttempt = async (injectViaRules: boolean): Promise<CursorRunOutcome> => {
@@ -2189,7 +2194,7 @@ export class AgentManager {
       const inner = injectViaRules
         ? (): Promise<CursorRunOutcome> => withSessionContextRule(cwd, ruleBlock, withHooks)
         : withHooks;
-      return withSessionCliJson(cwd, { deny: denyRules, allow: allowRules }, inner);
+      return withSessionCliJson(cwd, { deny: denyRules, allow: allowRules, ask: askRules }, inner);
     };
 
     let outcome: CursorRunOutcome;
@@ -2960,6 +2965,29 @@ export class AgentManager {
         };
       }
 
+      // Sensitive-file guard (both providers): secrets like `.env`, SSH private
+      // keys, and key/cert material are gated behind an explicit human approval
+      // rather than hard-blocked. This sits before the standing auto-approvals so
+      // `autoApproveReads` / `acceptEdits` can never silently allow a secret —
+      // sensitive access always asks (unless "always allow this session" was
+      // chosen). Mirrors the declarative `ask` rules in cursor/permissions.ts.
+      if (touchesSensitiveFile(toolName, input)) {
+        if (this.remembered.has(`${sessionId}:remember`)) {
+          return { behavior: 'allow', updatedInput: input };
+        }
+        const risk = classifyTool(toolName);
+        const request: PermissionRequest = {
+          id: newId(),
+          sessionId,
+          tool: toolName,
+          risk,
+          summary: `${summarizeTool(toolName, input, risk)} — secret file`,
+          detail: permissionDetail(toolName, input),
+          createdAt: Date.now(),
+        };
+        return this.promptForApproval(sessionId, input, request, signal);
+      }
+
       // Limboo's own memory + search tools are internal and strictly read-only —
       // always allow them (even during a plan run) so retrieval never prompts.
       if (
@@ -3047,29 +3075,46 @@ export class AgentManager {
         detail: permissionDetail(toolName, input),
         createdAt: Date.now(),
       };
-      this.pushActivity(sessionId, 'permission', `Asked to ${request.summary}`, undefined, 'warning');
-      this.diag('tool', 'warning', `Approval requested: ${request.summary}`, request.detail, sessionId);
-      this.setLifecycle('awaiting-permission');
-      this.setRequest(sessionId, { phase: 'awaiting-permission' });
-      this.broadcastChannel(IpcEvents.agentPermissionRequest, request);
+      return this.promptForApproval(sessionId, input, request, signal);
+  }
 
-      return new Promise<PermissionResult>((resolve) => {
-        const onAbort = () => {
-          this.pending.delete(request.id);
-          resolve({ behavior: 'deny', message: 'Run stopped.', interrupt: true });
-        };
-        if (signal.aborted) return onAbort();
-        signal.addEventListener('abort', onAbort, { once: true });
-        this.pending.set(request.id, {
-          sessionId,
-          input,
-          request,
-          resolve: (r) => {
-            signal.removeEventListener('abort', onAbort);
-            resolve(r);
-          },
-        });
+  /**
+   * Broadcast a permission request to the renderer and await the user's decision,
+   * resolving to the tool's `PermissionResult`. Shared by the normal permission
+   * fallback and the sensitive-file guard. Honors the run's AbortController so a
+   * stopped run resolves as a deny+interrupt instead of hanging on a pending
+   * prompt. Works for both providers (Claude's canUseTool and the Cursor hook
+   * bridge both await this Promise).
+   */
+  private promptForApproval(
+    sessionId: string,
+    input: Record<string, unknown>,
+    request: PermissionRequest,
+    signal: AbortSignal,
+  ): Promise<PermissionResult> {
+    this.pushActivity(sessionId, 'permission', `Asked to ${request.summary}`, undefined, 'warning');
+    this.diag('tool', 'warning', `Approval requested: ${request.summary}`, request.detail, sessionId);
+    this.setLifecycle('awaiting-permission');
+    this.setRequest(sessionId, { phase: 'awaiting-permission' });
+    this.broadcastChannel(IpcEvents.agentPermissionRequest, request);
+
+    return new Promise<PermissionResult>((resolve) => {
+      const onAbort = () => {
+        this.pending.delete(request.id);
+        resolve({ behavior: 'deny', message: 'Run stopped.', interrupt: true });
+      };
+      if (signal.aborted) return onAbort();
+      signal.addEventListener('abort', onAbort, { once: true });
+      this.pending.set(request.id, {
+        sessionId,
+        input,
+        request,
+        resolve: (r) => {
+          signal.removeEventListener('abort', onAbort);
+          resolve(r);
+        },
       });
+    });
   }
 
   /* ---------------------------------------------------------------- */
@@ -3635,6 +3680,80 @@ function touchesAppData(toolName: string, input: Record<string, unknown>): boole
     if (cmd.includes(root)) return true;
     if (/limboo\.db\b/i.test(cmd)) return true;
     if (/[\\/]limboo[\\/](limboo\.db|settings\.json|window-state\.json)/i.test(cmd)) return true;
+  }
+  return false;
+}
+
+/**
+ * True when a file basename is a secret-bearing file the agent must never touch:
+ * `.env` and its runtime variants (but NOT the non-secret templates
+ * `.env.example` / `.sample` / `.template` / `.dist`), SSH private keys, key/cert
+ * material (`.pem`/`.key`/`.p12`/`.pfx`, but not public `.pub`), and `.netrc`.
+ * Basename-only — path/depth is handled by the callers.
+ */
+const ENV_TEMPLATE_SUFFIX = /^\.env\.(example|sample|template|dist)$/i;
+function isSensitiveBasename(base: string): boolean {
+  const name = base.toLowerCase();
+  if (name === '.env') return true;
+  if (name.startsWith('.env.') && !ENV_TEMPLATE_SUFFIX.test(name)) return true;
+  if (name === '.netrc') return true;
+  if (/^id_(rsa|ed25519|ecdsa|dsa)$/.test(name)) return true;
+  if (/\.(pem|key|p12|pfx)$/.test(name)) return true;
+  return false;
+}
+
+/**
+ * Files that live inside `~/.ssh` but are NOT private keys, so touching them
+ * should not trigger the secret-file prompt (config, host lists, public keys).
+ * Everything else under `~/.ssh` is treated as a private key (they routinely have
+ * arbitrary, extension-less names like `id_work`).
+ */
+function isSshNonSecret(base: string): boolean {
+  const name = base.toLowerCase();
+  return (
+    name === 'config' ||
+    name === 'known_hosts' ||
+    name === 'known_hosts.old' ||
+    name === 'authorized_keys' ||
+    name === 'environment' ||
+    name.endsWith('.pub')
+  );
+}
+
+/**
+ * True when a tool call would touch project-local secrets — a path-bearing tool
+ * resolving to a sensitive basename or anything under the user's `~/.ssh`, or a
+ * `Bash`/command tool whose command string references such a file. Mirrors the
+ * declarative `ask` rules in cursor/permissions.ts; the caller turns a hit into a
+ * human-approval prompt (not a hard block) for BOTH providers — Cursor's
+ * absolute-path glob normalization is unreliable, so this app-level guard is the
+ * dependable catch (defense in depth, like touchesAppData).
+ */
+function touchesSensitiveFile(toolName: string, input: Record<string, unknown>): boolean {
+  const sshDir = path.join(os.homedir(), '.ssh');
+
+  const file = filePathOf(input);
+  if (file) {
+    const base = path.basename(file);
+    if (isSensitiveBasename(base)) return true;
+    // A private key under ~/.ssh (but not config/known_hosts/authorized_keys/*.pub).
+    if (isInside(sshDir, file) && !isSshNonSecret(base)) return true;
+  }
+
+  if (toolName === 'Bash') {
+    const cmd = String(input.command ?? '');
+    if (!cmd) return false;
+    // Whitespace-delimited token whose basename is sensitive (covers `cat .env`,
+    // `cp foo ~/.ssh/id_rsa`, redirections like `> .env.production`).
+    for (const tok of cmd.split(/[\s=]+/)) {
+      const bare = tok.replace(/^['"]|['"]$/g, '').replace(/^~[\\/]/, '');
+      if (!bare) continue;
+      if (isSensitiveBasename(path.basename(bare))) return true;
+      // A private key referenced under a .ssh directory — `.ssh/config`,
+      // `.ssh/known_hosts` and `.ssh/*.pub` are explicitly not secrets.
+      const ssh = bare.match(/(?:^|[\\/])\.ssh[\\/]([^\\/]+)$/);
+      if (ssh && !isSshNonSecret(ssh[1])) return true;
+    }
   }
   return false;
 }

--- a/src/main/managers/cursor/permissions.ts
+++ b/src/main/managers/cursor/permissions.ts
@@ -20,12 +20,24 @@ function globEscape(p: string): string {
 }
 
 /**
+ * Turn an OS-absolute path into a Cursor *absolute* rule path. Cursor's grammar
+ * treats a single leading `/` as **project-relative** and a double `//` as
+ * **absolute**; without this an absolute userData deny like `Read(/home/.../x)`
+ * is silently reinterpreted against the workspace and never matches. We
+ * glob-escape first, then guarantee exactly one extra leading slash.
+ */
+function absRulePath(p: string): string {
+  const escaped = globEscape(p);
+  return escaped.startsWith('/') ? `/${escaped}` : `//${escaped}`;
+}
+
+/**
  * The minimal deny-first rule set for any Cursor run. Mirrors the app-data
  * guard the Claude path enforces in canUseTool (touchesAppData) plus
  * repo-integrity, self-gate, and destructive-shell basics.
  */
 export function sessionDenyRules(userDataPath: string): string[] {
-  const userData = globEscape(userDataPath);
+  const userData = absRulePath(userDataPath);
   return [
     // Repo integrity: never let a force run rewrite git internals or its own gates.
     'Write(.git/**)',
@@ -37,8 +49,16 @@ export function sessionDenyRules(userDataPath: string): string[] {
     'Write(.limboo/**)',
     'Write(**/.limboo/**)',
     // App data: Limboo's own database/settings/secrets are never a tool target.
+    // Absolute rule path (`//…`) — a single leading slash would be read as
+    // project-relative and never match (see absRulePath).
     `Read(${userData}/**)`,
     `Write(${userData}/**)`,
+    // Named belt-and-suspenders denies for the two the design note calls out by
+    // name (both already inside the userData tree above, but explicit here).
+    // Limboo's own app data stays HARD-denied — the memory tools are the only
+    // sanctioned path in; workspace secrets (below) are ask-for-approval instead.
+    `Read(${userData}/secrets/**)`,
+    `Read(${userData}/limboo.db)`,
     // Destructive-shell basics (deny-first; everything else rides --force).
     'Shell(rm)',
     'Shell(rmdir)',
@@ -61,6 +81,48 @@ export function sessionDenyRules(userDataPath: string): string[] {
     'Shell(rg:*--pre*)',
     'Shell(rg:*--hostname-bin*)',
     'Shell(gh:*--web*)',
+  ];
+}
+
+/**
+ * Workspace secrets the agent may only touch with the user's approval. These go
+ * in the cli.json `ask` list (NOT `deny`): on a hook-verified run the
+ * `beforeReadFile`/`preToolUse` hook drives Limboo's own approval prompt, and on
+ * a non-hook run `ask` (unlike `deny`) neither hard-blocks the file nor poisons
+ * other tools. The live `touchesSensitiveFile` guard in AgentManager mirrors this
+ * as an approval prompt for both providers. Covers `.env` secret variants (the
+ * non-secret templates .env.example/.sample/.template/.dist stay untouched), SSH
+ * private keys, key/cert material, and netrc. Bare names match at any depth; `~/`
+ * is the home dir.
+ */
+export function sessionAskRules(): string[] {
+  return [
+    'Read(.env)',
+    'Read(.env.local)',
+    'Read(.env.*.local)',
+    'Read(.env.production*)',
+    'Read(.env.development*)',
+    'Read(.env.staging*)',
+    'Read(.env.test*)',
+    'Write(.env)',
+    'Write(.env.local)',
+    'Write(.env.*.local)',
+    'Write(.env.production*)',
+    'Write(.env.development*)',
+    'Write(.env.staging*)',
+    'Write(.env.test*)',
+    'Read(~/.ssh/**)',
+    'Write(~/.ssh/**)',
+    'Read(**/id_rsa)',
+    'Read(**/id_ed25519)',
+    'Read(**/id_ecdsa)',
+    'Read(**/id_dsa)',
+    'Read(**/*.pem)',
+    'Read(**/*.key)',
+    'Read(**/*.p12)',
+    'Read(**/*.pfx)',
+    'Read(~/.netrc)',
+    'Read(**/.netrc)',
   ];
 }
 
@@ -102,6 +164,9 @@ export function readOnlyShellAllowRules(): string[] {
 export function sessionAllowRules(posture: CursorAllowPosture): string[] {
   const rules: string[] = [];
   if (posture.autoApproveReads) {
+    // Worktree confinement comes from `--workspace <root>` + cwd, not from the
+    // read glob — so this is the proven bare `Read(**)` (a `Read(/**)` variant
+    // hinges on Cursor's single-slash grammar and can break read auto-approval).
     rules.push('Read(**)');
     // Same trust boundary as Read(**): provably read-only inspection shells.
     // Plan/ask runs keep these too — the provider already enforces read-only
@@ -128,7 +193,7 @@ export function sessionAllowRules(posture: CursorAllowPosture): string[] {
  */
 export async function withSessionCliJson<T>(
   root: string,
-  rules: { deny: string[]; allow?: string[] },
+  rules: { deny: string[]; allow?: string[]; ask?: string[] },
   fn: () => Promise<T>,
 ): Promise<T> {
   return withSessionFile(
@@ -142,7 +207,7 @@ export async function withSessionCliJson<T>(
 /** Merge our rules into a (possibly repo-authored) config, defensively. */
 function mergeConfig(
   originalBytes: Buffer | null,
-  rules: { deny: string[]; allow?: string[] },
+  rules: { deny: string[]; allow?: string[]; ask?: string[] },
 ): Record<string, unknown> {
   const original = safeParseObject(originalBytes);
   const out = copySafeKeys(original, new Set(['permissions']));
@@ -153,9 +218,11 @@ function mergeConfig(
       : {};
   const allow = Array.isArray(perms.allow) ? perms.allow.filter((r) => typeof r === 'string') : [];
   const deny = Array.isArray(perms.deny) ? perms.deny.filter((r) => typeof r === 'string') : [];
+  const ask = Array.isArray(perms.ask) ? perms.ask.filter((r) => typeof r === 'string') : [];
   out.permissions = {
     allow: [...new Set([...allow, ...(rules.allow ?? [])])],
     deny: [...new Set([...deny, ...rules.deny])],
+    ask: [...new Set([...ask, ...(rules.ask ?? [])])],
   };
   return out;
 }

--- a/src/renderer/lib/highlight.ts
+++ b/src/renderer/lib/highlight.ts
@@ -1,28 +1,59 @@
 /**
- * Thin wrapper over Shiki's singleton highlighter. `codeToHtml` lazily loads the
- * requested language + the bundled dark theme on demand and caches them, so we
- * never bundle every grammar eagerly. Returns themed HTML (one `<span class=
- * "line">` per line, which the CSS turns into gutter line numbers) or `null`
- * when the language is unknown — callers fall back to plain text.
+ * Thin wrapper over a cached Shiki highlighter. We build the highlighter on
+ * Shiki's **JavaScript RegExp engine** (`shiki/engine/javascript`) rather than
+ * the default WASM Oniguruma engine: the production CSP is `script-src 'self'
+ * blob:` (no `unsafe-eval`, no `wasm-unsafe-eval`), so WASM instantiation is
+ * blocked and the WASM engine silently fails — leaving code blocks unhighlighted
+ * in packaged builds. The JS engine needs neither WASM nor `unsafe-eval`, so it
+ * works under the strict CSP. Languages are loaded lazily on first use and cached.
+ *
+ * Returns themed HTML (one `<span class="line">` per line, which the CSS turns
+ * into gutter line numbers) or `null` when highlighting fails entirely — callers
+ * fall back to plain text.
  */
-import { codeToHtml } from 'shiki';
+import { createHighlighter, type Highlighter } from 'shiki';
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
 
 /** Tuned to read well on the pure-black surface. */
 const THEME = 'github-dark-default';
 
-export async function highlightCode(code: string, lang?: string): Promise<string | null> {
-  const language = (lang || '').toLowerCase().trim();
-  try {
-    return await codeToHtml(code, {
-      lang: language || 'text',
-      theme: THEME,
+let highlighterPromise: Promise<Highlighter> | null = null;
+const loadedLangs = new Set<string>();
+
+/** Lazily create the singleton highlighter (JS engine, no WASM). */
+function getHighlighter(): Promise<Highlighter> {
+  if (!highlighterPromise) {
+    highlighterPromise = createHighlighter({
+      themes: [THEME],
+      langs: [],
+      engine: createJavaScriptRegexEngine(),
     });
+  }
+  return highlighterPromise;
+}
+
+/** Ensure `lang` is loaded; return the usable language id (falls back to text). */
+async function ensureLang(hl: Highlighter, lang: string): Promise<string> {
+  if (!lang || lang === 'text') return 'text';
+  if (loadedLangs.has(lang)) return lang;
+  try {
+    await hl.loadLanguage(lang as Parameters<Highlighter['loadLanguage']>[0]);
+    loadedLangs.add(lang);
+    return lang;
   } catch {
-    // Unknown grammar — render as uncolored plaintext upstream.
-    try {
-      return await codeToHtml(code, { lang: 'text', theme: THEME });
-    } catch {
-      return null;
-    }
+    // Unknown/unsupported grammar — render as uncolored plaintext.
+    return 'text';
+  }
+}
+
+export async function highlightCode(code: string, lang?: string): Promise<string | null> {
+  const requested = (lang || '').toLowerCase().trim();
+  try {
+    const hl = await getHighlighter();
+    const language = await ensureLang(hl, requested);
+    return hl.codeToHtml(code, { lang: language, theme: THEME });
+  } catch {
+    // Total failure (engine/theme) — let the caller show plain text.
+    return null;
   }
 }


### PR DESCRIPTION
Three related fixes to the agent workspace:

1. Code blocks in the LLM stream render unhighlighted in packaged builds. lib/highlight.ts used Shiki's default WASM Oniguruma engine, which the production CSP (script-src 'self' blob:, no wasm-unsafe-eval) blocks — highlightCode threw and returned null, falling back to plain <pre>. Switch to Shiki's JavaScript RegExp engine (shiki/engine/javascript) via a cached singleton highlighter with lazy per-language loading. No WASM, no unsafe-eval, CSP-safe. UI/CSS/streaming contract unchanged.

2. Cursor tools were being over-denied. Revert the read-approval rule from the unverified Read(/**) back to the proven Read(**) (worktree confinement comes from --workspace, not the read glob), and stop the sensitive-file guard from hard-blocking legitimate commands. Tighten the .ssh matching so config, known_hosts, authorized_keys and *.pub no longer trip it (only private keys do).

3. Secret files now ask for human approval instead of being hard-blocked. The live touchesSensitiveFile guard issues an approval prompt (via a new extracted promptForApproval helper reused by the normal fallback), for both Claude and Cursor. The declarative Cursor layer moves the secret patterns from cli.json `deny` into a new `ask` list (sessionAskRules, threaded through withSessionCliJson/mergeConfig). Limboo's own app data (limboo.db, userData, secrets store) and git-integrity/destructive-shell rules stay hard-denied.

eslintrc: add ^shiki/ to import/no-unresolved ignore (ESLint 8's resolver can't follow Shiki's exports subpath; Vite resolves it fine).

Verified: npm run lint clean; renderer build + main esbuild bundle pass; Shiki JS-engine output produces colored spans; sensitive-file/Bash-scan logic covered by targeted tests.

<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent permission gating for secrets and Cursor cli.json rules—security-sensitive but aligned with explicit user approval rather than silent allow; Shiki engine swap is renderer-only with low blast radius.
> 
> **Overview**
> Fixes **unhighlighted code blocks in packaged builds** by switching `highlight.ts` from Shiki’s default WASM Oniguruma engine to the **JavaScript RegExp engine** (`shiki/engine/javascript`), with a cached singleton highlighter and lazy per-language loading so highlighting works under the strict production CSP. ESLint ignores `^shiki/` subpath imports.
> 
> **Secret files** (`.env` variants, SSH private keys, cert material, `.netrc`) are no longer hard-blocked: **`decideToolUse`** now runs a `touchesSensitiveFile` guard that always prompts for approval (before auto-read/auto-approve), with tighter `~/.ssh` handling so `config`, `known_hosts`, and `*.pub` are not treated as secrets. Permission UI flow is centralized in **`promptForApproval`**.
> 
> On **Cursor**, workspace secrets move from deny into a new **`sessionAskRules`** `ask` list merged through `withSessionCliJson`; **`absRulePath`** fixes absolute `userData` deny rules, and read auto-approval stays on proven **`Read(**)`** instead of `Read(/**)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dbb9f1e5dfd663ec3bac1edd08879af6e4c84a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Permissions**
  * Added approval prompts when accessing sensitive files such as environment files, SSH keys, certificates, and network credentials.
  * Strengthened protection for sensitive user data and application files.

* **Bug Fixes**
  * Improved permission handling for absolute paths.
  * Improved code highlighting reliability in packaged builds, with graceful fallback to plain text when highlighting fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->