### PR TITLE
fix(ci): install bsdtar for the pacman target, and stop claiming builds are signed

### DIFF
--- a/.github/workflows/_package.yml
+++ b/.github/workflows/_package.yml
@@ -58,8 +58,10 @@ jobs:
 
       - name: Install Linux packaging dependencies
         if: runner.os == 'Linux'
-        # rpm/dpkg + native module toolchain; electron-builder builds deb/rpm/AppImage.
-        run: sudo apt-get update && sudo apt-get install -y build-essential python3 rpm fakeroot dpkg
+        # rpm/dpkg + native module toolchain for deb/rpm/AppImage, plus
+        # libarchive-tools for bsdtar — fpm shells out to it when building the
+        # pacman target and fails late with a bare exit code 127 without it.
+        run: sudo apt-get update && sudo apt-get install -y build-essential python3 rpm fakeroot dpkg libarchive-tools
 
       - name: Install dependencies
         run: npm ci

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -147,7 +147,9 @@ package:linux:
     - if: $CI_COMMIT_TAG
     - if: $CI_PIPELINE_SOURCE == "web"   # manual dry-run from the UI
   before_script:
-    - apt-get update && apt-get install -y build-essential python3 rpm fakeroot dpkg
+    # libarchive-tools provides bsdtar, which fpm shells out to when building the
+    # pacman target — without it the build fails late with a bare exit code 127.
+    - apt-get update && apt-get install -y build-essential python3 rpm fakeroot dpkg libarchive-tools
     - npm ci --cache .npm --prefer-offline
   script:
     # Stamp the tag version into package.json before building the installers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,13 +62,14 @@ and arm64 builds for all three platforms.
 
 ### Added
 
-- **Code signing.** macOS builds are signed with a Developer ID certificate and
-  notarized (hardened runtime + entitlements), which is also what makes macOS
-  auto-update possible at all — Squirrel.Mac refuses to update an app it cannot
-  verify. Windows installers are signed with a self-signed certificate; this does
-  **not** remove the SmartScreen warning, and is documented as such. Azure Trusted
-  Signing is wired and dormant. All of it is opt-in via environment secrets
-  (`scripts/signing.cjs`), so unsigned dev and PR builds are unchanged.
+- **A code-signing pipeline.** Developer ID signing + notarization for macOS
+  (hardened runtime + entitlements) — which is also what makes macOS auto-update
+  possible at all, since Squirrel.Mac refuses to update an app it cannot verify —
+  and Authenticode for Windows, with Azure Trusted Signing wired and dormant
+  beside a self-signed route. Note that a self-signed certificate does **not**
+  remove the SmartScreen warning; it is documented as such. The whole path is
+  opt-in from environment credentials (`scripts/signing.cjs`), so builds without
+  them — **including this release** — are unsigned and behave exactly as before.
   Because signing runs in Forge rather than electron-builder — `--prepackaged`
   skips the pack step where electron-builder would sign — the split is documented
   in [code signing](docs/ci/code-signing.md).

--- a/README.md
+++ b/README.md
@@ -80,23 +80,35 @@ package manager and will ask for your password.
 > `dlopen(): error loading libfuse.so.2`. It installs alongside FUSE 3 without
 > replacing it.
 
-### What your OS will say about these builds
+### These builds are unsigned — here's what you'll see
 
-Signing status differs per platform, and the differences are worth knowing before
-you assume a download is broken.
+The signing pipeline is implemented (Developer ID + notarization for macOS,
+Authenticode for Windows, plus a Microsoft Store channel), but it is opt-in from
+credentials that are not yet configured — so published builds are currently
+unsigned and your OS will warn you. This is expected, not a broken download:
 
-- **macOS — signed and notarized.** Builds are signed with a Developer ID
-  certificate and notarized by Apple, so Gatekeeper opens them normally. (If you
-  are on a build from **v1.5.1 or earlier**, those were unsigned; see the note
-  below.)
-- **Windows — SmartScreen still warns.** The installer carries a signature, but
-  from a self-signed certificate that is not in Windows' trust store, so
-  SmartScreen still shows "Windows protected your PC." Choose **More info → Run
-  anyway**. A chain-trusted certificate is the only thing that removes this
-  prompt, and the Microsoft Store listing is the warning-free route once it is
-  live.
-- **Linux — no code signing exists** for these formats. Integrity comes from the
-  checksum manifest and build provenance below.
+- **Windows** — SmartScreen says "Windows protected your PC." Choose
+  **More info → Run anyway**.
+- **macOS** — Gatekeeper refuses an app from an unidentified developer.
+  Right-click the app → **Open**, or clear the quarantine flag:
+
+  ```bash
+  xattr -dr com.apple.quarantine /Applications/Limboo.app
+  ```
+
+  Being unsigned also means **macOS cannot auto-update**: Squirrel.Mac refuses to
+  update an app whose signature it cannot verify. Limboo detects this and says so
+  in Settings → Updates rather than offering a button that fails. Windows and
+  Linux self-update normally.
+- **Linux** — no code-signing mechanism exists for these formats. Integrity comes
+  from the checksum manifest and build provenance below.
+
+What each route buys once enabled, so the trade-offs are clear up front: a macOS
+Developer ID removes the Gatekeeper prompt *and* switches macOS auto-update on; a
+self-signed Windows certificate does **not** remove the SmartScreen warning (it
+chains to no trusted root) and only provides a stable publisher identity; the
+Microsoft Store is the warning-free Windows route that needs no certificate at
+all. See [code signing](docs/ci/code-signing.md).
 
 Rather than ask you to take any of that on trust, every artifact ships with a
 checksum manifest and a build-provenance attestation recorded in a public
@@ -411,10 +423,10 @@ SQLite.
 
 Being honest about the rough edges, because you will meet them:
 
-- **Windows installers trip SmartScreen.** They are signed, but with a
-  self-signed certificate that Windows does not trust, so the warning stays until
-  a chain-trusted certificate (or the Microsoft Store listing) lands. macOS is
-  signed and notarized; Linux formats have no signing mechanism to use. See
+- **Published builds are unsigned.** The signing pipeline exists but its
+  credentials are not yet configured, so expect SmartScreen and Gatekeeper
+  warnings — and note that macOS cannot auto-update while unsigned, because
+  Squirrel.Mac refuses to update an app it cannot verify. See
   [Download](#download).
 - **Cursor's default mode is propose-only.** Until the interactive hooks bridge is
   verified for your exact CLI build, proposed edits surface as a reviewable plan you

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -116,7 +116,8 @@ definitions:
         size: 2x   # Electron packaging needs the larger memory allowance
         caches: [npm]
         script:
-          - apt-get update && apt-get install -y build-essential python3 rpm fakeroot dpkg
+          # libarchive-tools provides bsdtar, required by fpm for the pacman target.
+          - apt-get update && apt-get install -y build-essential python3 rpm fakeroot dpkg libarchive-tools
           - npm ci --cache .npm --prefer-offline
           # Stamp the tag version into package.json before building the installers.
           - node ci/scripts/apply-tag-version.mjs

--- a/ci/scripts/generate-release-notes.mjs
+++ b/ci/scripts/generate-release-notes.mjs
@@ -125,8 +125,8 @@ function main() {
   out.push(
     '| Platform | File | Notes |',
     '| --- | --- | --- |',
-    '| Windows x64 / arm64 | `Limboo-Setup-*-<arch>.exe` | Signed, but with a self-signed certificate — SmartScreen still warns. Choose **More info → Run anyway**. |',
-    '| macOS Apple silicon / Intel | `Limboo-*-arm64.dmg` / `Limboo-*-x64.dmg` | Signed and notarized; Gatekeeper opens it normally. |',
+    '| Windows x64 / arm64 | `Limboo-Setup-*-<arch>.exe` | If SmartScreen warns, choose **More info → Run anyway**. |',
+    '| macOS Apple silicon / Intel | `Limboo-*-arm64.dmg` / `Limboo-*-x64.dmg` | If Gatekeeper blocks it, right-click → **Open**, or `xattr -dr com.apple.quarantine /Applications/Limboo.app`. |',
     '| Debian / Ubuntu | `limboo-*-<arch>.deb` | |',
     '| Fedora / RHEL / openSUSE | `limboo-*-<arch>.rpm` | |',
     '| Arch / Manjaro | `limboo-*-<arch>.pacman` | `sudo pacman -U <file>` |',


### PR DESCRIPTION
Two blockers found while cutting v1.6.0. Both surfaced from the real release
build rather than from review.

## 1. The pacman target could not build

The v1.6.0 release build failed on **both** Linux runners (x64 and arm64).
`fpm`'s pacman builder shells out to `bsdtar` to write the package's `.MTREE`,
and it is not present on the GitHub or GitLab Linux images:

```
Process failed: /bin/bash failed (exit code 127). Full command was:
["/bin/bash", "-c", "LANG=C bsdtar -czf .MTREE --format=mtree ... usr opt .PKGINFO .INSTALL"]
```

Exit 127 is "command not found". It surfaced ~7 minutes in, and only after
AppImage, deb and rpm had all succeeded — so the `pacman` target went out in #80
with its build dependency missing. `bsdtar` ships in `libarchive-tools` on
Debian/Ubuntu; added to all three providers' Linux dependency installs.

macOS (Apple silicon **and** Intel) and Windows (x64 **and** arm64) all built
cleanly in that same run, so the new architecture matrix itself is sound. The
publish job was skipped, so no broken release reached users.

[Failed run](https://github.com/limboo-ai/limboo/actions/runs/30146891554)

## 2. The docs claimed builds are signed. They are not.

The signing pipeline landed in #80, but it is opt-in from credentials that are
not configured on this repository. The v1.6.0 build logs are unambiguous:

```
[dist] macOS: unsigned (no CSC_LINK)
[dist] Windows: unsigned (no certificate configured)
```

The README, CHANGELOG and release-notes generator nevertheless stated "signed and
notarized" and "signed with a self-signed certificate" as fact. They now describe
the pipeline as implemented-but-not-enabled and say plainly that published builds
are unsigned.

This is not cosmetic on macOS. **Unsigned means Squirrel.Mac will not apply an
update**, so macOS auto-update remains unavailable until a Developer ID
certificate is configured — fixing the archive layout in #80 was necessary but
not sufficient. The README now says so where users will actually look, and the
app already reports it in Settings → Updates with a reason.

The generator's install table no longer asserts any signing state, since it runs
on every release regardless of whether credentials are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
