### PR TITLE
fix(ci): make the release gates actually verify (macOS layout + checksum manifest)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,12 @@ jobs:
               latest*.yml) continue ;;
               builder-debug.yml|builder-effective-config.yaml) continue ;;
               SHA256SUMS) continue ;;
+              # anchore/sbom-action writes this alongside the SBOM we asked for,
+              # and it is NOT in the release upload globs below. Left in place it
+              # lands in SHA256SUMS without ever being published, so
+              # `sha256sum -c SHA256SUMS` fails on a file the user cannot
+              # download — breaking the very command the release notes give them.
+              *.cyclonedx.json) continue ;;
             esac
             cp -n "$file" dist/
           done

--- a/ci/scripts/verify-artifacts.mjs
+++ b/ci/scripts/verify-artifacts.mjs
@@ -28,6 +28,7 @@
  *
  * Usage: node ci/scripts/verify-artifacts.mjs [artifactDir=dist] [--publish-set]
  */
+import { readFileSync } from 'node:fs';
 import { open, readdir, readFile, stat } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 
@@ -75,12 +76,46 @@ async function firstZipEntry(file) {
   }
 }
 
+/**
+ * Which files are macOS update zips?
+ *
+ * Derived from `latest-mac.yml` rather than from the filename, because the
+ * filename is exactly the wrong thing to trust here: this check once keyed on a
+ * `-mac.zip` suffix, the artifact naming changed to `-<arch>.zip`, and the most
+ * important gate in this script silently reported "nothing to check" on a real
+ * release. The update feed is authoritative — those entries are, by definition,
+ * the archives Squirrel.Mac will be handed.
+ */
+function macZipsFromFeed(files) {
+  const feed = files.find((f) => basename(f).toLowerCase() === 'latest-mac.yml');
+  if (!feed) return { feedPresent: false, zips: [] };
+  const listed = new Set();
+  for (const line of readFileSync(feed, 'utf8').split(/\r?\n/)) {
+    const match = line.match(/^\s*-\s+url:\s*(.+?)\s*$/);
+    if (match && match[1].toLowerCase().endsWith('.zip')) listed.add(basename(match[1]));
+  }
+  return { feedPresent: true, zips: files.filter((f) => listed.has(basename(f))) };
+}
+
 async function checkMacZips(files) {
-  const macZips = files.filter((f) => /-mac(-[a-z0-9]+)?\.zip$/i.test(basename(f)));
+  const { feedPresent, zips: macZips } = macZipsFromFeed(files);
+
   if (macZips.length === 0) {
-    note('no macOS update zips in this build — skipping the Squirrel.Mac layout check');
+    if (feedPresent) {
+      // A macOS update feed with no checkable zip beside it is not a "nothing to
+      // do" case — either the feed lists no zip (Squirrel.Mac has nothing to
+      // install) or the artifacts are missing from the publish set.
+      fail(
+        'latest-mac.yml is present but no macOS update zip could be matched to it. ' +
+          'Squirrel.Mac needs a zip listed in that feed; check the mac targets in ' +
+          'electron-builder.yml and that the zip reached this directory.',
+      );
+      return;
+    }
+    note('no macOS update feed in this build — Squirrel.Mac layout check not applicable');
     return;
   }
+
   for (const zip of macZips) {
     const entry = await firstZipEntry(zip);
     if (!entry) {

--- a/ci/scripts/verify-artifacts.mjs
+++ b/ci/scripts/verify-artifacts.mjs
@@ -212,6 +212,33 @@ async function checkFeeds(dir, files) {
 /* 4. Debug output                                                     */
 /* ------------------------------------------------------------------ */
 
+/**
+ * `SHA256SUMS` must describe exactly what is published — no more.
+ *
+ * A manifest listing a file the user cannot download makes `sha256sum -c
+ * SHA256SUMS` exit non-zero on a perfectly good release, which discredits the
+ * one verification command the README and release notes hand people. v1.6.0
+ * shipped with a stray `limboo-package.cyclonedx.json` entry for exactly this
+ * reason: a build side-file that was checksummed but never uploaded.
+ */
+async function checkChecksumManifest(dir, files) {
+  const manifest = files.find((f) => basename(f) === 'SHA256SUMS');
+  if (!manifest) return;
+  const present = new Set(files.map((f) => basename(f)));
+  for (const line of (await readFile(manifest, 'utf8')).split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    // `<hex>  <name>` — the name may carry a binary-mode `*` prefix.
+    const name = line.slice(line.indexOf(' ')).trim().replace(/^\*/, '');
+    if (name && !present.has(basename(name))) {
+      fail(
+        `SHA256SUMS lists "${name}", which is not in ${dir}. ` +
+          '`sha256sum -c SHA256SUMS` would fail for anyone who downloads the release — ' +
+          'checksum only what actually gets published.',
+      );
+    }
+  }
+}
+
 function checkForbidden(files) {
   if (!publishSet) return;
   for (const file of files) {
@@ -258,6 +285,7 @@ async function main() {
 
   await checkMacZips(files);
   await checkFeeds(artifactDir, files);
+  await checkChecksumManifest(artifactDir, files);
   checkForbidden(files);
 
   for (const n of notes) console.log(`verify-artifacts: ${n}`);


### PR DESCRIPTION
## The gate didn't run

The Squirrel.Mac layout check — the one that exists specifically to catch the
defect that made every macOS update in v1.5.x impossible — **did not run on the
v1.6.0 release**:

```
verify-artifacts: no macOS update zips in this build — skipping the Squirrel.Mac layout check
```

It keyed on a `-mac.zip` filename suffix, and the same PR that fixed the
packaging renamed the mac artifacts to `-<arch>.zip`. The check found nothing to
check and passed.

The published zips are in fact correct — verified by hand against the live
release, both rooted at `Limboo.app/` — but that was luck, not verification. A
gate that reports success when it inspected nothing is worse than no gate,
because it buys false confidence in exactly the place we already got burned.

## Fix

- **Derive the zip list from `latest-mac.yml`, not from filenames.** Those
  entries are by definition the archives Squirrel.Mac will be handed, so the
  check cannot drift when artifact naming changes again.
- **A mac feed with no matching zip is now a failure, not a skip.** The
  "nothing to check" path is reachable only when there is no macOS feed at all.
  A real build can no longer silently opt out of its own regression gate.

## Verified both directions, against real artifacts

Passes on v1.6.0:

```
verify-artifacts: Limboo-1.6.0-arm64.zip: rooted at Limboo.app/ — OK
verify-artifacts: Limboo-1.6.0-x64.zip: rooted at Limboo.app/ — OK
verify-artifacts: 18 file(s) checked — OK.
```

Still fails on v1.5.1's published artifacts:

```
FAIL — Limboo-1.5.1-mac.zip: first entry is "Limboo-darwin-arm64/", expected "<Product>.app/"
FAIL — latest-mac.yml: "Limboo-1.5.1-mac.zip" and "Limboo-1.5.1-arm64-mac.zip" have the SAME sha512
```

And on the new "feed present, zip missing" case:

```
FAIL — latest-mac.yml is present but no macOS update zip could be matched to it.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
