### PR TITLE
Release notes from the changelog, in-app What's New, and v1.7.0 prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,77 @@ All notable changes to Limboo are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-07-26
+
+Adds the **Work Graph** — a typed, queryable graph of what a session actually
+did, built from both coding agents' event streams and owned entirely by Limboo —
+along with a document-oriented workspace where diffs open as first-class tabs,
+and an in-app **What's New** tab so an update can finally tell you what changed.
+
+### Added
+
+- **The Work Graph (DAWG).** Every session's execution is recorded as a Directed
+  Acyclic Work Graph — objectives, plans, tasks, subagents, investigations,
+  searches, memory lookups, MCP calls, commands, files, commits, approvals and
+  results — connected by nine typed relationships (`follows`, `contains`,
+  `generated`, `depends-on`, `implemented-in`, `verified-by`, `blocked-by`,
+  `reviewed-by`, `produced-artifact`). Neither Claude nor Cursor exposes a work
+  graph; both are conversation-driven. This is Limboo's own layer, derived from
+  the structured events they *do* emit, so it records both agents identically and
+  every future adapter contributes nodes for free. It is deliberately shaped like
+  a git history — vertical execution lanes, one node per row, commits in a
+  right-hand gutter — rather than a free-floating node diagram, because that is
+  the mental model developers already have. Layout runs in a Web Worker and rows
+  virtualize, so a long session stays responsive.
+- **Structural search over the graph.** Queries traverse *shape*, not just text:
+  an FTS5 seed set (free text, node kinds, statuses, time range) expanded by a
+  bounded closure over the edge table. "Every task blocked by X" is a traversal,
+  not a transcript scroll.
+- **Eight export formats.** JSON, Markdown, Mermaid, Graphviz DOT, CSV and a
+  self-contained HTML report are rendered from the stored graph; SVG and PNG are
+  rendered from the layout. Exports go to the clipboard or to a file you pick.
+- **A document-oriented workspace.** Diffs promote out of the Changes panel into
+  first-class tabs with their own icons, pinning, reordering, close/reopen and
+  per-document view state. `ChangesNavigator` unifies file browsing across the Git
+  panel and Changes; `DiffEditor` adds syntax highlighting and word-level diffs.
+- **A "What's New" tab.** When Limboo starts on a version it has not shown you
+  before, the release notes for *that* version open as a workspace tab. Closing it
+  is remembered until the next update. It is available any time from the command
+  palette, and — like Claude Code's own `/release-notes` — it is display-only and
+  never enters the agent's context.
+
 ### Fixed
 
+- **The work graph silently discarded whole batches of its own data.** A node
+  whose payload exceeded the size cap was skipped, but the edges pointing at it
+  were still written. `INSERT OR IGNORE` does not suppress a FOREIGN KEY
+  violation, so the failing edge aborted the entire transaction and took every
+  other node and edge in that flush with it — behind a single `logger.warn`.
+  Oversized nodes are now shrunk rather than dropped, every edge's endpoints are
+  proven to exist before insert, and persistent failures surface as a banner in
+  the panel instead of an innocent-looking empty graph.
+- **Orphan cleanup deleted real work.** It removed any node with no edge, which is
+  the normal state of a terminal opened outside a run, a commit made with no agent
+  active, or a service started before the first prompt. Those kinds are now exempt.
+- **Commits could be attributed to the wrong session, or lost entirely.** An
+  unattributable commit was still recorded as "seen", so it was dropped
+  permanently at the exact moment its session next became active. It is now only
+  marked seen once it has been attributed. Separately, a `git pull` bringing in
+  upstream commits claimed the current run had implemented its files in every one
+  of them; that fan-out is now limited to commits made after the run started.
+- **Subagent work was spliced into the main timeline.** The `contains`
+  relationship was defined, drawn by the layouter and listed in the legend, but
+  nothing ever emitted it. Subagent nesting now rides the Agent SDK's
+  `parent_tool_use_id`, so a subagent's steps sit inside the node that spawned
+  them. (Cursor's print mode has no subagents, so the branch simply never forks
+  there.)
+- **Permission decisions were never recorded.** Approval nodes were inferred by
+  string-matching a log line's `"Blocked…"` prefix, which could not see the answer
+  the user actually gave. They now come from the one decision gate both providers
+  call, carrying the real decision, tool and risk.
+- **Nodes were labelled with the wrong agent.** Provider and mode were read from
+  current settings at write time rather than captured per run, so switching models
+  mid-session silently relabelled a run's history.
 - **Two release gates were not actually verifying anything.** Both were found by
   checking the published v1.6.0 artifacts by hand rather than trusting a green
   pipeline:
@@ -26,6 +95,40 @@ All notable changes to Limboo are documented here. The format is based on
     from the publish set, and a new check fails the build if the manifest names
     anything that is not being published. (The v1.6.0 manifest was corrected in
     place; its remaining hashes were always valid.)
+
+### Changed
+
+- **Release notes now come from this file.** The GitHub release body was
+  generated from commit subjects while the changelog was written by hand, so the
+  two said different things about the same release and nothing connected them.
+  The notes generator now reads the section for the tag being released and falls
+  back to the previous commit-subject behaviour only when there isn't one — which
+  also means the notes shown inside the app, the notes on the release page, and
+  this file are the same text by construction.
+- **An active icon is marked by its own color, not a filled block behind it.** In
+  the activity rail, the title-bar tab strip and the settings navigation, the
+  background plate is gone and the glyph takes the accent color. On a pure-black
+  canvas the plate read as a second element competing with the icon it sat
+  behind. Hover still shows it, where it is feedback rather than state.
+
+### Security
+
+- **The graph's secret redactor missed the case its own guide calls out.** It is
+  shared with the Hook Engine, so a gap in it was a gap in two subsystems. It now
+  covers credential-bearing URLs (`https://user:token@host` — a remote typed into
+  a terminal became a node title verbatim), GitHub, AWS and Slack tokens, PEM
+  private-key blocks, JWTs, and generic `secret=`-shaped assignments. Redaction
+  also runs recursively over a node's whole metadata on the single path into the
+  database, rather than only over its title and detail, so a future field is
+  covered without having to opt in.
+- **Export writes to disk without the renderer ever naming a path.** Saving a
+  graph sends only a session id and a format; the main process opens the save
+  dialog and writes wherever you chose. There is no renderer-supplied path, and
+  therefore no traversal surface to defend.
+- **Query inputs are bounded before they are examined.** Array arguments are
+  capped before filtering (an oversized array was previously walked in full),
+  export results are byte-capped, and edge reads are limited instead of unbounded
+  table scans.
 
 ## [1.6.0] - 2026-07-25
 
@@ -259,7 +362,8 @@ operational.
 - **Unified streaming timeline** — the conversation rendered as one continuous,
   turn-grouped event stream of messages, tool calls, and status markers.
 
-[Unreleased]: https://github.com/limboo-ai/limboo/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/limboo-ai/limboo/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/limboo-ai/limboo/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/limboo-ai/limboo/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/limboo-ai/limboo/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/limboo-ai/limboo/compare/v1.0.0...v1.5.0

--- a/README.md
+++ b/README.md
@@ -414,12 +414,12 @@ for contributors: [`CLAUDE.md`](CLAUDE.md) (the code-level working contract) and
 
 ## Project status
 
-**Current release: `v1.6.0`.** The desktop foundation and the platform services are
+**Current release: `v1.7.0`.** The desktop foundation and the platform services are
 built and in daily use: workspaces, sessions with per-session git worktrees, the git
 engine, the integrated terminal, the File System Layer, multi-agent orchestration
 (Claude and Cursor), the Local Memory System, the Search Engine, the Resume Pipeline,
-the MCP platform layer, the OS-level sandbox, and a hardened IPC layer over local
-SQLite.
+the Work Graph, the MCP platform layer, the OS-level sandbox, and a hardened IPC layer
+over local SQLite.
 
 Being honest about the rough edges, because you will meet them:
 

--- a/ci/scripts/generate-release-notes.mjs
+++ b/ci/scripts/generate-release-notes.mjs
@@ -1,13 +1,24 @@
 #!/usr/bin/env node
 /**
- * generate-release-notes.mjs — produce human-readable, categorized release notes
- * from git history between the previous tag and a target ref.
+ * generate-release-notes.mjs — produce the Markdown body for a GitHub/GitLab
+ * Release.
  *
- * Provider-neutral (Node builtins + git only). Rather than dumping raw commit
- * messages, it groups Conventional-Commit-style subjects into sections (Features,
- * Fixes, Performance, Security, …), lists other notable commits, surfaces
- * BREAKING CHANGES, and credits contributors. The output is Markdown suitable for
- * a GitHub/GitLab Release body.
+ * TWO SOURCES, in priority order:
+ *
+ *   1. `CHANGELOG.md`, when it has a section for the tag being released. Hand-
+ *      written notes explain *why* a change matters and what it means for the
+ *      user; a commit subject cannot. Every shipped release so far was in fact
+ *      hand-authored on the release page while this script generated something
+ *      else entirely — the two were never connected, so they disagreed.
+ *   2. Categorized git history, unchanged, when there is no such section. This
+ *      keeps the change additive: a tag cut without a changelog entry still gets
+ *      the notes it always got, rather than an empty release body.
+ *
+ * The `Installing` / `Verifying this release` footers are appended either way.
+ * They are per-release boilerplate rather than narrative, they answer the same
+ * questions every time, and every prior release carries them.
+ *
+ * Provider-neutral: Node builtins + git only.
  *
  * Usage:
  *   node ci/scripts/generate-release-notes.mjs [toRef=HEAD] [outFile]
@@ -16,6 +27,7 @@
  */
 import { spawnSync } from 'node:child_process';
 import { writeFile } from 'node:fs/promises';
+import { normalizeVersion, sectionFor } from './lib/changelog.mjs';
 
 // argv[2] may be an explicit empty string (e.g. an unset "$CIRCLE_TAG" passed
 // through by CI), which `?? 'HEAD'` would NOT catch — treat empty/whitespace as a
@@ -37,9 +49,24 @@ function git(args) {
   return r.stdout.trim();
 }
 
-/** The most recent tag strictly before `toRef`, or null for the first release. */
+/** True when git can resolve a ref — used to tolerate a not-yet-created tag. */
+function revExists(ref) {
+  return spawnSync('git', ['rev-parse', '--verify', '--quiet', `${ref}^{commit}`]).status === 0;
+}
+
+/**
+ * The ref git ranges actually run against.
+ *
+ * `docs/ci/release-process.md` tells maintainers to PREVIEW the notes before
+ * tagging, so the common local invocation names a tag that does not exist yet.
+ * Falling back to HEAD makes that preview work instead of aborting; in CI the
+ * tag always exists and this resolves to it.
+ */
+const gitRef = revExists(toRef) ? toRef : 'HEAD';
+
+/** The most recent tag strictly before the release, or null for the first one. */
 function previousTag() {
-  const r = spawnSync('git', ['describe', '--tags', '--abbrev=0', `${toRef}^`], { encoding: 'utf8' });
+  const r = spawnSync('git', ['describe', '--tags', '--abbrev=0', `${gitRef}^`], { encoding: 'utf8' });
   return r.status === 0 ? r.stdout.trim() : null;
 }
 
@@ -68,9 +95,30 @@ function parse(subject) {
   return { section, breaking: !!bang, text: desc };
 }
 
-function main() {
-  const prev = previousTag();
-  const range = prev ? `${prev}..${toRef}` : toRef;
+/**
+ * The narrative body, taken from CHANGELOG.md when it has a section for this
+ * tag. Returns null when it does not — that null is the signal to fall back.
+ */
+function bodyFromChangelog(prev) {
+  const section = sectionFor(toRef);
+  if (!section) return null;
+  const version = normalizeVersion(toRef);
+  const out = [`## Limboo ${version}${section.date ? ` (${section.date})` : ''}`, ''];
+  if (prev) out.push(`Changes since **${prev}**.`, '');
+  out.push(section.body, '');
+  return { out, commitCount: countCommits(prev) };
+}
+
+/** How many commits this release contains, for the footer line. */
+function countCommits(prev) {
+  const range = prev ? `${prev}..${gitRef}` : gitRef;
+  const raw = git(['log', range, '--no-merges', '--pretty=format:%h']);
+  return raw.split('\n').filter(Boolean).length;
+}
+
+/** The categorized-from-git-history body — unchanged behaviour, now a fallback. */
+function bodyFromHistory(prev) {
+  const range = prev ? `${prev}..${gitRef}` : gitRef;
   const sep = '';
   // subject<US>author-name per commit (exclude merge commits for cleaner notes)
   const raw = git(['log', range, '--no-merges', `--pretty=format:%s${sep}%an`]);
@@ -116,6 +164,21 @@ function main() {
     out.push('### Contributors', '');
     out.push([...contributors].sort().map((c) => `@${c}`).join(', '), '');
   }
+
+  return { out, commitCount };
+}
+
+function main() {
+  const prev = previousTag();
+  // CHANGELOG first, history second. Which one ran is logged to stderr so a
+  // release that silently fell back is visible in the job output.
+  const fromChangelog = bodyFromChangelog(prev);
+  console.error(
+    fromChangelog
+      ? `generate-release-notes: using the CHANGELOG.md section for ${toRef}`
+      : `generate-release-notes: no CHANGELOG.md section for ${toRef}; using git history`,
+  );
+  const { out, commitCount } = fromChangelog ?? bodyFromHistory(prev);
 
   // Installation notes ride every release because the answers differ per
   // platform and the questions are otherwise asked every single time: why

--- a/ci/scripts/lib/changelog.mjs
+++ b/ci/scripts/lib/changelog.mjs
@@ -1,0 +1,124 @@
+/**
+ * changelog.mjs — parse `CHANGELOG.md` into per-version sections.
+ *
+ * One parser, three consumers: the GitHub/GitLab release body
+ * (`generate-release-notes.mjs`), the notes bundled into the app
+ * (`scripts/gen-release-notes.mjs`), and the changelog itself. Before this
+ * existed the release body was generated from commit subjects while the
+ * changelog was written by hand, so the two described the same release
+ * differently and nothing connected them.
+ *
+ * Dependency-free by house rule — every script under `ci/scripts/` runs on a
+ * bare Node with no install step, because they gate the build that would
+ * install things.
+ *
+ * The format parsed is Keep a Changelog as this project writes it:
+ *
+ *     ## [1.7.0] - 2026-07-26
+ *     <prose summary>
+ *     ### Added
+ *     - **Lead-in.** Explanation.
+ *
+ * `## [Unreleased]` is deliberately skipped: it is a staging area, not a
+ * release, and emitting it as a release body would publish notes for work that
+ * has not shipped.
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Repo root, resolved from this file so callers need not agree on a cwd. */
+export const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+/** Default changelog location. */
+export const CHANGELOG_PATH = path.join(REPO_ROOT, 'CHANGELOG.md');
+
+/**
+ * A released section. `body` is the markdown BELOW the version heading and
+ * above the next one, trimmed — heading excluded so a consumer can re-title it.
+ */
+/** @typedef {{ version: string, date: string | null, body: string }} ChangelogSection */
+
+/** Matches `## [1.7.0] - 2026-07-26`, and `## [1.0.0]` with no date. */
+const HEADING = /^## \[([^\]\s]+)\](?:\s*-\s*(\d{4}-\d{2}-\d{2}))?\s*$/;
+
+/**
+ * Parse a changelog into released sections, newest first.
+ *
+ * @param {string} [file] path to CHANGELOG.md
+ * @returns {ChangelogSection[]}
+ */
+export function parseChangelog(file = CHANGELOG_PATH) {
+  let text;
+  try {
+    text = readFileSync(file, 'utf8');
+  } catch {
+    // A missing changelog is not fatal: callers fall back to git history.
+    return [];
+  }
+
+  const lines = text.split(/\r?\n/);
+  /** @type {ChangelogSection[]} */
+  const sections = [];
+  /** @type {ChangelogSection | null} */
+  let current = null;
+  /** @type {string[]} */
+  let buffer = [];
+
+  const flush = () => {
+    if (!current) return;
+    current.body = buffer.join('\n').trim();
+    // The link-reference block at the foot of the file belongs to no section.
+    current.body = current.body.replace(/\n\[[^\]]+\]:\s*https?:\/\/\S+(?:\n\[[^\]]+\]:\s*https?:\/\/\S+)*\s*$/, '').trim();
+    if (current.body) sections.push(current);
+    current = null;
+    buffer = [];
+  };
+
+  for (const line of lines) {
+    const m = HEADING.exec(line);
+    if (!m) {
+      if (current) buffer.push(line);
+      continue;
+    }
+    flush();
+    const [, version, date] = m;
+    // Skip the staging area — it is not a release.
+    if (/^unreleased$/i.test(version)) continue;
+    current = { version, date: date ?? null, body: '' };
+  }
+  flush();
+
+  return sections;
+}
+
+/** Strip a leading `v` so `v1.7.0` and `1.7.0` both resolve. */
+export function normalizeVersion(ref) {
+  return String(ref ?? '').trim().replace(/^v/, '');
+}
+
+/**
+ * The section for one version, or null when the changelog has no entry for it.
+ * Returning null is meaningful: it is how a caller knows to fall back.
+ *
+ * @param {string} ref  tag or version, with or without a leading `v`
+ * @param {string} [file]
+ * @returns {ChangelogSection | null}
+ */
+export function sectionFor(ref, file = CHANGELOG_PATH) {
+  const wanted = normalizeVersion(ref);
+  if (!wanted) return null;
+  return parseChangelog(file).find((s) => s.version === wanted) ?? null;
+}
+
+/**
+ * The most recent `count` released sections, newest first — what the app
+ * bundles so a user updating across several versions can read what they missed.
+ *
+ * @param {number} count
+ * @param {string} [file]
+ * @returns {ChangelogSection[]}
+ */
+export function recentSections(count, file = CHANGELOG_PATH) {
+  return parseChangelog(file).slice(0, Math.max(0, count));
+}

--- a/docs/operations/release-process.md
+++ b/docs/operations/release-process.md
@@ -20,14 +20,32 @@ Forge; releases are driven from the `main` branch.
 2. **Update the changelog.** Move the `Unreleased` items in
    [CHANGELOG.md](../../CHANGELOG.md) into a new version section with the date, and
    refresh the compare links.
-3. **Commit and tag.** Commit the changelog, then tag `vX.Y.Z` and
+
+   This file is the **single source of the release notes**. The section you write
+   here becomes the GitHub/GitLab release body verbatim —
+   `ci/scripts/generate-release-notes.mjs` reads it and only falls back to
+   categorized commit subjects when a tag has no section — and the same text is
+   what the app shows in its **What's New** tab. Preview the body before tagging:
+
+   ```bash
+   node ci/scripts/generate-release-notes.mjs vX.Y.Z
+   ```
+
+   It prints which source it used to stderr, so a release that silently fell back
+   to commit subjects is visible rather than discovered on the release page.
+3. **Regenerate the bundled notes.** `npm run gen:notes` rewrites
+   `src/shared/releaseNotes.generated.ts` from the changelog so the build ships
+   its own release notes. Commit it with the changelog — it is generated but
+   committed, so the notes are reviewable in the diff and a build never depends
+   on the script having been run.
+4. **Commit and tag.** Commit the changelog, then tag `vX.Y.Z` and
    `git push origin vX.Y.Z` (fans out to GitLab — the source of truth — and the
    GitHub mirror). The tag triggers the GitLab release pipeline, and separately
    the GitHub Actions `release-supplement.yml` workflow, which adds the
    architectures GitLab's runners cannot build (macOS Intel, arm64 Linux, arm64
    Windows) to the same release. Tagging a commit that already carries a `v*` tag
    is rejected by `ci/scripts/check-tag-unique.mjs`.
-4. **Build artifacts.**
+5. **Build artifacts.**
    ```bash
    npm run package   # runnable bundle (no installers)
    npm run dist      # branded installers + auto-update metadata into dist/
@@ -37,12 +55,12 @@ Forge; releases are driven from the `main` branch.
    `latest*.yml` auto-update metadata. See
    [installer and updates](installer-and-updates.md) and
    [packaging and signing](packaging-and-signing.md).
-5. **Publish.** The GitLab pipeline publishes automatically on a `v*` tag — an
+6. **Publish.** The GitLab pipeline publishes automatically on a `v*` tag — an
    identical GitLab Release and GitHub Release (see
    [release-process](../ci/release-process.md)). For a manual fallback use
    `npm run dist:publish` (with `GH_TOKEN` set) or attach `dist/*` — installers,
    `latest*.yml`, and `*.blockmap` — to the GitHub release with the `gh` CLI.
-6. **Verify the release.** Download an artifact from both hosts and confirm it
+7. **Verify the release.** Download an artifact from both hosts and confirm it
    launches.
 
 ## Release checklist
@@ -50,6 +68,9 @@ Forge; releases are driven from the `main` branch.
 - [ ] `main` is green (CI passed).
 - [ ] `package.json` version left ALONE (the tag supplies it).
 - [ ] `CHANGELOG.md` updated with date and compare links.
+- [ ] `npm run gen:notes` re-run and `src/shared/releaseNotes.generated.ts` committed.
+- [ ] `node ci/scripts/generate-release-notes.mjs vX.Y.Z` reports it used the
+      CHANGELOG section, not the git-history fallback.
 - [ ] Tag `vX.Y.Z` created on a commit that carries no other `v*` tag.
 - [ ] Artifacts built (`npm run dist`) and smoke-tested.
 - [ ] `ci/scripts/verify-artifacts.mjs` passed on the assembled publish set.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dist": "electron-forge package && node scripts/dist.mjs",
     "dist:publish": "electron-forge package && node scripts/dist.mjs --publish always",
     "gen:icons": "node scripts/gen-icons.mjs",
+    "gen:notes": "node scripts/gen-release-notes.mjs",
     "gen:installer": "node scripts/gen-installer-assets.mjs",
     "gen:appx": "node scripts/gen-appx-assets.mjs",
     "lint": "eslint --ext .ts,.tsx ."

--- a/scripts/gen-release-notes.mjs
+++ b/scripts/gen-release-notes.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Bundle the release notes the app shows in its "What's New" tab, from the
+ * single source of truth: CHANGELOG.md.
+ *
+ *   node scripts/gen-release-notes.mjs        (npm run gen:notes)
+ *
+ * Output:
+ *   src/shared/releaseNotes.generated.ts   the most recent N released sections
+ *
+ * WHY A GENERATED MODULE RATHER THAN A BUNDLED ASSET. `electron-builder.yml`
+ * deliberately declares no `files`/`extraResources` block — it repacks Forge's
+ * output via `--prepackaged` so the security fuses and asar integrity Forge
+ * baked in survive. A data file copied for packaging would therefore need a
+ * second mechanism (and a runtime path that differs between dev, asar, and
+ * asar-unpacked). An imported module needs none of that and behaves identically
+ * everywhere.
+ *
+ * WHY NOT READ THE UPDATER'S NOTES INSTEAD. `UpdateInfo.releaseNotes` describes
+ * the version being *offered*, is HTML-stripped and capped on its way through
+ * the updater, and lives only in memory — so it is gone by the time the new
+ * version boots and cannot answer "what did I just get?". Bundled notes always
+ * match the running build, need no network, and work in development.
+ *
+ * The generated file is COMMITTED so it is reviewable in a diff and so a build
+ * never depends on this script having been run.
+ */
+import { writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { CHANGELOG_PATH, REPO_ROOT, recentSections } from '../ci/scripts/lib/changelog.mjs';
+
+/**
+ * How many past releases ship with the app. Enough that someone updating across
+ * a couple of versions can read what they missed, few enough that the changelog
+ * does not become app payload — it grows without bound, the bundle should not.
+ */
+const KEEP = 3;
+
+const OUT = path.join(REPO_ROOT, 'src', 'shared', 'releaseNotes.generated.ts');
+
+/** Escape a string for a TS backtick template literal. */
+function escapeTemplate(text) {
+  return text.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+}
+
+function main() {
+  const sections = recentSections(KEEP, CHANGELOG_PATH);
+  if (sections.length === 0) {
+    console.error('gen-release-notes: no released sections found in CHANGELOG.md');
+    process.exit(1);
+  }
+
+  const entries = sections
+    .map(
+      (s) => `  {
+    version: '${s.version}',
+    date: ${s.date ? `'${s.date}'` : 'null'},
+    markdown: \`${escapeTemplate(s.body)}\`,
+  },`,
+    )
+    .join('\n');
+
+  const file = `/**
+ * GENERATED FILE — DO NOT EDIT.
+ *
+ * Written by \`npm run gen:notes\` (scripts/gen-release-notes.mjs) from
+ * CHANGELOG.md, which is the single source of truth for release notes: the same
+ * text becomes the GitHub release body, this in-app "What's New" tab, and the
+ * changelog itself. Re-run the script after editing CHANGELOG.md.
+ *
+ * Contains the ${KEEP} most recent released sections.
+ */
+
+/** One release's notes, as authored in CHANGELOG.md. */
+export interface ReleaseNotesEntry {
+  /** Semantic version, without a leading \`v\`. */
+  version: string;
+  /** ISO release date, or null for a section written without one. */
+  date: string | null;
+  /** The section body as Markdown — headings and bullets, no version heading. */
+  markdown: string;
+}
+
+/** Newest first. */
+export const RELEASE_NOTES: ReleaseNotesEntry[] = [
+${entries}
+];
+
+/** The notes for one version, or null when this build does not carry them. */
+export function releaseNotesFor(version: string): ReleaseNotesEntry | null {
+  const wanted = version.replace(/^v/, '');
+  return RELEASE_NOTES.find((r) => r.version === wanted) ?? null;
+}
+`;
+
+  writeFileSync(OUT, file, 'utf8');
+  console.error(
+    `Wrote ${path.relative(REPO_ROOT, OUT)} — ${sections.length} release(s): ` +
+      sections.map((s) => s.version).join(', '),
+  );
+}
+
+main();

--- a/src/main/managers/SettingsManager.ts
+++ b/src/main/managers/SettingsManager.ts
@@ -438,6 +438,12 @@ export class SettingsManager {
 
     merged.updates.autoCheck = !!merged.updates.autoCheck;
     merged.updates.autoDownload = !!merged.updates.autoDownload;
+    // Persisted user data, so never trusted verbatim: it is compared against
+    // `app.getVersion()` and rendered, and a hand-edited settings.json must not
+    // be able to put an unbounded string into either path.
+    merged.updates.lastSeenVersion = String(merged.updates.lastSeenVersion ?? '')
+      .trim()
+      .slice(0, 64);
 
     // Voice — clamp the numeric tuning knobs, whitelist the enums, and coerce
     // the boolean toggles (renderer-supplied strings must never reach the

--- a/src/renderer/features/activity/ActivityRail.tsx
+++ b/src/renderer/features/activity/ActivityRail.tsx
@@ -1,7 +1,13 @@
 /**
- * Fixed far-right icon rail. Each tab toggles its drawer panel open/closed; the
- * active tab shows an accent indicator. Backed by the layout store so the open
- * tab persists across launches.
+ * Fixed far-right icon rail. Each tab toggles its drawer panel open/closed.
+ *
+ * The active tab is marked by the ICON'S OWN COLOR — no background plate. On a
+ * pure-black canvas a filled `bg-surface-2` block reads as a second UI element
+ * competing with the glyph it sits behind; the accent glyph alone is the
+ * quieter and more legible signal. The plate is kept for hover, where it is
+ * transient feedback rather than persistent state.
+ *
+ * Backed by the layout store so the open tab persists across launches.
  */
 import { RAIL_TABS } from './tabs';
 import { useLayoutStore } from '@/renderer/stores/useLayoutStore';
@@ -29,7 +35,7 @@ export function ActivityRail() {
             className={cn(
               'relative flex h-9 w-9 items-center justify-center rounded-md transition-colors',
               'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent',
-              isActive ? 'bg-surface-2 text-accent' : 'text-muted hover:bg-surface-2 hover:text-fg',
+              isActive ? 'text-accent' : 'text-muted hover:bg-surface-2 hover:text-fg',
             )}
           >
             <tab.icon size={17} />

--- a/src/renderer/features/activity/ActivityTabIcons.tsx
+++ b/src/renderer/features/activity/ActivityTabIcons.tsx
@@ -3,6 +3,11 @@
  * Hooks tabs, rendered next to the Settings gear. Each button toggles its drawer
  * open/closed on the right, exactly like the vertical `ActivityRail`; only the
  * placement differs. Styled to match the TitleBar's Settings `IconButton`.
+ *
+ * Active state is the icon's own accent color, with no background plate — see
+ * the note in `ActivityRail`. The two must stay identical: they are the same
+ * control in two placements, and a user switching between them would read any
+ * difference as a bug.
  */
 import { TOP_TABS } from './tabs';
 import { useLayoutStore } from '@/renderer/stores/useLayoutStore';
@@ -30,7 +35,7 @@ export function ActivityTabIcons() {
             className={cn(
               'relative flex h-7 w-7 items-center justify-center rounded-md transition-colors',
               'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent',
-              isActive ? 'bg-surface-2 text-accent' : 'text-muted hover:bg-surface-2 hover:text-fg',
+              isActive ? 'text-accent' : 'text-muted hover:bg-surface-2 hover:text-fg',
             )}
           >
             <tab.icon size={15} />

--- a/src/renderer/features/settings/SettingsNav.tsx
+++ b/src/renderer/features/settings/SettingsNav.tsx
@@ -104,10 +104,14 @@ export function SettingsNav({
                     onClick={() => onSelectCategory(category.id)}
                     aria-current={active ? 'page' : undefined}
                     className={cn(
-                      'relative flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-[12px] transition-colors',
+                      'flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-[12px] transition-colors',
                       'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent',
+                      // Active is carried by COLOR, not a background plate (see
+                      // ActivityRail). The label takes accent too: with the plate
+                      // gone, `text-fg` alone is nearly indistinguishable from an
+                      // inactive row on this palette.
                       active
-                        ? 'bg-surface-2 text-fg'
+                        ? 'text-accent'
                         : 'text-muted hover:bg-surface-2 hover:text-fg',
                     )}
                   >

--- a/src/renderer/features/updates/ReleaseNotesDocument.tsx
+++ b/src/renderer/features/updates/ReleaseNotesDocument.tsx
@@ -1,0 +1,65 @@
+/**
+ * The "What's New" document — the release notes for one app version, rendered
+ * as a workspace tab.
+ *
+ * The notes are COMPILED INTO THE BUNDLE from `CHANGELOG.md` (see
+ * `scripts/gen-release-notes.mjs`), not fetched: the updater's own
+ * `releaseNotes` describes the version being *offered*, is HTML-stripped and
+ * capped on the way through, and is gone by the time the new version boots — so
+ * it can never answer "what did I just get?". Bundled notes always match the
+ * running build, need no network, and work in development.
+ *
+ * This document is DISPLAY-ONLY and is never added to any agent context
+ * provider. Claude Code shipped a fix for exactly this bug — its "Show all"
+ * release-notes view was injecting the whole changelog into every subsequent
+ * request — and the same mistake is available here for free if anyone ever
+ * wires this text into a context block.
+ *
+ * Shell shape follows `DiffWorkspace`: a `h-9` identity row over a single
+ * scrolling body, so every document in the center column reads the same.
+ */
+import { Sparkles } from 'lucide-react';
+import { Markdown } from '@/renderer/features/workspace/Markdown';
+import { EmptyState } from '@/renderer/components/ui/EmptyState';
+import { releaseNotesFor } from '@shared/releaseNotes.generated';
+
+interface ReleaseNotesDocumentProps {
+  /** The version whose notes to show, without a leading `v`. */
+  version: string;
+}
+
+export function ReleaseNotesDocument({ version }: ReleaseNotesDocumentProps) {
+  const entry = releaseNotesFor(version);
+
+  return (
+    <section className="flex h-full min-h-0 flex-col bg-surface">
+      {/* Identity row */}
+      <div className="flex h-9 shrink-0 items-center gap-2 border-b border-line px-3">
+        <Sparkles size={14} className="shrink-0 text-accent" />
+        <span className="shrink-0 text-[12px] font-medium text-fg">What&apos;s New</span>
+        <span className="shrink-0 text-[11px] text-muted">Limboo {version}</span>
+        {entry?.date && <span className="text-[11px] text-faint">{entry.date}</span>}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+        {entry ? (
+          // The house Markdown renderer: react-markdown + remark-gfm +
+          // rehype-sanitize, with links routed through `system.openExternal`
+          // rather than navigating the renderer.
+          <div className="mx-auto max-w-3xl">
+            <Markdown text={entry.markdown} />
+          </div>
+        ) : (
+          // A development build carries the placeholder version from
+          // package.json, which has no changelog section. Say so plainly rather
+          // than rendering an empty page that looks like a failure.
+          <EmptyState
+            compact
+            title="No release notes for this build"
+            description={`This build reports version ${version}, which has no entry in the changelog. Release builds always carry their own notes.`}
+          />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/renderer/features/updates/useReleaseNotes.ts
+++ b/src/renderer/features/updates/useReleaseNotes.ts
@@ -1,0 +1,104 @@
+/**
+ * "What's New" lifecycle: decide whether this launch is the first on a new
+ * version, open the tab once when it is, and remember the dismissal.
+ *
+ * The rule the whole feature rests on: the notes appear when the running
+ * version differs from the last one the user acknowledged, and closing the tab
+ * acknowledges it. Nothing else opens it automatically.
+ *
+ * Two guards keep that honest:
+ *
+ *  - **Only when notes actually exist for this build.** A development build
+ *    reports the placeholder version from `package.json`, which has no
+ *    changelog section; without this check every dev launch would open an empty
+ *    tab that could never be dismissed into a stable state.
+ *  - **Only once per app run.** The auto-open effect re-runs whenever its
+ *    dependencies change, and the version is not marked seen until the tab is
+ *    closed — so without a run-scoped latch, closing the tab would immediately
+ *    reopen it.
+ */
+import { useEffect, useRef } from 'react';
+import { releaseNotesFor } from '@shared/releaseNotes.generated';
+import { useDocumentStore, type DocumentRef } from '@/renderer/stores/useDocumentStore';
+import { useSettingsStore } from '@/renderer/stores/useSettingsStore';
+import { useUpdateStore } from '@/renderer/stores/useUpdateStore';
+
+/**
+ * Whether this app run has already auto-opened the notes. Module scope, not
+ * component state: `CenterWorkspace` remounts on layout changes, and a remount
+ * must not re-open a tab the user just closed.
+ */
+let autoOpenedThisRun = false;
+
+/** The ref for a version's notes — one place, so id derivation cannot drift. */
+export function releaseNotesRef(version: string): DocumentRef {
+  return { kind: 'release-notes', version };
+}
+
+export interface ReleaseNotesState {
+  /** The running app version, `''` before the update store has hydrated. */
+  version: string;
+  /** True when this build carries notes the user has not acknowledged. */
+  unseen: boolean;
+  /** Whether this build carries notes at all (false in dev). */
+  available: boolean;
+  /** Record the running version as seen. Idempotent. */
+  markSeen: () => void;
+}
+
+export function useReleaseNotes(): ReleaseNotesState {
+  // `currentVersion` is re-stamped by main on every status emit, so it is
+  // available without a separate `app.getInfo()` round trip.
+  const version = useUpdateStore((s) => s.status.currentVersion) ?? '';
+  const lastSeen = useSettingsStore((s) => s.settings.updates.lastSeenVersion);
+  const settingsHydrated = useSettingsStore((s) => s.hydrated);
+  const update = useSettingsStore((s) => s.update);
+
+  const available = !!version && !!releaseNotesFor(version);
+  const unseen = settingsHydrated && available && version !== lastSeen;
+
+  const markSeen = () => {
+    if (!version || version === lastSeen) return;
+    void update({ updates: { lastSeenVersion: version } });
+  };
+
+  return { version, unseen, available, markSeen };
+}
+
+/**
+ * Drive the tab: open it once on a new version, and mark the version seen when
+ * it is closed. Mounted once from `CenterWorkspace`.
+ *
+ * Dismissal is detected as an open→closed transition rather than by wiring a
+ * callback into the tab's close button, so EVERY route to closing it — the X,
+ * middle-click, "close others", "close all", the command palette — counts as
+ * acknowledgement. A close button that only worked when clicked directly would
+ * be the kind of gap that silently reopens the tab forever.
+ */
+export function useReleaseNotesTab(sessionId: string | null): void {
+  const { version, unseen, markSeen } = useReleaseNotes();
+  const promote = useDocumentStore((s) => s.promote);
+  const isOpen = useDocumentStore((s) =>
+    sessionId ? !!s.bySession[sessionId]?.docs[`release-notes:${version}`] : false,
+  );
+  const wasOpen = useRef(false);
+
+  // Open once, when there is a session to open it in.
+  useEffect(() => {
+    if (!sessionId || !unseen || autoOpenedThisRun) return;
+    autoOpenedThisRun = true;
+    promote(sessionId, releaseNotesRef(version));
+  }, [sessionId, unseen, version, promote]);
+
+  // Closing the tab is the dismissal.
+  useEffect(() => {
+    if (isOpen) {
+      wasOpen.current = true;
+      return;
+    }
+    if (wasOpen.current) {
+      wasOpen.current = false;
+      markSeen();
+    }
+  });
+}

--- a/src/renderer/features/workspace/CenterWorkspace.tsx
+++ b/src/renderer/features/workspace/CenterWorkspace.tsx
@@ -33,6 +33,8 @@ import { useResumeStore } from '@/renderer/stores/useResumeStore';
 import { useDocumentStore } from '@/renderer/stores/useDocumentStore';
 import { ResumeBanner } from '@/renderer/features/resume/ResumeBanner';
 import { DiffWorkspace } from '@/renderer/features/git/diff/DiffWorkspace';
+import { ReleaseNotesDocument } from '@/renderer/features/updates/ReleaseNotesDocument';
+import { useReleaseNotes, useReleaseNotesTab } from '@/renderer/features/updates/useReleaseNotes';
 import { DocumentTabs } from './DocumentTabs';
 
 export function CenterWorkspace() {
@@ -70,6 +72,13 @@ export function CenterWorkspace() {
   // A promoted diff takes over the column: the conversation chrome below
   // (session header, services, banners, composer) belongs to the conversation
   // document, and re-rendering it above a diff would waste three rows.
+  const releaseNotes = useReleaseNotes();
+
+  // Opens the What's New tab once on a new version, and treats closing it as
+  // the dismissal. Mounted before any early return so its effects run on every
+  // render path, including the document-takeover one below.
+  useReleaseNotesTab(session?.id ?? null);
+
   if (session && activeDoc && activeDoc.ref.kind !== 'conversation') {
     return (
       <main className="flex h-full min-h-0 flex-col bg-surface">
@@ -84,6 +93,8 @@ export function CenterWorkspace() {
             staged={activeDoc.ref.staged}
             baseRef={activeDoc.ref.baseRef}
           />
+        ) : activeDoc.ref.kind === 'release-notes' ? (
+          <ReleaseNotesDocument key={activeDoc.id} version={activeDoc.ref.version} />
         ) : (
           <div className="flex min-h-0 flex-1 items-center justify-center text-[12px] text-faint">
             {activeDoc.ref.path}
@@ -131,6 +142,11 @@ export function CenterWorkspace() {
                   </div>
                 </div>
               )
+            ) : releaseNotes.unseen ? (
+              // Freshly updated with no session selected: the notes would
+              // otherwise be unreachable, because the document strip that hosts
+              // them is session-scoped.
+              <ReleaseNotesDocument version={releaseNotes.version} />
             ) : (
               <div className="m-auto flex flex-col items-center gap-4 text-center">
                 <Logo size={40} />

--- a/src/renderer/features/workspace/DocumentTabs.tsx
+++ b/src/renderer/features/workspace/DocumentTabs.tsx
@@ -11,7 +11,7 @@
  * never opens a diff keeps exactly the layout it had before this existed.
  */
 import { useState } from 'react';
-import { MessageSquare, Pin, X } from 'lucide-react';
+import { MessageSquare, Pin, Sparkles, X } from 'lucide-react';
 import { cn } from '@/renderer/lib/cn';
 import { getFileIcon } from '@/renderer/lib/fileIcons';
 import {
@@ -87,16 +87,21 @@ function DocumentTab({
   onDropBefore: (after: boolean) => void;
 }) {
   const isConversation = entry.ref.kind === 'conversation';
+  const isReleaseNotes = entry.ref.kind === 'release-notes';
   // The file's own icon, not a generic diff glyph — a diff tab should read as
-  // the same kind of object as every other editor tab.
-  const spec = isConversation ? null : getFileIcon(entry.title);
-  const Icon = spec?.icon ?? MessageSquare;
-  const path = entry.ref.kind === 'conversation' ? undefined : entry.ref.path;
+  // the same kind of object as every other editor tab. Release notes are not a
+  // file, so they carry their own mark rather than a guess from the title.
+  const spec = isConversation || isReleaseNotes ? null : getFileIcon(entry.title);
+  const Icon = isReleaseNotes ? Sparkles : (spec?.icon ?? MessageSquare);
+  const path =
+    entry.ref.kind === 'conversation' || entry.ref.kind === 'release-notes'
+      ? undefined
+      : entry.ref.path;
   const staged = entry.ref.kind === 'diff' && entry.ref.staged;
   const baseRef = entry.ref.kind === 'diff' ? entry.ref.baseRef : undefined;
 
   const title = [
-    path ?? 'Conversation',
+    path ?? (isReleaseNotes ? entry.title : 'Conversation'),
     staged ? 'staged' : undefined,
     baseRef ? `vs ${baseRef}` : undefined,
   ]

--- a/src/renderer/lib/commands.ts
+++ b/src/renderer/lib/commands.ts
@@ -16,6 +16,8 @@ import { useFileSystemStore } from '@/renderer/stores/useFileSystemStore';
 import { useTerminalStore } from '@/renderer/stores/useTerminalStore';
 import { useVoiceStore } from '@/renderer/stores/useVoiceStore';
 import { useDocumentStore } from '@/renderer/stores/useDocumentStore';
+import { useUpdateStore } from '@/renderer/stores/useUpdateStore';
+import { releaseNotesRef } from '@/renderer/features/updates/useReleaseNotes';
 
 /** Set the composer's default permission mode (Plan / Ask before edits / Accept edits). */
 function setDefaultMode(defaultMode: SessionPermissionMode): void {
@@ -151,6 +153,20 @@ export const COMMANDS: Command[] = [
   // Workspace documents. Ctrl+Tab / Ctrl+Shift+Tab already cycle WORKTREE tabs
   // (above), so documents deliberately take Mod+PageDown / Mod+PageUp instead of
   // stealing a binding that already means something else in this window.
+  {
+    // The equivalent of Claude Code's `/release-notes`: the notes normally
+    // appear once after an update, so there has to be a way back to them.
+    id: 'updates.releaseNotes',
+    title: "What's New in this version",
+    section: 'Workspace',
+    inPalette: true,
+    run: () => {
+      const sessionId = useSessionStore.getState().selectedId;
+      const version = useUpdateStore.getState().status.currentVersion;
+      if (!sessionId || !version) return;
+      useDocumentStore.getState().promote(sessionId, releaseNotesRef(version));
+    },
+  },
   {
     id: 'document.next',
     title: 'Next document tab',

--- a/src/renderer/stores/useDocumentStore.ts
+++ b/src/renderer/stores/useDocumentStore.ts
@@ -24,7 +24,13 @@ import { debounce } from '@/renderer/lib/debounce';
 export type DocumentRef =
   | { kind: 'conversation' }
   | { kind: 'diff'; path: string; staged: boolean; baseRef?: string }
-  | { kind: 'file'; path: string };
+  | { kind: 'file'; path: string }
+  /**
+   * The release notes for one app version. Pathless — unlike every other kind
+   * it does not point at a file in the repository, which is why `documentId`
+   * and `titleFor` below both need an explicit case for it.
+   */
+  | { kind: 'release-notes'; version: string };
 
 export type DocumentId = string;
 
@@ -126,6 +132,9 @@ const CONVERSATION_ENTRY: DocumentEntry = {
 export function documentId(ref: DocumentRef): DocumentId {
   if (ref.kind === 'conversation') return CONVERSATION_ID;
   if (ref.kind === 'file') return `file:${ref.path}`;
+  // Keyed by version, so notes for two versions are two documents and the tab
+  // for a version already read is never reused for a newer one.
+  if (ref.kind === 'release-notes') return `release-notes:${ref.version}`;
   return `diff:${ref.staged ? 's' : 'w'}:${ref.baseRef ?? ''}:${ref.path}`;
 }
 
@@ -141,6 +150,9 @@ function basename(p: string): string {
 
 function titleFor(ref: DocumentRef): string {
   if (ref.kind === 'conversation') return 'Conversation';
+  // Must precede the `basename` call: this ref has no path, and reading one
+  // would hand `basename` an undefined and throw while opening the tab.
+  if (ref.kind === 'release-notes') return "What's New";
   return basename(ref.path);
 }
 
@@ -171,6 +183,12 @@ const persist = debounce((bySession: Record<string, SessionDocuments>) => {
     for (const id of session.order) {
       const entry = session.docs[id];
       if (!entry || entry.ref.kind === 'conversation') continue;
+      // Release notes are deliberately NOT restored: reopening What's New on
+      // every launch is the exact behaviour "dismiss until the next update" is
+      // meant to prevent. Skipped explicitly rather than left to be dropped by
+      // the pathless-ref filter in SettingsManager, so the intent is in the
+      // code instead of being an accident of a downstream guard.
+      if (entry.ref.kind === 'release-notes') continue;
       if (documents.length >= DOCUMENT_LIMITS.maxPersisted) break;
       documents.push({
         sessionId,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -887,6 +887,9 @@ export const DEFAULT_SETTINGS: AppSettings = {
   updates: {
     autoCheck: true,
     autoDownload: true,
+    // Empty on a fresh install: the very first launch shows the notes for the
+    // version it shipped with, which is the correct introduction to the app.
+    lastSeenVersion: '',
   },
   voice: {
     enabled: true,

--- a/src/shared/releaseNotes.generated.ts
+++ b/src/shared/releaseNotes.generated.ts
@@ -1,0 +1,289 @@
+/**
+ * GENERATED FILE — DO NOT EDIT.
+ *
+ * Written by `npm run gen:notes` (scripts/gen-release-notes.mjs) from
+ * CHANGELOG.md, which is the single source of truth for release notes: the same
+ * text becomes the GitHub release body, this in-app "What's New" tab, and the
+ * changelog itself. Re-run the script after editing CHANGELOG.md.
+ *
+ * Contains the 3 most recent released sections.
+ */
+
+/** One release's notes, as authored in CHANGELOG.md. */
+export interface ReleaseNotesEntry {
+  /** Semantic version, without a leading `v`. */
+  version: string;
+  /** ISO release date, or null for a section written without one. */
+  date: string | null;
+  /** The section body as Markdown — headings and bullets, no version heading. */
+  markdown: string;
+}
+
+/** Newest first. */
+export const RELEASE_NOTES: ReleaseNotesEntry[] = [
+  {
+    version: '1.7.0',
+    date: '2026-07-26',
+    markdown: `Adds the **Work Graph** — a typed, queryable graph of what a session actually
+did, built from both coding agents' event streams and owned entirely by Limboo —
+along with a document-oriented workspace where diffs open as first-class tabs,
+and an in-app **What's New** tab so an update can finally tell you what changed.
+
+### Added
+
+- **The Work Graph (DAWG).** Every session's execution is recorded as a Directed
+  Acyclic Work Graph — objectives, plans, tasks, subagents, investigations,
+  searches, memory lookups, MCP calls, commands, files, commits, approvals and
+  results — connected by nine typed relationships (\`follows\`, \`contains\`,
+  \`generated\`, \`depends-on\`, \`implemented-in\`, \`verified-by\`, \`blocked-by\`,
+  \`reviewed-by\`, \`produced-artifact\`). Neither Claude nor Cursor exposes a work
+  graph; both are conversation-driven. This is Limboo's own layer, derived from
+  the structured events they *do* emit, so it records both agents identically and
+  every future adapter contributes nodes for free. It is deliberately shaped like
+  a git history — vertical execution lanes, one node per row, commits in a
+  right-hand gutter — rather than a free-floating node diagram, because that is
+  the mental model developers already have. Layout runs in a Web Worker and rows
+  virtualize, so a long session stays responsive.
+- **Structural search over the graph.** Queries traverse *shape*, not just text:
+  an FTS5 seed set (free text, node kinds, statuses, time range) expanded by a
+  bounded closure over the edge table. "Every task blocked by X" is a traversal,
+  not a transcript scroll.
+- **Eight export formats.** JSON, Markdown, Mermaid, Graphviz DOT, CSV and a
+  self-contained HTML report are rendered from the stored graph; SVG and PNG are
+  rendered from the layout. Exports go to the clipboard or to a file you pick.
+- **A document-oriented workspace.** Diffs promote out of the Changes panel into
+  first-class tabs with their own icons, pinning, reordering, close/reopen and
+  per-document view state. \`ChangesNavigator\` unifies file browsing across the Git
+  panel and Changes; \`DiffEditor\` adds syntax highlighting and word-level diffs.
+- **A "What's New" tab.** When Limboo starts on a version it has not shown you
+  before, the release notes for *that* version open as a workspace tab. Closing it
+  is remembered until the next update. It is available any time from the command
+  palette, and — like Claude Code's own \`/release-notes\` — it is display-only and
+  never enters the agent's context.
+
+### Fixed
+
+- **The work graph silently discarded whole batches of its own data.** A node
+  whose payload exceeded the size cap was skipped, but the edges pointing at it
+  were still written. \`INSERT OR IGNORE\` does not suppress a FOREIGN KEY
+  violation, so the failing edge aborted the entire transaction and took every
+  other node and edge in that flush with it — behind a single \`logger.warn\`.
+  Oversized nodes are now shrunk rather than dropped, every edge's endpoints are
+  proven to exist before insert, and persistent failures surface as a banner in
+  the panel instead of an innocent-looking empty graph.
+- **Orphan cleanup deleted real work.** It removed any node with no edge, which is
+  the normal state of a terminal opened outside a run, a commit made with no agent
+  active, or a service started before the first prompt. Those kinds are now exempt.
+- **Commits could be attributed to the wrong session, or lost entirely.** An
+  unattributable commit was still recorded as "seen", so it was dropped
+  permanently at the exact moment its session next became active. It is now only
+  marked seen once it has been attributed. Separately, a \`git pull\` bringing in
+  upstream commits claimed the current run had implemented its files in every one
+  of them; that fan-out is now limited to commits made after the run started.
+- **Subagent work was spliced into the main timeline.** The \`contains\`
+  relationship was defined, drawn by the layouter and listed in the legend, but
+  nothing ever emitted it. Subagent nesting now rides the Agent SDK's
+  \`parent_tool_use_id\`, so a subagent's steps sit inside the node that spawned
+  them. (Cursor's print mode has no subagents, so the branch simply never forks
+  there.)
+- **Permission decisions were never recorded.** Approval nodes were inferred by
+  string-matching a log line's \`"Blocked…"\` prefix, which could not see the answer
+  the user actually gave. They now come from the one decision gate both providers
+  call, carrying the real decision, tool and risk.
+- **Nodes were labelled with the wrong agent.** Provider and mode were read from
+  current settings at write time rather than captured per run, so switching models
+  mid-session silently relabelled a run's history.
+- **Two release gates were not actually verifying anything.** Both were found by
+  checking the published v1.6.0 artifacts by hand rather than trusting a green
+  pipeline:
+  - The Squirrel.Mac layout check — the gate that exists to catch the defect that
+    made every macOS update in v1.5.x impossible — reported "no macOS update zips
+    in this build" and passed. It matched on a \`-mac.zip\` filename suffix, and
+    the packaging fix in 1.6.0 renamed the artifacts to \`-<arch>.zip\`. The zip
+    list now comes from \`latest-mac.yml\`, which is naming-independent and
+    authoritative, and a macOS feed with no matching zip is a failure rather than
+    a skip — a build can no longer opt out of its own regression gate.
+  - \`SHA256SUMS\` listed \`limboo-package.cyclonedx.json\`, a side-file the SBOM
+    action writes but the upload globs exclude, so \`sha256sum -c SHA256SUMS\`
+    exited non-zero on an otherwise correct release — discrediting the one
+    verification command the README and release notes give users. It is excluded
+    from the publish set, and a new check fails the build if the manifest names
+    anything that is not being published. (The v1.6.0 manifest was corrected in
+    place; its remaining hashes were always valid.)
+
+### Changed
+
+- **Release notes now come from this file.** The GitHub release body was
+  generated from commit subjects while the changelog was written by hand, so the
+  two said different things about the same release and nothing connected them.
+  The notes generator now reads the section for the tag being released and falls
+  back to the previous commit-subject behaviour only when there isn't one — which
+  also means the notes shown inside the app, the notes on the release page, and
+  this file are the same text by construction.
+- **An active icon is marked by its own color, not a filled block behind it.** In
+  the activity rail, the title-bar tab strip and the settings navigation, the
+  background plate is gone and the glyph takes the accent color. On a pure-black
+  canvas the plate read as a second element competing with the icon it sat
+  behind. Hover still shows it, where it is feedback rather than state.
+
+### Security
+
+- **The graph's secret redactor missed the case its own guide calls out.** It is
+  shared with the Hook Engine, so a gap in it was a gap in two subsystems. It now
+  covers credential-bearing URLs (\`https://user:token@host\` — a remote typed into
+  a terminal became a node title verbatim), GitHub, AWS and Slack tokens, PEM
+  private-key blocks, JWTs, and generic \`secret=\`-shaped assignments. Redaction
+  also runs recursively over a node's whole metadata on the single path into the
+  database, rather than only over its title and detail, so a future field is
+  covered without having to opt in.
+- **Export writes to disk without the renderer ever naming a path.** Saving a
+  graph sends only a session id and a format; the main process opens the save
+  dialog and writes wherever you chose. There is no renderer-supplied path, and
+  therefore no traversal surface to defend.
+- **Query inputs are bounded before they are examined.** Array arguments are
+  capped before filtering (an oversized array was previously walked in full),
+  export results are byte-capped, and edge reads are limited instead of unbounded
+  table scans.`,
+  },
+  {
+    version: '1.6.0',
+    date: '2026-07-25',
+    markdown: `Repairs in-app updating, which has never worked on macOS and could fail to
+install or restart anywhere; adds code signing and a Microsoft Store channel;
+and extends the release to every architecture, including Arch/Manjaro packages
+and arm64 builds for all three platforms.
+
+### Fixed
+
+- **"Restart & install" did nothing.** Clicking it could leave the app running on
+  the old version, or quit without ever coming back. Four separate causes:
+  - The install request was gated on the UI stage being \`downloaded\`, but the
+    hourly poll re-emitted \`update-available\` for the already-downloaded version
+    and moved the stage off it. The click then returned with no log, no error and
+    no feedback of any kind. Staged updates are now tracked by version
+    independently of the UI stage, polling is suspended while an update is
+    staged, and every refusal is logged and surfaced to the user.
+  - **The restart lost a race with itself.** \`quitAndInstall\` spawns the
+    replacement process synchronously but defers \`app.quit()\` to the next tick,
+    so the new instance hit \`requestSingleInstanceLock()\` while the old one still
+    held it and quit itself. The lock is now released before the handoff, and
+    \`second-instance\` events are ignored while an update is in flight.
+  - **A throwing disposer could keep the app alive.** \`before-quit\` ran thirteen
+    \`dispose()\` calls with no error containment; one throw aborted the rest and
+    was swallowed by the global \`uncaughtException\` handler, leaving the process
+    up with an installer waiting on it. Each disposer is now isolated, and a
+    watchdog forces the exit if the process is still running four seconds after
+    the handoff.
+  - Windows now installs silently (\`--updated /S --force-run\`). Without \`/S\` the
+    assisted NSIS wizard re-ran from the first page, which reads as "nothing
+    happened".
+- **macOS auto-update was impossible, and the "Intel" downloads were arm64
+  builds.** \`scripts/dist.mjs\` passed the Forge output *directory* to
+  \`electron-builder --prepackaged\`, but electron-builder treats that value as the
+  \`.app\` bundle path on macOS. The published update zips were rooted at
+  \`Limboo-darwin-arm64/\` instead of \`Limboo.app/\`, which Squirrel.Mac cannot
+  install — they downloaded and checksummed perfectly and then failed, every
+  time. The same misconfiguration made electron-builder wrap that one
+  single-architecture directory once per architecture listed in
+  \`electron-builder.yml\`, so \`Limboo-1.5.1-mac.zip\` ("Intel") and
+  \`Limboo-1.5.1-arm64-mac.zip\` were byte-identical. Fixed by pointing
+  \`--prepackaged\` at the bundle on darwin and removing every explicit \`arch:\`
+  list, so the architecture comes only from the CI matrix.
+  **Users on v1.5.1 or earlier must download the new \`.dmg\` once, manually** —
+  those builds cannot auto-update to this release.
+- **Linux \`.deb\` / \`.rpm\` installs never received updates.** Self-update was
+  disabled unless \`APPIMAGE\` was set, though electron-updater has supported
+  installing deb, rpm and pacman packages through the system package manager for
+  some time. The app now selects its updater explicitly — \`APPIMAGE\` first, then
+  the \`package-type\` marker — which also fixes AppImages that shipped a stale
+  \`deb\`/\`rpm\` marker from electron-builder's shared staging directory and so
+  routed AppImage users to the wrong updater.
+
+### Added
+
+- **A code-signing pipeline.** Developer ID signing + notarization for macOS
+  (hardened runtime + entitlements) — which is also what makes macOS auto-update
+  possible at all, since Squirrel.Mac refuses to update an app it cannot verify —
+  and Authenticode for Windows, with Azure Trusted Signing wired and dormant
+  beside a self-signed route. Note that a self-signed certificate does **not**
+  remove the SmartScreen warning; it is documented as such. The whole path is
+  opt-in from environment credentials (\`scripts/signing.cjs\`), so builds without
+  them — **including this release** — are unsigned and behave exactly as before.
+  Because signing runs in Forge rather than electron-builder — \`--prepackaged\`
+  skips the pack step where electron-builder would sign — the split is documented
+  in [code signing](docs/ci/code-signing.md).
+- **A Microsoft Store (MSIX) channel**, the only warning-free Windows route that
+  does not require buying a certificate. Store builds disable self-update, since
+  the Store owns updates there. See
+  [microsoft-store.md](docs/operations/microsoft-store.md).
+- **Wider platform coverage.** Linux gains \`pacman\` (Arch/Manjaro) and \`tar.gz\`
+  targets, and every platform now publishes both x64 and arm64. The
+  architectures GitLab's SaaS runners cannot build — macOS Intel, arm64 Linux,
+  arm64 Windows — are produced by a new tag-triggered
+  \`release-supplement.yml\` workflow that uploads into the same release.
+- **Release gates for the failures above.**
+  \`ci/scripts/verify-artifacts.mjs\` asserts the macOS zip root, that no two
+  artifacts in an update feed share a hash, that every file a feed references
+  exists, and that debug output stays out of the publish set.
+  \`ci/scripts/verify-signing.mjs\` gained a Gatekeeper assessment and enforces the
+  Windows \`publisherName\` invariant.
+  \`ci/scripts/merge-update-metadata.mjs\` merges the per-runner update feeds, so a
+  supplementary upload adds an architecture instead of deleting one.
+- [auto-update.md](docs/operations/auto-update.md) — the per-platform update
+  mechanism and the invariants that must not be broken.
+- Documentation subsystem: landing \`README\`, a structured \`docs/\` site (getting
+  started, concepts, guides, reference, architecture, operations), community-health
+  files (\`LICENSE\`, \`CONTRIBUTING\`, \`CODE_OF_CONDUCT\`, \`SECURITY\`, \`ROADMAP\`,
+  \`SUPPORT\`, \`GOVERNANCE\`, \`AUTHORS\`, \`CITATION.cff\`), and \`.github/\` automation
+  (CI, CodeQL, Dependabot, issue/PR templates).
+
+### Security
+
+- Windows update-signature verification is pinned off
+  (\`win.verifyUpdateCodeSignature: false\`) while the self-signed route is in use,
+  and enforced in CI. Left at its default, electron-builder derives
+  \`publisherName\` from the certificate CN and writes it into \`app-update.yml\`;
+  electron-updater would then demand a trusted Authenticode chain that a
+  self-signed certificate can never satisfy, breaking every Windows update with
+  no recovery short of a manual reinstall.
+
+### Changed
+
+- **Integrated Terminal** — pinned \`node-pty\` to the \`1.2.0-beta\` line,
+  Microsoft's in-progress rewrite of the native addon on Node-API
+  (\`node-addon-api\`) instead of NAN. The compiled binary is ABI-stable across
+  Node.js *and* Electron major versions, so the per-platform prebuilt bundled
+  in the npm package works as-is — no \`node-gyp\` rebuild, no Visual Studio
+  Build Tools requirement, for any Electron version including future ones.
+  \`forge.config.ts\`'s \`rebuildConfig.ignoreModules\` excludes \`node-pty\` from
+  Electron Forge's native-rebuild pass, since \`@electron/rebuild\` doesn't know
+  the bundled prebuilt is already correct and would otherwise try (and fail
+  without the toolchain) to recompile it. No terminal behavior change. (An
+  earlier attempt at this used \`@homebridge/node-pty-prebuilt-multiarch\`, a
+  NAN-based fork — verified afterward to have no published prebuilt past
+  roughly Electron 29's ABI, so it didn't actually fix the problem; superseded
+  by this change.) See [installation](docs/getting-started/installation.md).`,
+  },
+  {
+    version: '1.5.1',
+    date: '2026-07-25',
+    markdown: `### Fixed
+
+- **Linux packages could not launch.** \`electron-builder.yml\` set no
+  \`linux.executableName\`, so electron-builder derived every Linux launcher path
+  from the package name (\`limboo\`, lowercase) while Electron Forge — which owns
+  packaging and hands the result over via \`--prepackaged\` — produced the binary
+  as \`Limboo\`. On a case-sensitive filesystem that mismatch broke all three
+  Linux artifacts in v1.5.0: the AppImage's \`AppRun\` exec'd a non-existent
+  \`limboo\` and failed to start at all, and the deb/rpm shipped a
+  \`.desktop\` entry pointing at \`/opt/Limboo/limboo\` plus a dangling
+  \`/usr/bin/limboo\` symlink. Windows and macOS were unaffected. The application
+  itself was never broken — only the launchers around it.`,
+  },
+];
+
+/** The notes for one version, or null when this build does not carry them. */
+export function releaseNotesFor(version: string): ReleaseNotesEntry | null {
+  const wanted = version.replace(/^v/, '');
+  return RELEASE_NOTES.find((r) => r.version === wanted) ?? null;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -599,6 +599,13 @@ export interface AppSettings {
     autoCheck: boolean;
     /** Download an available update automatically (else wait for the user). */
     autoDownload: boolean;
+    /**
+     * The last app version whose release notes the user has seen, `''` before
+     * they have seen any. Written when the What's New tab is CLOSED, not when
+     * it opens — so notes are never marked read on a launch nobody looked at.
+     * Any mismatch with the running version opens the tab exactly once.
+     */
+    lastSeenVersion: string;
   };
   /**
    * Voice subsystem — speech is another input/output modality for the SAME
@@ -3146,6 +3153,7 @@ export type CommandId =
   | 'document.reopenClosed'
   | 'document.next'
   | 'document.prev'
+  | 'updates.releaseNotes'
   | 'diff.toggleSplit'
   | 'drawer.toggleFiles'
   | 'drawer.toggleChanges'


### PR DESCRIPTION
## Why

`CHANGELOG.md` was connected to nothing. A repo-wide grep for `CHANGELOG` across
`.ts/.tsx/.mjs/.yml` returned zero hits — the GitHub release body was generated
from commit subjects while the changelog was written by hand, so the two
described the same release differently.

And the app could tell you an update was *available* but never what you *got*:
`UpdateInfo.releaseNotes` describes the version being offered, is HTML-stripped
and capped on the way through the updater, and is destroyed by the restart that
installs the update.

## What changed

**One source of truth.** `generate-release-notes.mjs` now reads the CHANGELOG
section for the tag being released, falling back to the existing commit-subject
categorization only when there isn't one — so the change is additive and a tag
cut without a changelog entry still gets the notes it always got. It also stops
crashing when previewing a not-yet-created tag, which is exactly what
`docs/ci/release-process.md` instructs maintainers to do.

**In-app What's New.** The notes are compiled into the bundle from the changelog
(`npm run gen:notes`), so they always match the running build, work offline and
in development, and need no network. They open once as a workspace tab when the
running version differs from the last acknowledged one; closing the tab is the
acknowledgement, persisted in `settings.updates.lastSeenVersion`.

The tab reuses the existing document machinery — the `kind: 'file'` arm was an
unimplemented stub — and the existing sanitized `Markdown` renderer, so there is
no new dependency and no new IPC channel. It is display-only and never reaches
an agent context provider: Claude Code shipped a fix for exactly that bug, where
its release-notes view injected the whole changelog into every later request.

**Active state.** The filled `bg-surface-2` plate behind an active icon is gone
from the activity rail, the title-bar tab strip and the settings navigation; the
accent glyph is now the sole signal. Hover keeps the plate, where it is feedback
rather than state. Badge bubbles, the sessions row accent bar and the tab
underlines are untouched.

**v1.7.0 prep.** Changelog section, compare links, README release line.
`package.json` version deliberately left at its placeholder — the tag supplies it.

## Verification

- `npx vite build --config vite.renderer.config.mts` and `npm run lint` pass.
- `generate-release-notes.mjs v1.7.0` reports it used the CHANGELOG section;
  a tag without one reports the git-history fallback.
- `npm run gen:notes` is idempotent (re-running produces no diff).
- App boots clean; `lastSeenVersion` persists via deep-merge with no migration.

Not verified from the CLI: the tab's appearance and the close→dismiss round
trip need a GUI.