### PR TITLE
chore(release): prepare v1.6.0

### DIFF
--- a/.github/workflows/release-supplement.yml
+++ b/.github/workflows/release-supplement.yml
@@ -15,8 +15,13 @@ name: Release supplement (extra architectures)
 #                        binaries inside an arm64-labelled package)
 #   windows-11-arm    -> Windows arm64
 #
-# Flow: wait for GitLab's release to exist -> build the extra arches -> MERGE the
-# update feeds with the ones already on the release -> upload with --clobber.
+# Flow: wait for the release to exist -> skip if those arches are already there
+# -> build them -> MERGE the update feeds with the ones already on the release ->
+# upload with --clobber.
+#
+# The skip matters: release.yml (the manual fallback) builds the complete matrix
+# itself, so when IT published the release there is nothing to supplement and a
+# rebuild would just burn runners re-uploading identical files.
 #
 # The feed merge is the load-bearing step. Each runner writes a `latest*.yml`
 # describing only its own artifacts, so uploading this workflow's
@@ -44,12 +49,13 @@ jobs:
       contents: read
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
+      needed: ${{ steps.assets.outputs.needed }}
     steps:
       - name: Resolve tag
         id: resolve
         run: echo "tag=${{ inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
 
-      - name: Wait for GitLab to publish the release
+      - name: Wait for the release to be published
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.resolve.outputs.tag }}
@@ -70,9 +76,35 @@ jobs:
           echo "::error::Release $TAG was not published within 60 minutes. Re-run this workflow manually once it exists."
           exit 1
 
+      - name: Check whether the extra architectures are already published
+        id: assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        # release.yml (the manual fallback) builds the COMPLETE matrix on its own,
+        # including these three. When it published the release there is nothing
+        # left to supplement, and rebuilding would burn ~30 minutes of runners to
+        # re-upload identical files. Detect that and skip.
+        run: |
+          set -euo pipefail
+          assets=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')
+          echo "$assets"
+          missing=0
+          # One representative artifact per architecture this workflow exists to add.
+          grep -qiE 'x64\.dmg$'                  <<<"$assets" || { echo "missing: macOS x64";     missing=1; }
+          grep -qiE 'arm64\.(AppImage|deb|rpm)$' <<<"$assets" || { echo "missing: Linux arm64";   missing=1; }
+          grep -qiE 'arm64\.exe$'                <<<"$assets" || { echo "missing: Windows arm64"; missing=1; }
+          if [ "$missing" -eq 0 ]; then
+            echo "All supplementary architectures are already on the release — nothing to do."
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          fi
+
   package:
     name: Package extra architectures
     needs: [wait-for-release]
+    if: needs.wait-for-release.outputs.needed == 'true'
     uses: ./.github/workflows/_package.yml
     permissions:
       contents: read
@@ -86,6 +118,7 @@ jobs:
   upload:
     name: Merge feeds and upload
     needs: [wait-for-release, package]
+    if: needs.wait-for-release.outputs.needed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write   # upload assets onto the existing release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to Limboo are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-07-25
+
+Repairs in-app updating, which has never worked on macOS and could fail to
+install or restart anywhere; adds code signing and a Microsoft Store channel;
+and extends the release to every architecture, including Arch/Manjaro packages
+and arm64 builds for all three platforms.
+
 ### Fixed
 
 - **"Restart & install" did nothing.** Clicking it could leave the app running on
@@ -231,7 +238,8 @@ operational.
 - **Unified streaming timeline** — the conversation rendered as one continuous,
   turn-grouped event stream of messages, tool calls, and status markers.
 
-[Unreleased]: https://github.com/limboo-ai/limboo/compare/v1.5.1...HEAD
+[Unreleased]: https://github.com/limboo-ai/limboo/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/limboo-ai/limboo/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/limboo-ai/limboo/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/limboo-ai/limboo/compare/v1.0.0...v1.5.0
 [1.0.0]: https://github.com/limboo-ai/limboo/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ for contributors: [`CLAUDE.md`](CLAUDE.md) (the code-level working contract) and
 
 ## Project status
 
-**Current release: `v1.5.1`.** The desktop foundation and the platform services are
+**Current release: `v1.6.0`.** The desktop foundation and the platform services are
 built and in daily use: workspaces, sessions with per-session git worktrees, the git
 engine, the integrated terminal, the File System Layer, multi-agent orchestration
 (Claude and Cursor), the Local Memory System, the Search Engine, the Resume Pipeline,


### PR DESCRIPTION
Release prep for **v1.6.0**.

- Promotes `[Unreleased]` to `[1.6.0]` with a summary line and compare links.
- Updates the README's current-release line.
- **Guards `release-supplement.yml` against a duplicate build.** It triggers on
  the same `v*` tag as the primary publisher, but `release.yml` (the manual
  fallback) builds the *complete* matrix itself — macOS x64, Linux arm64 and
  Windows arm64 included. So whenever the fallback publishes a release, the
  supplement had nothing to add and would still burn ~30 minutes of runners
  rebuilding and re-uploading identical artifacts. It now inspects the release's
  assets first and skips when every supplementary architecture is already there.

No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
