### PR TITLE
fix(build): pin linux.executableName so Linux packages can launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,21 @@ All notable changes to Limboo are documented here. The format is based on
   roughly Electron 29's ABI, so it didn't actually fix the problem; superseded
   by this change.) See [installation](docs/getting-started/installation.md).
 
+## [1.5.1] - 2026-07-25
+
+### Fixed
+
+- **Linux packages could not launch.** `electron-builder.yml` set no
+  `linux.executableName`, so electron-builder derived every Linux launcher path
+  from the package name (`limboo`, lowercase) while Electron Forge — which owns
+  packaging and hands the result over via `--prepackaged` — produced the binary
+  as `Limboo`. On a case-sensitive filesystem that mismatch broke all three
+  Linux artifacts in v1.5.0: the AppImage's `AppRun` exec'd a non-existent
+  `limboo` and failed to start at all, and the deb/rpm shipped a
+  `.desktop` entry pointing at `/opt/Limboo/limboo` plus a dangling
+  `/usr/bin/limboo` symlink. Windows and macOS were unaffected. The application
+  itself was never broken — only the launchers around it.
+
 ## [1.5.0] - 2026-07-25
 
 Restores boot after a regression that made the app unlaunchable, and adds

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -102,6 +102,14 @@ linux:
   category: Development
   icon: assets/icon.png
   synopsis: The operating system for AI software development
+  # MUST match the binary Forge produces (packagerConfig.name = 'Limboo'), which
+  # `--prepackaged` hands over as-is. electron-builder does NOT read that name:
+  # it defaults executableName to package.json `name` ('limboo', lowercase) and
+  # writes every Linux launcher path from it. Without this, v1.5.0 shipped an
+  # AppRun that exec'd a non-existent `limboo` (the AppImage could not start at
+  # all), a .desktop `Exec=/opt/Limboo/limboo`, and a dangling
+  # /usr/bin/limboo symlink. Case matters on Linux — keep these two in sync.
+  executableName: Limboo
   target:
     - AppImage
     - deb


### PR DESCRIPTION
## Summary

**Every Linux artifact in v1.5.0 is unlaunchable.** Forge owns packaging and emits the binary as `Limboo` (`packagerConfig.name`), which electron-builder consumes as-is through `--prepackaged`. But builder never reads that name — with no `linux.executableName` it falls back to package.json `name` (`limboo`, lowercase) and writes every Linux launcher path from it. Case matters on Linux:

```
AppRun:   BIN="$APPDIR/limboo"                    -> no such file; AppImage never starts
desktop:  Exec=/opt/Limboo/limboo                 -> dangling
postinst: /usr/bin/limboo -> /opt/Limboo/limboo   -> dangling symlink
```

Windows (NSIS, `${productName}.exe`) and macOS (`.app` bundle) resolve through `productName` and were unaffected.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [x] Build / CI / tooling

## Architectural reasoning

One line plus a comment in `electron-builder.yml`'s `linux:` block. The comment states the invariant explicitly — this value must track Forge's `packagerConfig.name`, because the two tools have no shared source for it and nothing else fails loudly when they drift.

## Verification

- [x] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes <!-- n/a — packaging config only -->
- [x] App still starts with `npm start`
- [x] Manual testing steps described below

Diagnosed against the **published v1.5.0 artifacts**, not a local build:

1. `./Limboo-1.5.0.AppImage` → `AppRun: /tmp/.mount_*/limboo: No such file or directory`.
2. `--appimage-extract` shows the binary is `Limboo`; `AppRun` line 30 is `BIN="$APPDIR/limboo"`.
3. `ar x limboo_1.5.0_amd64.deb` → binary at `./opt/Limboo/Limboo`, `.desktop` says `Exec=/opt/Limboo/limboo`, `postinst` symlinks `/usr/bin/limboo` → `/opt/Limboo/limboo`.
4. Running the extracted `./Limboo` directly with a fresh `--user-data-dir` boots correctly — `DB migration: added sessions.tags`, `SQLite opened`, `Limboo main process ready`. The app was never broken; only the launchers around it.

Final verification happens on the v1.5.1 artifacts: download the AppImage from the release and launch it unextracted.

## Security checklist (if touching main process)

- [x] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown <!-- packaging metadata only -->

## Documentation and changelog

- [x] Added a `CHANGELOG.md` entry (if user-facing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)