### PR TITLE
Fix/mcp plan ask gate

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -524,6 +524,7 @@ function migrate(database: Database.Database): void {
       enabled               INTEGER NOT NULL DEFAULT 1,
       startup               TEXT NOT NULL DEFAULT 'on-demand',
       trust                 TEXT NOT NULL DEFAULT 'ask',
+      plan_access           TEXT NOT NULL DEFAULT 'annotated',
       timeout_ms            INTEGER NOT NULL DEFAULT 60000,
       restart_policy        TEXT NOT NULL DEFAULT 'on-failure',
       providers_json        TEXT NOT NULL DEFAULT '{"claude":true,"cursor":true}',
@@ -656,6 +657,15 @@ function migrate(database: Database.Database): void {
     type: 'TEXT',
     notNull: true,
     default: '',
+  });
+  // How far a server's tools reach inside the read-only plan/ask session modes,
+  // which otherwise deny every non-read tool outright (McpPlanAccess). Existing
+  // rows adopt 'annotated': only tools the server itself declares read-only —
+  // and even those still prompt unless the server is also marked trusted.
+  addColumnIfMissing(database, 'mcp_servers', 'plan_access', {
+    type: 'TEXT',
+    notNull: true,
+    default: 'annotated',
   });
 
   const current = database

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -203,6 +203,10 @@ function bootstrap(): void {
     // health probes, and permission trust. Its own SecretStore instance (the
     // store is stateless — filesystem-backed) keeps MCP secrets namespaced.
     mcp = new McpManager(new SecretStore(), settings, workspace);
+    // A run's MCP scope comes from ITS session's workspace, not from whichever
+    // workspace happens to be active — otherwise switching projects mid-run
+    // silently changes which servers the permission gate can see.
+    mcp.setSessionManager(sessions);
     // The Work Graph — a provider-neutral platform service owned by the app,
     // peer to Memory / Search / Resume. It normalizes BOTH adapters' event
     // streams into one typed, queryable DAG of the work itself. Purely

--- a/src/main/managers/AgentManager.ts
+++ b/src/main/managers/AgentManager.ts
@@ -116,7 +116,7 @@ import { createMemoryMcpServer } from './memory/memoryTools';
 import type { AttachmentManager } from './attachments/AttachmentManager';
 import type { SearchManager } from './search/SearchManager';
 import { createSearchMcpServer } from './search/searchTools';
-import type { McpManager } from './mcp/McpManager';
+import type { McpManager, McpPlanVerdict } from './mcp/McpManager';
 
 /* ------------------------------------------------------------------ */
 /* ESM loader — the SDK is ESM-only; main is a CJS bundle. Load it with */
@@ -240,14 +240,107 @@ function classifyTool(name: string): ToolRisk {
   if (WRITE_TOOLS.has(name)) return 'write';
   if (COMMAND_TOOLS.has(name)) return 'command';
   if (READ_TOOLS.has(name)) return 'read';
-  // Unknown / MCP tools are gated as commands (the conservative default). This
-  // also covers the SDK's Task subagent tool: it is gated as a command through
-  // decideToolUseCore, and every tool the subagent then runs re-enters the SAME
-  // canUseTool with the SAME cwd — and the parent run's `Options.sandbox` is
-  // process-wide — so a subagent inherits the exact worktree boundary, network
-  // policy, and OS jail of its parent. No path here ever widens a subagent's
-  // access (per the SDK docs: subagents use the parent's sandbox configuration).
+  // Unknown / MCP tools are gated as commands (the conservative default). That
+  // includes the SDK's Task/Agent subagent tool, which stays a 'command' here so
+  // it keeps prompting in default/acceptEdits mode.
+  //
+  // What makes a subagent safe is NOT sandbox inheritance — `mapClaudeSandbox`
+  // returns undefined whenever the network policy is 'all' (the default), so
+  // there is frequently no OS jail to inherit, and the subagent input carries
+  // its own `dangerouslyDisableSandbox` flag. The load-bearing invariant is
+  // that `makeCanUseTool` builds ONE closure per query: every tool a subagent
+  // calls re-enters the SAME canUseTool with the SAME `permMode` and the SAME
+  // cwd. A subagent spawned during a plan run is therefore bound by this exact
+  // gate and can still only read. See PLAN_SAFE_BUILTINS.
   return 'command';
+}
+
+/**
+ * Built-in provider tools that may still run in the read-only session modes.
+ *
+ * Without this, `classifyTool`'s conservative 'command' default means plan/ask
+ * hard-denies the SDK's subagent tool — so the agent cannot delegate exploration
+ * while planning, in any project. Claude Code's own Plan Mode permits `Task`
+ * (forbidding only Edit/Write/Bash), so denying it made Limboo diverge from the
+ * provider it wraps. Names verified against the pinned CLI binary, which defines
+ * BOTH `Agent` and `Task` as wire names for the subagent tool.
+ *
+ * Consumed ONLY by the plan/ask branch — never folded into `effectiveRisk`,
+ * which feeds `autoApproveReads`. Folding `Task` in would let a subagent spawn
+ * with no prompt in DEFAULT mode; the point here is narrower, that planning
+ * stops being a dead end.
+ *
+ * Safety rests on the closure invariant documented in `classifyTool`: every tool
+ * the subagent calls re-enters this same gate with this same `permMode`, so a
+ * subagent inside a plan run can only read.
+ *
+ * To add a future provider tool: append it here and state why it cannot mutate.
+ * Deliberately EXCLUDED — `SlashCommand` (arbitrary command expansion),
+ * `RefreshMcpTools` (re-probes servers: real spawns/network), `Skill` (injects
+ * instructions that steer later tools, and Limboo has no Skill surface), and
+ * `ReadMcpResource`, which names a server and so is gated on that server's own
+ * `planAccess` instead (see decideToolUseCore).
+ */
+const PLAN_SAFE_BUILTINS = new Set([
+  'Task', 'Agent', // spawn a subagent — bound by this same gate
+  'TaskOutput', 'TaskGet', 'TaskList', // observe one
+  'TaskStop', // halting work is not a mutation
+  'TaskCreate', 'TaskUpdate', // checklist bookkeeping; defensive, since
+  // CLAUDE_CODE_ENABLE_TASKS=0 pins TodoWrite on today
+  'ListMcpResources', // enumerate resource URIs; no fetch
+]);
+
+/** Subagent tools that accept an opt-out from the OS sandbox. */
+const SUBAGENT_TOOLS = new Set(['Task', 'Agent']);
+
+/**
+ * Provider tools that read an MCP RESOURCE. They take `{ server, uri }`, so they
+ * are gated on the named server's own `planAccess` rather than listed in
+ * PLAN_SAFE_BUILTINS — a blanket allow would reach past a blocked server.
+ */
+const RESOURCE_READ_TOOLS = new Set(['ReadMcpResource', 'ReadMcpResourceDir']);
+
+/**
+ * The remedy sentence appended to a plan/ask denial of an MCP tool.
+ *
+ * Each verdict points at the thing the user would actually have to change. The
+ * previous single message always blamed the `planAccess` setting, which is wrong
+ * — and actively misleading — when the server is unknown, belongs to another
+ * workspace, or is simply not trusted.
+ */
+function mcpDenyReason(verdict: McpPlanVerdict, toolName: string): string {
+  if (verdict.ok) return '';
+  switch (verdict.reason) {
+    case 'mcp-disabled':
+      return 'MCP is disabled in Settings › MCP.';
+    case 'unknown-server':
+      return `No configured MCP server matches ${toolName}.`;
+    case 'out-of-scope':
+      return `The MCP server "${verdict.server}" is not configured for this session's workspace.`;
+    case 'blocked':
+    case 'not-annotated':
+      return `If this tool only reads, allow it under Settings › MCP › ${verdict.server} › "Plan & Ask access".`;
+    default:
+      return '';
+  }
+}
+
+/**
+ * Is this a built-in the read-only modes may run?
+ *
+ * Input-aware because the subagent tools carry `dangerouslyDisableSandbox`:
+ * planning must not silently start a subagent that asked to run outside the
+ * jail, even though this gate would still confine its children to reads.
+ */
+function isPlanSafeBuiltin(name: string, input: Record<string, unknown>): boolean {
+  if (!PLAN_SAFE_BUILTINS.has(name)) return false;
+  if (
+    SUBAGENT_TOOLS.has(name) &&
+    (input as { dangerouslyDisableSandbox?: unknown }).dangerouslyDisableSandbox === true
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function filePathOf(input: Record<string, unknown>): string | undefined {
@@ -396,6 +489,19 @@ interface ActiveRun {
   /** Attachments riding this turn (manifest + vision blocks; reused on retry). */
   attachmentIds?: string[];
   /**
+   * The workspace this run's MCP scope was resolved against, pinned at run start.
+   *
+   * The run-start injection (`options.mcpServers` / `options.allowedTools`, the
+   * generated `.cursor/mcp.json`) is a SNAPSHOT, while the permission gate
+   * re-resolves on every tool call. If the active workspace changes mid-run —
+   * a switch, or a removal, neither of which cancels an in-flight run — the two
+   * stop agreeing: a trusted server starts prompting and a plan-readable one
+   * gets hard-denied, both for servers that are still live in the query.
+   * Pinning it here makes them agree structurally rather than by timing. Same
+   * idea as resolving `cwd` once in runOnce and closing over it.
+   */
+  mcpScopeWorkspaceId?: string | null;
+  /**
    * Cursor runs only: absolute path of the per-run in-workspace attachment
    * staging dir (`<root>/.limboo/attachments`). The read-flip hook and the
    * decideToolUse attachment carve-out honor it alongside the userData dir.
@@ -501,6 +607,22 @@ export class AgentManager {
   /** Inject the Session Manager so the first prompt can name an untitled session. */
   setSessionManager(sessions: SessionManager): void {
     this.sessions = sessions;
+  }
+
+  /**
+   * Pin the workspace this run's MCP servers were resolved from, so the live
+   * permission gate answers for the same set the run-start injection used even
+   * if the active workspace changes mid-run. See `ActiveRun.mcpScopeWorkspaceId`.
+   */
+  private pinMcpScope(sessionId: string, fallbackWorkspaceId: string): void {
+    const run = this.runs.get(sessionId);
+    if (!run) return;
+    run.mcpScopeWorkspaceId = this.sessions?.get(sessionId)?.workspaceId ?? fallbackWorkspaceId;
+  }
+
+  /** The pinned MCP scope for this session's active run (undefined outside a run). */
+  private mcpScopeFor(sessionId: string): string | null | undefined {
+    return this.runs.get(sessionId)?.mcpScopeWorkspaceId;
   }
 
   /**
@@ -1662,6 +1784,7 @@ export class AgentManager {
     // isInside(cwd, …) path guard automatically confines every file tool to the
     // worktree. Plain sessions keep the workspace root.
     const cwd = this.resolveSessionRoot?.(sessionId) ?? ws.path;
+    this.pinMcpScope(sessionId, ws.id);
     const agent = this.settings.getAll().agent;
 
     let streaming: ChatMessage | null = null;
@@ -1794,11 +1917,28 @@ export class AgentManager {
       // trustedToolMatchers), NOT via allowedTools, so the single permission
       // authority + governance audit still cover every MCP call.
       if (this.mcp) {
-        const inj = this.mcp.claudeServersFor();
+        const inj = this.mcp.claudeServersFor(sessionId, this.mcpScopeFor(sessionId));
         const mcpNames = Object.keys(inj.servers);
         if (mcpNames.length > 0) {
           options.mcpServers = { ...(options.mcpServers ?? {}), ...inj.servers };
           this.recordStatus(sessionId, `Loading ${mcpNames.length} MCP server(s)…`, mcpNames.join(', '));
+        }
+        // The ONE exception to the rule directly above. Under permissionMode
+        // 'plan' the SDK auto-denies every mcp__* tool BEFORE canUseTool runs,
+        // so our own plan-mode relaxation can never be reached — read-only MCP
+        // tools are unusable while planning no matter what we decide. (Ask mode
+        // is unaffected: buildOptions maps it to 'default'.)
+        //
+        // allowedTools entries run with no prompt, so membership requires an
+        // explicit human decision: either the user declared the whole server
+        // read-only (planAccess 'all' — their own assertion, made out of band in
+        // Settings), or a TRUSTED server declared the individual tool read-only
+        // (planAccess 'annotated'). See McpManager.planAllowedToolsFor for why
+        // those two cases differ. Nothing else is listed, so a run never skips
+        // an approval the user has not already given.
+        if (permMode === 'plan') {
+          const planAllow = this.mcp.planAllowedToolsFor(sessionId, this.mcpScopeFor(sessionId));
+          if (planAllow.length > 0) options.allowedTools = planAllow;
         }
       }
       this.diag('lifecycle', 'debug', 'Handshake — query opened', undefined, sessionId);
@@ -2235,7 +2375,11 @@ export class AgentManager {
     // referenced as ${env:NAME} in the generated .cursor/mcp.json (never the
     // file). Independent of the limboo bridge pipe — external servers don't need
     // it — so a server is registered even when the bridge failed to start.
-    const cursorMcp = this.mcp ? this.mcp.cursorSpecFor() : { userServers: {}, allowRules: [], secretEnv: {} };
+    // Every field of CursorMcpInjection must be present here: the allow-rule
+    // array below spreads `planAllowRules`, and spreading `undefined` throws.
+    const cursorMcp = this.mcp
+      ? this.mcp.cursorSpecFor(sessionId, this.mcpScopeFor(sessionId))
+      : { userServers: {}, allowRules: [], planAllowRules: [], secretEnv: {} };
     const hasUserServers = Object.keys(cursorMcp.userServers).length > 0;
     const limbooBridge = !!(pipe && mcpBridgePath);
     const mcpSpec: McpBridgeSpec | null =
@@ -2309,6 +2453,17 @@ export class AgentManager {
       // Trusted user MCP servers auto-approve declaratively too (Mcp(<name>:*)),
       // matching the decideToolUse trust for the Claude path.
       ...cursorMcp.allowRules,
+      // Read-only MCP tools the user opened up for the plan/ask modes. Spliced
+      // per-mode, not always, so a server granted read-only planning access does
+      // not thereby become allow-listed for ordinary runs.
+      //
+      // Note this is the ONLY enforcement surface for MCP on the Cursor path:
+      // cursor/hooks.ts has no `beforeMCPExecution`, so if `preToolUse` does not
+      // fire for MCP calls, decideToolUse never sees them and can neither prompt
+      // nor deny. Do NOT try to compensate with a broad Mcp(<name>:*) deny plus
+      // narrow allows — deny supersedes allow in Cursor's grammar and would eat
+      // the allows.
+      ...(permMode === 'plan' || permMode === 'ask' ? cursorMcp.planAllowRules : []),
     ];
     // Workspace secrets (.env / SSH keys / key-cert material) are ask-for-approval,
     // not hard-denied: on a hook-verified run the beforeReadFile hook drives the
@@ -3207,19 +3362,23 @@ export class AgentManager {
     signal: AbortSignal,
     gate?: { prompted: boolean },
   ): Promise<PermissionResult> {
-      // Sandbox-escape audit (G4): when a Bash command sets the SDK's
+      // Sandbox-escape audit (G4): when a tool sets the SDK's
       // `dangerouslyDisableSandbox` flag, it is being retried OUTSIDE the OS jail
       // and falls back to this normal permission flow. Record it in the timeline
-      // so the audit trail shows whether a command stayed contained or escaped —
-      // enforcement is unchanged (the command still passes every guard below).
+      // so the audit trail shows whether it stayed contained or escaped —
+      // enforcement is unchanged (it still passes every guard below). Covers the
+      // subagent tools as well as Bash: the flag is on all of their input
+      // schemas, and only Bash used to be recorded.
       if (
-        toolName === 'Bash' &&
+        (toolName === 'Bash' || SUBAGENT_TOOLS.has(toolName)) &&
         (input as { dangerouslyDisableSandbox?: unknown }).dangerouslyDisableSandbox === true
       ) {
         this.pushActivity(
           sessionId,
           'status',
-          'Command ran outside the sandbox — normal permission flow',
+          toolName === 'Bash'
+            ? 'Command ran outside the sandbox — normal permission flow'
+            : 'Subagent requested to run outside the sandbox — normal permission flow',
           undefined,
           'warning',
         );
@@ -3314,20 +3473,67 @@ export class AgentManager {
           (toolName === 'Bash' && isReadOnlyShellCommand(input.command)));
       const effectiveRisk: ToolRisk = readOnlyShell ? 'read' : risk;
 
+      // An external MCP tool the user declared reachable in the read-only modes
+      // (per-server `planAccess`, optionally backed by the server's own
+      // `readOnlyHint`). Every `mcp__*` name classifies as 'command' because
+      // classifyTool has no way to know better, which otherwise makes plan/ask
+      // unusable with any third-party MCP server.
+      //
+      // Deliberately NOT folded into `effectiveRisk` like `readOnlyShell` is.
+      // That relaxation rests on an allowlist WE authored; this one rests on a
+      // claim the server makes about itself, and `effectiveRisk` feeds the
+      // `autoApproveReads` branch further down — so folding it in would make a
+      // plan-mode setting silently stop these tools prompting in DEFAULT mode
+      // too. Keeping it separate means a qualifying tool merely stops being
+      // hard-denied here and falls through to the normal path: auto-allowed if
+      // its server is trusted, otherwise PROMPTED, with the chip still honestly
+      // reading 'command'.
+      const mcpScope = this.mcpScopeFor(sessionId);
+      const mcpVerdict: McpPlanVerdict | null =
+        risk === 'command' && toolName.startsWith('mcp__')
+          ? (this.mcp?.planVerdictFor(toolName, sessionId, mcpScope) ?? {
+              ok: false,
+              reason: 'mcp-disabled',
+            })
+          : null;
+      const planReadableMcp = mcpVerdict?.ok === true;
+
+      // Built-in provider tools the read-only modes may still run — chiefly the
+      // subagent tool, which Claude Code's own Plan Mode permits. Same shape and
+      // same reason as the MCP relaxation above, and equally kept out of
+      // `effectiveRisk`. See PLAN_SAFE_BUILTINS.
+      const planSafeBuiltin = risk === 'command' && isPlanSafeBuiltin(toolName, input);
+
+      // An MCP RESOURCE read names its server (these tools take `{server, uri}`),
+      // so it is gated on that server's own plan access rather than
+      // blanket-allowed — otherwise it would reach straight past a
+      // `planAccess: 'block'` server. Resources are read-only by MCP definition,
+      // so no per-item hint is consulted.
+      const planReadableResource =
+        RESOURCE_READ_TOOLS.has(toolName) &&
+        typeof input.server === 'string' &&
+        (this.mcp?.resourceReadableIn(input.server, sessionId, mcpScope) ?? false);
+
+      const planPermitted = planReadableMcp || planSafeBuiltin || planReadableResource;
+
       // Read-only contract (defense in depth): plan runs propose before touching
       // the repo, ask runs never touch it at all. The SDK/provider already leans
       // read-only in these modes, but we also refuse any write/mutating command
       // here so a misbehaving tool can never slip through. Kept AHEAD of the
       // auto/remembered auto-approvals below — nothing bypasses this gate.
-      if ((permMode === 'plan' || permMode === 'ask') && effectiveRisk !== 'read') {
+      if ((permMode === 'plan' || permMode === 'ask') && effectiveRisk !== 'read' && !planPermitted) {
         const label = permMode === 'plan' ? 'planning' : 'ask mode';
         this.pushActivity(sessionId, 'permission', `Blocked ${toolName} during ${label}`, undefined, 'warning');
+        const base =
+          permMode === 'plan'
+            ? 'Planning is read-only — approve the plan to make changes.'
+            : 'Ask mode is read-only — switch to another mode to make changes.';
+        // Name the actual cause. This used to blame the `planAccess` setting
+        // unconditionally, which is wrong (and sends the user to an already-
+        // correct field) when the server is unknown, out of scope, or untrusted.
         return {
           behavior: 'deny',
-          message:
-            permMode === 'plan'
-              ? 'Planning is read-only — approve the plan to make changes.'
-              : 'Ask mode is read-only — switch to another mode to make changes.',
+          message: mcpVerdict ? `${base} ${mcpDenyReason(mcpVerdict, toolName)}` : base,
         };
       }
 
@@ -3352,13 +3558,26 @@ export class AgentManager {
 
       // User-configured MCP servers marked "trusted" auto-approve — the single
       // permission authority both providers share for external tools. Placed
-      // AFTER the plan/ask read-only gate and the path guard (so trust never
-      // reopens a plan run), and untrusted MCP tools fall through to the prompt
-      // below like any other 'command'-risk tool.
+      // AFTER the plan/ask read-only gate and the path guard, so trust ALONE
+      // never reopens a plan run: a tool only reaches here during plan/ask if
+      // the server's separate `planAccess` setting already declared it
+      // read-only. Trust then decides prompt-vs-silent, not allowed-vs-denied.
+      // Untrusted MCP tools fall through to the prompt below like any other
+      // 'command'-risk tool.
       if (this.mcp && toolName.startsWith('mcp__')) {
-        for (const prefix of this.mcp.trustedToolMatchers()) {
+        for (const prefix of this.mcp.trustedToolMatchers(sessionId, mcpScope)) {
           if (toolName.startsWith(prefix)) return { behavior: 'allow', updatedInput: input };
         }
+      }
+
+      // A subagent spawned while planning performs no I/O itself, and every tool
+      // it goes on to call re-enters THIS gate with THIS `permMode` — so
+      // approving the spawn grants no reachable capability, and prompting per
+      // spawn would make a fan-out plan unusable. Scoped to plan/ask on purpose:
+      // in default / acceptEdits these tools keep prompting exactly as before.
+      // Placed after the path guard so nothing skips it.
+      if ((permMode === 'plan' || permMode === 'ask') && (planSafeBuiltin || planReadableResource)) {
+        return { behavior: 'allow', updatedInput: input };
       }
 
       const autoRead =

--- a/src/main/managers/cursor/translate.ts
+++ b/src/main/managers/cursor/translate.ts
@@ -7,6 +7,7 @@
  */
 import type { CursorAssistantEvent, CursorEvent, CursorToolCallEvent } from './types';
 import { isReadOnlyShellCommand } from '../agent/readOnlyCommands';
+import { MCP_SERVER_NAME_RE } from '@shared/constants';
 
 /**
  * Disambiguate `--stream-partial-output` assistant events (official contract):
@@ -187,8 +188,48 @@ function reshapeArgs(name: string, args: Record<string, unknown>): Record<string
 
 /** Best-effort human name for an unmapped union key: strip suffix, capitalize. */
 function genericToolName(key: string): string {
+  // An already-qualified MCP name is an IDENTITY, not a label — capitalizing it
+  // to `Mcp__server__tool` breaks every `mcp__` prefix match downstream (the
+  // permission gate's trusted-server and plan-readable lookups both key off it)
+  // and renders a mangled chip.
+  if (key.startsWith('mcp__')) return key;
   const base = key.replace(/ToolCall$/, '') || key;
   return base.charAt(0).toUpperCase() + base.slice(1);
+}
+
+/**
+ * Recover the `mcp__<server>__<tool>` identity from a hook payload.
+ *
+ * The streamed event path builds this name itself, but the hook path receives
+ * whatever the CLI puts in `tool_name`, which may be already-qualified, split
+ * across a separate server field, or dot/underscore separated. Without this the
+ * name reaches the permission gate as an opaque string and every MCP lookup
+ * misses.
+ *
+ * Both segments are charset-validated before interpolation: this is
+ * provider-supplied data feeding a prefix-matched security decision, and a
+ * segment containing `__` could forge a different server's namespace.
+ */
+function mcpHookToolName(rawName: string, payload: Record<string, unknown>): string | null {
+  if (rawName.startsWith('mcp__')) return rawName;
+  const safe = (s: string | undefined): string | null =>
+    s && MCP_SERVER_NAME_RE.test(s) ? s : null;
+
+  const server = safe(
+    strField(payload, 'server_name') ?? strField(payload, 'serverName') ?? strField(payload, 'server'),
+  );
+  if (server) {
+    const tool = safe(strField(payload, 'tool_name') ?? strField(payload, 'toolName')) ?? safe(rawName);
+    if (tool) return `mcp__${server}__${tool}`;
+  }
+  // `mcp.server.tool` / `mcp_server_tool` — split the first two segments only.
+  const m = /^mcp[_.]([^_.]+)[_.](.+)$/i.exec(rawName);
+  if (m) {
+    const s = safe(m[1]);
+    const t = safe(m[2]);
+    if (s && t) return `mcp__${s}__${t}`;
+  }
+  return null;
 }
 
 export interface MappedToolResult {
@@ -320,6 +361,12 @@ export function mapHookEvent(
         rawInput && typeof rawInput === 'object' && !Array.isArray(rawInput)
           ? (rawInput as Record<string, unknown>)
           : {};
+      // MCP first: an `mcp__server__tool` identity must survive verbatim to the
+      // gate, and reshapeArgs only knows the Claude-shaped tools — running it
+      // over MCP args would be a no-op at best and could drop the `path` key the
+      // workspace guard reads.
+      const mcpName = mcpHookToolName(rawName, payload);
+      if (mcpName) return { name: mcpName, input: args, observeOnly: false };
       const name =
         HOOK_TOOL_NAME_MAP[rawName.toLowerCase()] ??
         TOOL_NAME_MAP[rawName] ??

--- a/src/main/managers/mcp/McpManager.ts
+++ b/src/main/managers/mcp/McpManager.ts
@@ -34,12 +34,14 @@ import { getDb } from '../../db/database';
 import type { SecretStore } from '../../secrets/SecretStore';
 import type { SettingsManager } from '../SettingsManager';
 import type { WorkspaceManager } from '../WorkspaceManager';
+import type { SessionManager } from '../SessionManager';
 import {
   cachedTools,
   countServers,
   deleteServer,
   getServer,
   listServers,
+  listAllServers,
   nameTaken,
   setEnabledRow,
   setToolsCache,
@@ -57,10 +59,53 @@ export interface ClaudeMcpInjection {
   allowedTools: string[];
 }
 
+/**
+ * Why a tool may (or may not) run in a read-only session mode. The reason drives
+ * the denial message — see `McpManager.planVerdictFor`.
+ */
+export type McpPlanVerdict =
+  | { ok: true }
+  | { ok: false; reason: 'mcp-disabled' }
+  | { ok: false; reason: 'unknown-server' }
+  /** The server exists but belongs to another workspace. */
+  | { ok: false; reason: 'out-of-scope'; server: string }
+  /** planAccess === 'block'. */
+  | { ok: false; reason: 'blocked'; server: string }
+  /** planAccess === 'annotated' but the server never declared this tool read-only. */
+  | { ok: false; reason: 'not-annotated'; server: string };
+
+/**
+ * Longest-prefix match of a fully-qualified `mcp__<server>__<tool>` name.
+ *
+ * PREFIX-matched, never split on `__`: `MCP_SERVER_NAME_RE` permits underscores
+ * in a server name, so `mcp__my__server__do__thing` is genuinely ambiguous.
+ */
+function matchPrefix(
+  configs: McpServerConfig[],
+  qualified: string,
+): { cfg: McpServerConfig; tool: string } | null {
+  let best: { cfg: McpServerConfig; tool: string } | null = null;
+  for (const cfg of configs) {
+    if (!cfg.enabled) continue;
+    const prefix = `mcp__${cfg.name}__`;
+    if (!qualified.startsWith(prefix)) continue;
+    if (!best || cfg.name.length > best.cfg.name.length) {
+      best = { cfg, tool: qualified.slice(prefix.length) };
+    }
+  }
+  return best;
+}
+
 /** Config the Cursor runtime consumes (merged into .cursor/mcp.json). */
 export interface CursorMcpInjection {
   userServers: Record<string, unknown>;
   allowRules: string[];
+  /**
+   * Extra `Mcp(...)` rules that apply ONLY to a plan/ask run — the tools the
+   * user declared reachable in the read-only modes. Kept separate from
+   * `allowRules` so the caller splices them per mode rather than always.
+   */
+  planAllowRules: string[];
   /** Env vars carrying resolved secret values, referenced as ${env:NAME} in the file. */
   secretEnv: Record<string, string>;
 }
@@ -71,12 +116,24 @@ export class McpManager {
   private readonly probing = new Set<string>();
   private heartbeatTimer: NodeJS.Timeout | null = null;
   private unsubscribeSettings: (() => void) | null = null;
+  /**
+   * Setter-injected (mirrors `agent.setSessionManager` / `setSessionRootResolver`
+   * in the composition root): McpManager is constructed before SessionManager is
+   * wired, and must not hard-depend on it. Used only to resolve a session to its
+   * workspace — see `scopeFor`.
+   */
+  private sessions: SessionManager | null = null;
 
   constructor(
     private readonly secrets: SecretStore,
     private readonly settings: SettingsManager,
     private readonly workspace: WorkspaceManager,
   ) {}
+
+  /** Wire the session lookup used to resolve a run's workspace. See `scopeFor`. */
+  setSessionManager(sessions: SessionManager): void {
+    this.sessions = sessions;
+  }
 
   /** Begin the heartbeat + probe eager servers. Called once after app-ready. */
   start(): void {
@@ -327,12 +384,12 @@ export class McpManager {
   /* ------------------------------------------------------ injection producers */
 
   /** Servers to inject into a Claude run (options.mcpServers) + trusted allow list. */
-  claudeServersFor(): ClaudeMcpInjection {
+  claudeServersFor(sessionId: string, scope?: string | null): ClaudeMcpInjection {
     const s = this.settings.getAll().mcp;
     if (!s.enabled || !s.injectIntoClaude) return { servers: {}, allowedTools: [] };
     const servers: Record<string, unknown> = {};
     const allowedTools: string[] = [];
-    for (const cfg of this.injectable('claude')) {
+    for (const cfg of this.injectable('claude', sessionId, scope)) {
       if (cfg.transport === 'stdio') {
         servers[cfg.name] = { command: cfg.command, args: cfg.args, env: this.resolveEnv(cfg) };
       } else {
@@ -344,13 +401,15 @@ export class McpManager {
   }
 
   /** Servers to inject into a Cursor run (.cursor/mcp.json) + allow rules + secret env. */
-  cursorSpecFor(): CursorMcpInjection {
+  cursorSpecFor(sessionId: string, scope?: string | null): CursorMcpInjection {
     const s = this.settings.getAll().mcp;
-    if (!s.enabled || !s.injectIntoCursor) return { userServers: {}, allowRules: [], secretEnv: {} };
+    if (!s.enabled || !s.injectIntoCursor)
+      return { userServers: {}, allowRules: [], planAllowRules: [], secretEnv: {} };
     const userServers: Record<string, unknown> = {};
     const allowRules: string[] = [];
+    const planAllowRules: string[] = [];
     const secretEnv: Record<string, string> = {};
-    for (const cfg of this.injectable('cursor')) {
+    for (const cfg of this.injectable('cursor', sessionId, scope)) {
       if (cfg.transport === 'stdio') {
         const env: Record<string, string> = {};
         for (const [k, fv] of Object.entries(cfg.env)) {
@@ -368,26 +427,186 @@ export class McpManager {
             : { url: cfg.url, headers };
       }
       if (cfg.trust === 'trusted') allowRules.push(`Mcp(${cfg.name}:*)`);
+      if (cfg.planAccess === 'all') {
+        planAllowRules.push(`Mcp(${cfg.name}:*)`);
+      } else if (cfg.planAccess === 'annotated') {
+        for (const t of cachedTools(getDb(), cfg.id)) {
+          if (t.readOnly === true) planAllowRules.push(`Mcp(${cfg.name}:${t.name})`);
+        }
+      }
     }
-    return { userServers, allowRules, secretEnv };
+    return { userServers, allowRules, planAllowRules, secretEnv };
   }
 
   /** `mcp__<name>__` prefixes of trusted, enabled, in-scope servers (both providers). */
-  trustedToolMatchers(): string[] {
+  trustedToolMatchers(sessionId: string, scope?: string | null): string[] {
     if (!this.settings.getAll().mcp.enabled) return [];
-    return this.scoped()
+    return this.scoped(sessionId, scope)
       .filter((c) => c.enabled && c.trust === 'trusted')
       .map((c) => `mcp__${c.name}__`);
   }
 
-  /* --------------------------------------------------------------- internals */
-
-  private scoped(): McpServerConfig[] {
-    return listServers(getDb(), this.activeWorkspaceId());
+  /**
+   * May a plan/ask run read RESOURCES from this server?
+   *
+   * MCP resources are read-only by definition, but `ReadMcpResource` names a
+   * SERVER — so allowing it blindly would reach straight past that server's
+   * `planAccess: 'block'`. The per-server setting stays the single authority
+   * over that server's data, tools and resources alike. Resources carry no
+   * per-item readOnlyHint, so 'annotated' and 'all' both qualify.
+   */
+  resourceReadableIn(serverName: string, sessionId: string, scope?: string | null): boolean {
+    if (!this.settings.getAll().mcp.enabled) return false;
+    const cfg = this.scoped(sessionId, scope).find((c) => c.enabled && c.name === serverName);
+    return !!cfg && cfg.planAccess !== 'block';
   }
 
-  private injectable(provider: 'claude' | 'cursor'): McpServerConfig[] {
-    return this.scoped().filter((c) => c.enabled && c.providers[provider]);
+  /**
+   * Resolve a fully-qualified `mcp__<server>__<tool>` name back to its config.
+   *
+   * PREFIX-matched, never split on `__`: `MCP_SERVER_NAME_RE` permits underscores
+   * in a server name, so `mcp__my__server__do__thing` is genuinely ambiguous.
+   * Longest matching prefix wins, and the remainder is the tool name.
+   */
+  private resolveMcpTool(
+    qualified: string,
+    sessionId?: string,
+    scope?: string | null,
+  ): { cfg: McpServerConfig; tool: string } | null {
+    if (!this.settings.getAll().mcp.enabled) return null;
+    return matchPrefix(this.scoped(sessionId, scope), qualified);
+  }
+
+  /**
+   * May this tool run inside a read-only session mode (`plan` / `ask`), and if
+   * not, WHY?
+   *
+   * The reason is load-bearing, not decoration: a denial here used to blame the
+   * `planAccess` setting unconditionally, which is simply wrong when the server
+   * is unknown, out of scope, or merely untrusted — and it sent the user to a
+   * settings field that was already correct.
+   *
+   * This answers "is it read-only", NOT "is it approved" — the permission gate
+   * still runs on top, so a tool that qualifies here still prompts unless the
+   * server is separately marked trusted.
+   *
+   * Reads the DURABLE tool cache rather than `this.runtime`, which is empty
+   * after a restart until the server is probed again. An empty cache therefore
+   * FAILS CLOSED: an enabled server is probed on add/update/enable/eager-start
+   * and by the heartbeat, so "no cached tools" means it never connected, and
+   * denying is the correct reading of that.
+   */
+  planVerdictFor(qualified: string, sessionId: string, scope?: string | null): McpPlanVerdict {
+    if (!this.settings.getAll().mcp.enabled) return { ok: false, reason: 'mcp-disabled' };
+    const hit = this.resolveMcpTool(qualified, sessionId, scope);
+    if (!hit) {
+      // Distinguish "no such server" from "wrong workspace". Unscoped lookup,
+      // deny path only — never an input to an allow decision.
+      const other = matchPrefix(listAllServers(getDb()), qualified);
+      return other
+        ? { ok: false, reason: 'out-of-scope', server: other.cfg.name }
+        : { ok: false, reason: 'unknown-server' };
+    }
+    const server = hit.cfg.name;
+    if (hit.cfg.planAccess === 'block') return { ok: false, reason: 'blocked', server };
+    if (hit.cfg.planAccess === 'all') return { ok: true };
+    const declared = cachedTools(getDb(), hit.cfg.id).some(
+      (t) => t.name === hit.tool && t.readOnly === true,
+    );
+    return declared ? { ok: true } : { ok: false, reason: 'not-annotated', server };
+  }
+
+  /**
+   * Fully-qualified tool names to put in a Claude PLAN run's `options.allowedTools`.
+   *
+   * This exists only to get past the Agent SDK's own plan-mode block, which
+   * auto-denies `mcp__*` before `canUseTool` is ever consulted. Entries here
+   * "execute automatically without asking the user for approval" (the SDK's own
+   * words), so membership requires an explicit human decision — one of exactly
+   * two, mirroring the MCP spec's trusted/untrusted split:
+   *
+   *   planAccess 'all'       — the USER asserted, per server and out of band,
+   *                            that this server only reads. Their machine,
+   *                            their claim; it stands on its own, and it is a
+   *                            more deliberate act than clicking a mid-run
+   *                            dialog. Trust is NOT additionally required.
+   *   planAccess 'annotated' — the claim comes from the SERVER's own
+   *                            readOnlyHint, and the spec says a client must
+   *                            treat annotations as untrusted unless the server
+   *                            is trusted. So this case DOES require
+   *                            `trust: 'trusted'`.
+   *
+   * 'block' never qualifies. Nothing else reaches this list, so a run can never
+   * silently skip a prompt the user did not already answer.
+   *
+   * Exact names, never a `mcp__<server>__*` wildcard: a wildcard would readmit
+   * that server's WRITE tools past the SDK's block. The single exception is a
+   * server the user declared read-only wholesale and which has no cached tools
+   * to enumerate.
+   */
+  planAllowedToolsFor(sessionId: string, scope?: string | null): string[] {
+    const s = this.settings.getAll().mcp;
+    if (!s.enabled || !s.injectIntoClaude) return [];
+    const out: string[] = [];
+    for (const cfg of this.injectable('claude', sessionId, scope)) {
+      if (cfg.planAccess === 'block') continue;
+      if (cfg.planAccess === 'annotated' && cfg.trust !== 'trusted') continue;
+      const tools = cachedTools(getDb(), cfg.id);
+      if (cfg.planAccess === 'all') {
+        if (tools.length === 0) out.push(`mcp__${cfg.name}__*`);
+        else for (const t of tools) out.push(`mcp__${cfg.name}__${t.name}`);
+      } else {
+        for (const t of tools) {
+          if (t.readOnly === true) out.push(`mcp__${cfg.name}__${t.name}`);
+        }
+      }
+      if (out.length >= MCP_LIMITS.maxPlanAllowedTools) break;
+    }
+    return out.slice(0, MCP_LIMITS.maxPlanAllowedTools);
+  }
+
+  /* --------------------------------------------------------------- internals */
+
+  private scoped(sessionId?: string, scope?: string | null): McpServerConfig[] {
+    return listServers(getDb(), this.scopeFor(sessionId, scope));
+  }
+
+  private injectable(
+    provider: 'claude' | 'cursor',
+    sessionId?: string,
+    scope?: string | null,
+  ): McpServerConfig[] {
+    return this.scoped(sessionId, scope).filter((c) => c.enabled && c.providers[provider]);
+  }
+
+  /**
+   * The workspace whose MCP servers a call may see.
+   *
+   * Callers with no session — the UI list, the heartbeat, eager startup,
+   * import/export — legitimately follow the ACTIVE workspace. A run-path caller
+   * always passes a session, and resolves through that session's own workspace
+   * (`sessions.workspace_id` is TEXT NOT NULL, so the session always knows).
+   * `scope` is the workspace pinned on the run record at run start; it wins,
+   * because the run's servers were injected from it and the live gate must
+   * answer for the same set even if the active workspace changes mid-run.
+   *
+   * Same shape as `WorktreeManager.resolveSessionRoot`, including the
+   * `workspace.getById` validity check so a stale id cannot silently collapse
+   * the scope.
+   *
+   * The fallback is the ACTIVE workspace, not global-only. Narrowing looks
+   * safer but is not: on the gate side a narrow scope fails closed (fine), but
+   * on the INJECTION side it means the server is never registered with the
+   * provider at all, so the model gets an opaque "no such tool" instead of a
+   * gate decision. Both sides run through this one function precisely so they
+   * cannot disagree — that disagreement is the bug this exists to prevent.
+   */
+  private scopeFor(sessionId?: string, scope?: string | null): string | null {
+    if (scope && this.workspace.getById(scope)) return scope;
+    if (!sessionId) return this.activeWorkspaceId();
+    const ws = this.sessions?.get(sessionId)?.workspaceId;
+    if (ws && this.workspace.getById(ws)) return ws;
+    return this.activeWorkspaceId();
   }
 
   private activeWorkspaceId(): string | null {

--- a/src/main/managers/mcp/client/protocol.ts
+++ b/src/main/managers/mcp/client/protocol.ts
@@ -41,6 +41,26 @@ export function initializeParams(): Record<string, unknown> {
   };
 }
 
+/**
+ * Read the MCP `annotations.readOnlyHint` for one tool entry.
+ *
+ * Per the spec these hints are asserted by the SERVER about itself and clients
+ * must treat them as untrusted — so this is captured as information, and the
+ * permission gate decides what (if anything) to do with it.
+ *
+ * A tool qualifies only when it claims `readOnlyHint: true` AND does not also
+ * claim `destructiveHint: true`. The spec's default for `destructiveHint` is
+ * `true`, but a server that explicitly sets both is describing something
+ * self-contradictory, and the safe reading of a contradiction is "not read-only".
+ * `idempotentHint` / `openWorldHint` are irrelevant to this decision.
+ */
+function readOnlyHintOf(tool: object): boolean {
+  const ann = (tool as { annotations?: unknown }).annotations;
+  if (!ann || typeof ann !== 'object' || Array.isArray(ann)) return false;
+  const a = ann as { readOnlyHint?: unknown; destructiveHint?: unknown };
+  return a.readOnlyHint === true && a.destructiveHint !== true;
+}
+
 /** Defensively parse the tools array from a `tools/list` result. */
 export function parseToolList(result: unknown, max: number): McpToolInfo[] {
   const raw =
@@ -53,7 +73,13 @@ export function parseToolList(result: unknown, max: number): McpToolInfo[] {
     const name = (t as { name?: unknown }).name;
     if (typeof name !== 'string' || !name) continue;
     const description = (t as { description?: unknown }).description;
-    out.push({ name, description: typeof description === 'string' ? description : undefined });
+    out.push({
+      name,
+      description: typeof description === 'string' ? description : undefined,
+      // Omit the key entirely when unclaimed, so the cached JSON stays small and
+      // "absent" and "false" are the same thing on read.
+      ...(readOnlyHintOf(t) ? { readOnly: true as const } : {}),
+    });
     if (out.length >= max) break;
   }
   return out;

--- a/src/main/managers/mcp/registry.ts
+++ b/src/main/managers/mcp/registry.ts
@@ -35,6 +35,7 @@ interface DbServerRow {
   enabled: number;
   startup: string;
   trust: string;
+  plan_access: string;
   timeout_ms: number;
   restart_policy: string;
   providers_json: string;
@@ -84,8 +85,14 @@ function parseFieldMap(json: string): Record<string, McpFieldValue> {
 
 function parseTools(json: string): McpToolInfo[] {
   return parseArray(json)
-    .filter((t): t is { name: string; description?: string } => !!t && typeof t === 'object' && typeof (t as { name?: unknown }).name === 'string')
-    .map((t) => ({ name: t.name, description: typeof t.description === 'string' ? t.description : undefined }))
+    .filter((t): t is { name: string; description?: unknown; readOnly?: unknown } => !!t && typeof t === 'object' && typeof (t as { name?: unknown }).name === 'string')
+    .map((t) => ({
+      name: t.name,
+      description: typeof t.description === 'string' ? t.description : undefined,
+      // Strict identity, never a truthy coercion: this flag feeds a permission
+      // decision, so a hand-edited row holding "false" must not read as true.
+      ...(t.readOnly === true ? { readOnly: true as const } : {}),
+    }))
     .slice(0, MCP_LIMITS.maxTools);
 }
 
@@ -114,6 +121,11 @@ export function rowToConfig(row: DbServerRow): McpServerConfig {
     enabled: row.enabled === 1,
     startup: row.startup as McpStartup,
     trust: row.trust as McpTrust,
+    // Whitelisted rather than cast: this column feeds the plan/ask permission
+    // gate, so an unrecognized value must land on the most restrictive setting
+    // instead of being trusted into the type.
+    planAccess:
+      row.plan_access === 'annotated' || row.plan_access === 'all' ? row.plan_access : 'block',
     timeoutMs: row.timeout_ms,
     restartPolicy: row.restart_policy as McpRestartPolicy,
     providers: parseProviders(row.providers_json),
@@ -135,6 +147,18 @@ export function listServers(db: Database.Database, workspaceId: string | null): 
        ORDER BY updated_at DESC`,
     )
     .all(workspaceId) as DbServerRow[];
+  return rows.map(rowToConfig);
+}
+
+/**
+ * Every server row regardless of scope.
+ *
+ * Used only on a permission DENY path, to tell "no such server" apart from
+ * "that server belongs to another workspace" so the message can say which.
+ * Never use this to make an ALLOW decision — `listServers` is the scoped view.
+ */
+export function listAllServers(db: Database.Database): McpServerConfig[] {
+  const rows = db.prepare('SELECT * FROM mcp_servers').all() as DbServerRow[];
   return rows.map(rowToConfig);
 }
 
@@ -165,16 +189,26 @@ export function nameTaken(
   return !!row && row.id !== exceptId;
 }
 
+/**
+ * Insert or update a server row.
+ *
+ * `tools_json` is written on INSERT only — the UPDATE branch deliberately leaves
+ * it alone. It is owned by `setToolsCache` (a probe result), not by the config
+ * the user just edited, and clobbering it on every save would drop the cached
+ * `readOnly` hints that `planAccess: 'annotated'` reads. That would make an
+ * enabled server fail closed in plan/ask after each edit until the next probe
+ * landed — and stay closed if the probe failed.
+ */
 export function upsertServer(db: Database.Database, cfg: McpServerConfig): void {
   db.prepare(
     `INSERT INTO mcp_servers (
        id, workspace_id, name, display_name, transport, command, args_json, env_json,
-       cwd, url, headers_json, enabled, startup, trust, timeout_ms, restart_policy,
+       cwd, url, headers_json, enabled, startup, trust, plan_access, timeout_ms, restart_policy,
        providers_json, allow_private_network, category, icon, source, tools_json,
        created_at, updated_at
      ) VALUES (
        @id, @workspace_id, @name, @display_name, @transport, @command, @args_json, @env_json,
-       @cwd, @url, @headers_json, @enabled, @startup, @trust, @timeout_ms, @restart_policy,
+       @cwd, @url, @headers_json, @enabled, @startup, @trust, @plan_access, @timeout_ms, @restart_policy,
        @providers_json, @allow_private_network, @category, @icon, @source, @tools_json,
        @created_at, @updated_at
      )
@@ -182,9 +216,10 @@ export function upsertServer(db: Database.Database, cfg: McpServerConfig): void 
        workspace_id = @workspace_id, name = @name, display_name = @display_name,
        transport = @transport, command = @command, args_json = @args_json, env_json = @env_json,
        cwd = @cwd, url = @url, headers_json = @headers_json, enabled = @enabled,
-       startup = @startup, trust = @trust, timeout_ms = @timeout_ms, restart_policy = @restart_policy,
+       startup = @startup, trust = @trust, plan_access = @plan_access,
+       timeout_ms = @timeout_ms, restart_policy = @restart_policy,
        providers_json = @providers_json, allow_private_network = @allow_private_network,
-       category = @category, icon = @icon, source = @source, tools_json = @tools_json,
+       category = @category, icon = @icon, source = @source,
        updated_at = @updated_at`,
   ).run({
     id: cfg.id,
@@ -201,6 +236,7 @@ export function upsertServer(db: Database.Database, cfg: McpServerConfig): void 
     enabled: cfg.enabled ? 1 : 0,
     startup: cfg.startup,
     trust: cfg.trust,
+    plan_access: cfg.planAccess,
     timeout_ms: cfg.timeoutMs,
     restart_policy: cfg.restartPolicy,
     providers_json: JSON.stringify(cfg.providers),

--- a/src/main/managers/mcp/validate.ts
+++ b/src/main/managers/mcp/validate.ts
@@ -20,6 +20,7 @@ import type {
   McpStartup,
   McpTransport,
   McpTrust,
+  McpPlanAccess,
 } from '@shared/types';
 import { categorizeServer } from './categorize';
 
@@ -56,6 +57,7 @@ export interface PreparedServer {
     enabled: boolean;
     startup: McpStartup;
     trust: McpTrust;
+    planAccess: McpPlanAccess;
     timeoutMs: number;
     restartPolicy: McpRestartPolicy;
     providers: { claude: boolean; cursor: boolean };
@@ -156,6 +158,11 @@ export function prepareServer(
   const secretHeaders = validatePairs(input.secretHeaders, true, 'header');
 
   const trust: McpTrust = input.trust === 'trusted' || input.trust === 'ask' ? input.trust : opts.defaultTrust;
+  // Whitelist-only, so an imported/marketplace definition can never widen its
+  // own plan/ask reach — 'all' is reachable from the settings form and nowhere
+  // else.
+  const planAccess: McpPlanAccess =
+    input.planAccess === 'block' || input.planAccess === 'all' ? input.planAccess : 'annotated';
   const startup: McpStartup = input.startup === 'eager' ? 'eager' : 'on-demand';
   const restartPolicy: McpRestartPolicy = input.restartPolicy === 'never' ? 'never' : 'on-failure';
   const category: McpCategory =
@@ -184,6 +191,7 @@ export function prepareServer(
       enabled: input.enabled !== false,
       startup,
       trust,
+      planAccess,
       timeoutMs,
       restartPolicy,
       providers: {

--- a/src/renderer/features/activity/PlanPanel.tsx
+++ b/src/renderer/features/activity/PlanPanel.tsx
@@ -19,7 +19,6 @@
  */
 import { useEffect, useMemo, useState } from 'react';
 import {
-  CheckCircle2,
   ChevronDown,
   ChevronRight,
   ClipboardList,
@@ -39,19 +38,11 @@ import {
   Search,
   TriangleAlert,
 } from 'lucide-react';
-import type {
-  PlanMeta,
-  PlanRevision,
-  PlanStatus,
-  SessionPermissionMode,
-  SessionPlan,
-  TaskItem,
-} from '@shared/types';
+import type { PlanRevision, SessionPlan, TaskItem } from '@shared/types';
 import { EmptyState, IconButton, Spinner, SuccessCheck } from '@/renderer/components/ui';
 import { cn } from '@/renderer/lib/cn';
 import {
   applyRuntime,
-  outlineToJson,
   parsePlanOutline,
   type OutlinePhase,
   type OutlineTask,
@@ -62,22 +53,13 @@ import { useSessionStore } from '@/renderer/stores/useSessionStore';
 import { useAgentStore } from '@/renderer/stores/useAgentStore';
 import { useSettingsStore } from '@/renderer/stores/useSettingsStore';
 import { useLayoutStore } from '@/renderer/stores/useLayoutStore';
-import { useUIStore } from '@/renderer/stores/useUIStore';
 import { Markdown } from '@/renderer/features/workspace/Markdown';
-
-const STATUS_BADGE: Record<PlanStatus, { label: string; cls: string }> = {
-  planning: { label: 'Planning', cls: 'text-accent' },
-  ready: { label: 'Ready for approval', cls: 'text-accent' },
-  implementing: { label: 'Active execution', cls: 'text-warning' },
-  completed: { label: 'Completed', cls: 'text-success' },
-  rejected: { label: 'Rejected', cls: 'text-faint' },
-};
-
-const RISK_CLS: Record<NonNullable<PlanMeta['risk']>, string> = {
-  low: 'text-success',
-  medium: 'text-warning',
-  high: 'text-danger',
-};
+import {
+  ApprovalControls,
+  PlanMetaRow,
+  STATUS_BADGE,
+  usePlanActions,
+} from '@/renderer/features/plan/parts';
 
 type TaskFilter = 'all' | 'pending' | 'done';
 
@@ -123,8 +105,6 @@ function PlanView({
   const approvePlan = useAgentStore((s) => s.approvePlan);
   const rejectPlan = useAgentStore((s) => s.rejectPlan);
   const regeneratePlan = useAgentStore((s) => s.regeneratePlan);
-  const setPlanPinned = useAgentStore((s) => s.setPlanPinned);
-  const addToast = useUIStore((s) => s.addToast);
 
   // Run signals used to derive live per-task execution states.
   const awaitingPermission = useAgentStore((s) => (sessionId ? !!s.pendingBySession[sessionId] : false));
@@ -176,17 +156,11 @@ function PlanView({
       : { completed: outline.completed, total: outline.taskCount, active: 0 };
   const hasProgress = progress.total > 0;
 
-  const copy = () => {
-    void window.limboo?.system?.clipboardWrite(plan.markdown);
-    addToast({ title: 'Plan copied', tone: 'success' });
-  };
-  const exportMarkdown = () => downloadText(`${slugify(plan.title)}.md`, plan.markdown);
-  const exportJson = () =>
-    downloadText(`${slugify(plan.title)}.json`, outlineToJson(outline, plan.title));
-  const print = () => printPlan(plan.title, plan.markdown);
-  const togglePin = () => {
-    if (sessionId) setPlanPinned(sessionId, !plan.pinned);
-  };
+  const { copy, exportMarkdown, exportJson, print, togglePin } = usePlanActions(
+    sessionId,
+    plan,
+    outline,
+  );
   const setAllCollapsed = (value: boolean) => {
     const next: Record<string, boolean> = {};
     for (const p of outline.phases) next[p.id] = value;
@@ -375,69 +349,6 @@ function PlanView({
 /* ------------------------------------------------------------------ */
 /* Approval                                                            */
 /* ------------------------------------------------------------------ */
-
-function ApprovalControls({
-  settings,
-  onApprove,
-  onRegenerate,
-  onReject,
-}: {
-  settings: { requireSecondaryConfirm: boolean };
-  onApprove: (mode: SessionPermissionMode) => void;
-  onRegenerate: () => void;
-  onReject: () => void;
-}) {
-  const [confirming, setConfirming] = useState<SessionPermissionMode | null>(null);
-
-  const approve = (mode: SessionPermissionMode) => {
-    if (settings.requireSecondaryConfirm && confirming !== mode) {
-      setConfirming(mode);
-      return;
-    }
-    setConfirming(null);
-    onApprove(mode);
-  };
-
-  return (
-    <div className="flex flex-col gap-2 rounded-md border border-accent/40 bg-accent/10 px-3 py-2.5">
-      <p className="text-[12px] text-muted">
-        Review the plan above. Approving exits Plan Mode and begins implementation against this
-        outline — choose how much to review as it works.
-      </p>
-      <div className="flex flex-wrap items-center gap-2">
-        <button
-          type="button"
-          onClick={() => approve('default')}
-          className="flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-[12px] font-semibold text-base transition-opacity hover:opacity-90"
-        >
-          <CheckCircle2 size={13} />
-          {confirming === 'default' ? 'Confirm — start now' : 'Approve & ask before edits'}
-        </button>
-        <button
-          type="button"
-          onClick={() => approve('acceptEdits')}
-          className="rounded-md border border-accent/50 bg-accent/15 px-2.5 py-1.5 text-[12px] font-medium text-accent transition-colors hover:bg-accent/25"
-        >
-          {confirming === 'acceptEdits' ? 'Confirm — accept edits' : 'Approve & accept edits'}
-        </button>
-        <button
-          type="button"
-          onClick={onRegenerate}
-          className="rounded-md border border-line bg-surface-2 px-2.5 py-1.5 text-[12px] text-muted transition-colors hover:bg-elevated hover:text-fg"
-        >
-          Keep planning
-        </button>
-        <button
-          type="button"
-          onClick={onReject}
-          className="ml-auto rounded-md px-2.5 py-1.5 text-[12px] text-faint transition-colors hover:text-danger"
-        >
-          Reject
-        </button>
-      </div>
-    </div>
-  );
-}
 
 /* ------------------------------------------------------------------ */
 /* Outline tree                                                        */
@@ -732,32 +643,6 @@ function HistorySection({ sessionId, plan }: { sessionId: string; plan: SessionP
 /* Shared bits                                                         */
 /* ------------------------------------------------------------------ */
 
-function PlanMetaRow({ meta, highlightRisk }: { meta: PlanMeta; highlightRisk: boolean }) {
-  const chips: Array<{ label: string; cls?: string }> = [];
-  if (meta.taskCount) chips.push({ label: `${meta.taskCount} task${meta.taskCount === 1 ? '' : 's'}` });
-  if (meta.affectedFiles)
-    chips.push({ label: `~${meta.affectedFiles} file${meta.affectedFiles === 1 ? '' : 's'}` });
-  if (meta.risk) chips.push({ label: `${meta.risk} risk`, cls: highlightRisk ? RISK_CLS[meta.risk] : undefined });
-  if (meta.frameworks && meta.frameworks.length > 0)
-    chips.push({ label: meta.frameworks.slice(0, 3).join(', ') });
-  if (chips.length === 0) return null;
-  return (
-    <div className="flex flex-wrap items-center gap-1.5">
-      {chips.map((c, i) => (
-        <span
-          key={i}
-          className={cn(
-            'rounded-md border border-line bg-surface-2 px-1.5 py-0.5 text-[10.5px] font-medium',
-            c.cls ?? 'text-muted',
-          )}
-        >
-          {c.label}
-        </span>
-      ))}
-    </div>
-  );
-}
-
 function TaskChecklist({ tasks, title = 'Checklist' }: { tasks: TaskItem[]; title?: string }) {
   const done = tasks.filter((t) => t.done).length;
   return (
@@ -795,66 +680,6 @@ function TaskChecklist({ tasks, title = 'Checklist' }: { tasks: TaskItem[]; titl
 /* ------------------------------------------------------------------ */
 /* helpers                                                             */
 /* ------------------------------------------------------------------ */
-
-function slugify(s: string): string {
-  return (
-    s
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '')
-      .slice(0, 60) || 'plan'
-  );
-}
-
-/** Trigger a client-side file download for the given text (no fs / IPC needed). */
-function downloadText(filename: string, text: string): void {
-  const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  URL.revokeObjectURL(url);
-}
-
-/**
- * Print just the plan via an offscreen iframe. A new BrowserWindow is denied by
- * the app's window-open handler, so we print the iframe's own document instead of
- * the whole shell. The raw Markdown is shown in a readable monospace block.
- */
-function printPlan(title: string, markdown: string): void {
-  const iframe = document.createElement('iframe');
-  iframe.style.position = 'fixed';
-  iframe.style.right = '0';
-  iframe.style.bottom = '0';
-  iframe.style.width = '0';
-  iframe.style.height = '0';
-  iframe.style.border = '0';
-  document.body.appendChild(iframe);
-  const doc = iframe.contentWindow?.document;
-  if (!doc) {
-    iframe.remove();
-    return;
-  }
-  const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  doc.open();
-  doc.write(
-    `<html><head><title>${esc(title)}</title><style>` +
-      'body{font:12px/1.5 -apple-system,Segoe UI,Roboto,sans-serif;color:#111;padding:24px}' +
-      'h1{font-size:18px;margin:0 0 12px}pre{white-space:pre-wrap;word-wrap:break-word;font:11px/1.5 ui-monospace,Menlo,Consolas,monospace}' +
-      `</style></head><body><h1>${esc(title)}</h1><pre>${esc(markdown)}</pre></body></html>`,
-  );
-  doc.close();
-  const win = iframe.contentWindow;
-  if (win) {
-    win.focus();
-    win.print();
-  }
-  // Give the print dialog time to read the document before tearing it down.
-  window.setTimeout(() => iframe.remove(), 1000);
-}
 
 /** Naive line set-diff for a compact +added / -removed history summary. */
 function diffLines(current: string, revision: string): { added: number; removed: number } {

--- a/src/renderer/features/plan/PlanCard.tsx
+++ b/src/renderer/features/plan/PlanCard.tsx
@@ -1,0 +1,207 @@
+/**
+ * The plan, inline in the conversation stream.
+ *
+ * Plan Mode's output used to live only in the ~320px Tasks drawer, so the stream
+ * — where the work is actually happening — showed nothing but a one-line marker
+ * and a banner pointing elsewhere. This is the primary surface now: the plan
+ * renders as prose at the transcript's full measure, with its document actions
+ * on the card itself.
+ *
+ * The body goes through the shared {@link Markdown} renderer (the same one
+ * assistant messages use), so a plan reads as text rather than as Markdown
+ * source; the raw view is the opt-in behind the toolbar toggle, not the default.
+ *
+ * "Maximize" hands off to the drawer's `PlanPanel`, which owns the things that
+ * need vertical room and a persistent home — the live task outline, revision
+ * history, search/filter. The two share `./parts` so approval and status can
+ * never drift between them.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ChevronDown,
+  ChevronRight,
+  Code2,
+  Copy,
+  Loader2,
+  Maximize2,
+  Minimize2,
+  Pin,
+  PinOff,
+} from 'lucide-react';
+import type { SessionPlan, TaskItem } from '@shared/types';
+import { IconButton, Spinner } from '@/renderer/components/ui';
+import { cn } from '@/renderer/lib/cn';
+import { applyRuntime, parsePlanOutline } from '@/renderer/lib/planOutline';
+import { RUNNING_PHASES } from '@/renderer/features/sessions/useSessionRunning';
+import { Markdown } from '@/renderer/features/workspace/Markdown';
+import { useAgentStore } from '@/renderer/stores/useAgentStore';
+import { useLayoutStore } from '@/renderer/stores/useLayoutStore';
+import { useSettingsStore } from '@/renderer/stores/useSettingsStore';
+import { ApprovalControls, PlanMetaRow, STATUS_BADGE, usePlanActions } from './parts';
+
+export function PlanCard({ sessionId }: { sessionId: string }) {
+  const plan = useAgentStore((s) => s.bySession[sessionId]?.plan) ?? null;
+  if (!plan) return null;
+  return <PlanCardBody sessionId={sessionId} plan={plan} />;
+}
+
+function PlanCardBody({ sessionId, plan }: { sessionId: string; plan: SessionPlan }) {
+  const settings = useSettingsStore((s) => s.settings.agent.plan);
+  const tasks = useAgentStore((s) => s.bySession[sessionId]?.tasks) ?? EMPTY_TASKS;
+  const approvePlan = useAgentStore((s) => s.approvePlan);
+  const rejectPlan = useAgentStore((s) => s.rejectPlan);
+  const regeneratePlan = useAgentStore((s) => s.regeneratePlan);
+
+  // Run signals, matching PlanPanel — the outline overlay needs the same inputs.
+  const awaitingPermission = useAgentStore((s) => !!s.pendingBySession[sessionId]);
+  const request = useAgentStore((s) => s.requestsBySession[sessionId]);
+  const running = !!request && RUNNING_PHASES.has(request.phase);
+  const failed = request?.outcome === 'failed' || request?.outcome === 'tool-rejected';
+
+  const [raw, setRaw] = useState(false);
+  const [open, setOpen] = useState(true);
+
+  // Once implementation starts the live outline in the drawer is what matters,
+  // so the proposal folds itself away rather than pushing the run off-screen.
+  useEffect(() => {
+    if (plan.status === 'implementing') setOpen(false);
+  }, [plan.status]);
+
+  const outline = useMemo(() => {
+    const parsed = parsePlanOutline(plan.markdown);
+    return applyRuntime(parsed, { tasks, awaitingPermission, failed, running });
+  }, [plan.markdown, tasks, awaitingPermission, failed, running]);
+
+  const actions = usePlanActions(sessionId, plan, outline);
+
+  const planning = plan.status === 'planning';
+  const ready = plan.status === 'ready';
+  const badge = STATUS_BADGE[plan.status];
+
+  // Live tally straight off the streamed todos, falling back to the outline
+  // before any have arrived (PlanPanel's rule — the fuzzy match can miss).
+  const progress = useMemo(() => {
+    let completed = 0;
+    let active = 0;
+    for (const t of tasks) {
+      if (t.done || t.status === 'completed') completed += 1;
+      else if (t.status === 'in_progress') active += 1;
+    }
+    return tasks.length > 0
+      ? { completed, active, total: tasks.length }
+      : { completed: outline.completed, active: 0, total: outline.taskCount };
+  }, [tasks, outline]);
+
+  const showBody = open && !planning && !!plan.markdown && settings.showReasoning;
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border border-line bg-surface-2/50 animate-fade-in">
+      {/* Header — title + status on the left, document actions on the right. */}
+      <div className="flex items-start gap-2 px-3 pt-2.5">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          disabled={planning}
+          className={cn(
+            'flex min-w-0 flex-1 items-start gap-1.5 rounded text-left',
+            planning ? 'cursor-default' : 'transition-colors hover:opacity-80',
+          )}
+        >
+          {!planning &&
+            (open ? (
+              <ChevronDown size={13} className="mt-0.5 shrink-0 text-faint" />
+            ) : (
+              <ChevronRight size={13} className="mt-0.5 shrink-0 text-faint" />
+            ))}
+          <span className="flex min-w-0 flex-col">
+            <span className="flex items-center gap-1.5 truncate text-[13px] font-semibold text-fg" title={plan.title}>
+              {plan.pinned && <Pin size={11} className="shrink-0 text-accent" />}
+              {plan.title}
+            </span>
+            <span className={cn('text-[11px] font-medium', badge.cls)}>
+              {(planning || progress.active > 0) && (
+                <Loader2 size={10} className="mr-1 inline animate-spin" />
+              )}
+              {badge.label}
+              {progress.total > 0 && ` · ${progress.completed}/${progress.total}`}
+              {progress.active > 0 && <span className="ml-1 text-accent">· {progress.active} running</span>}
+            </span>
+          </span>
+        </button>
+        {!planning && (
+          <div className="flex shrink-0 items-center gap-0.5">
+            <IconButton size="sm" label="Copy plan as Markdown" onClick={actions.copy}>
+              <Copy size={13} />
+            </IconButton>
+            <IconButton
+              size="sm"
+              label={raw ? 'Show rendered plan' : 'View as Markdown'}
+              active={raw}
+              onClick={() => setRaw((v) => !v)}
+            >
+              <Code2 size={13} />
+            </IconButton>
+            <IconButton
+              size="sm"
+              label={plan.pinned ? 'Unpin plan' : 'Pin plan'}
+              active={plan.pinned}
+              onClick={actions.togglePin}
+            >
+              {plan.pinned ? <PinOff size={13} /> : <Pin size={13} />}
+            </IconButton>
+            <IconButton size="sm" label="Collapse plan" onClick={() => setOpen(false)}>
+              <Minimize2 size={13} />
+            </IconButton>
+            <IconButton
+              size="sm"
+              label="Open the full plan panel"
+              onClick={() => useLayoutStore.getState().setActiveTab('tasks')}
+            >
+              <Maximize2 size={13} />
+            </IconButton>
+          </div>
+        )}
+      </div>
+
+      {settings.showEstimates && !planning && open && (
+        <div className="px-3">
+          <PlanMetaRow meta={plan.meta} highlightRisk={settings.highlightRisk} />
+        </div>
+      )}
+
+      {planning && (
+        <div className="flex items-center gap-2 px-3 pb-2.5 text-[12px] text-muted">
+          <Spinner size={12} />
+          Analyzing the repository — reading files and dependencies (read-only)…
+        </div>
+      )}
+
+      {showBody &&
+        (raw ? (
+          <pre className="mx-3 max-h-[60vh] overflow-auto rounded-md border border-line bg-base px-3 py-2 text-[11.5px] leading-relaxed text-muted">
+            {plan.markdown}
+          </pre>
+        ) : (
+          <div className="border-t border-line px-3 py-2">
+            <Markdown text={plan.markdown} streaming={running} />
+          </div>
+        ))}
+
+      {ready && (
+        <div className="px-3 pb-3">
+          <ApprovalControls
+            settings={settings}
+            onApprove={(mode) => approvePlan(sessionId, mode)}
+            onRegenerate={() => regeneratePlan(sessionId)}
+            onReject={() => rejectPlan(sessionId)}
+          />
+        </div>
+      )}
+
+      {/* Keep a bottom edge when nothing below the header rendered. */}
+      {!ready && !showBody && !planning && <div className="pb-1" />}
+    </div>
+  );
+}
+
+const EMPTY_TASKS: TaskItem[] = [];

--- a/src/renderer/features/plan/parts.tsx
+++ b/src/renderer/features/plan/parts.tsx
@@ -1,0 +1,229 @@
+/**
+ * Shared plan pieces, used by BOTH surfaces the plan renders on:
+ *
+ *   • {@link PlanCard} — inline in the conversation stream (the primary view)
+ *   • `activity/PlanPanel` — the Tasks drawer (the maximized view)
+ *
+ * Extracted so the two can never drift on what "approve" means or how a plan's
+ * status reads. Presentational + pure helpers only — no store subscriptions
+ * beyond the toast used by the copy action, and no business logic.
+ */
+import { useState } from 'react';
+import { CheckCircle2 } from 'lucide-react';
+import type { PlanMeta, PlanStatus, SessionPermissionMode, SessionPlan } from '@shared/types';
+import { cn } from '@/renderer/lib/cn';
+import { outlineToJson, type PlanOutline } from '@/renderer/lib/planOutline';
+import { useUIStore } from '@/renderer/stores/useUIStore';
+import { useAgentStore } from '@/renderer/stores/useAgentStore';
+
+export const STATUS_BADGE: Record<PlanStatus, { label: string; cls: string }> = {
+  planning: { label: 'Planning', cls: 'text-accent' },
+  ready: { label: 'Ready for approval', cls: 'text-accent' },
+  implementing: { label: 'Active execution', cls: 'text-warning' },
+  completed: { label: 'Completed', cls: 'text-success' },
+  rejected: { label: 'Rejected', cls: 'text-faint' },
+};
+
+export const RISK_CLS: Record<NonNullable<PlanMeta['risk']>, string> = {
+  low: 'text-success',
+  medium: 'text-warning',
+  high: 'text-danger',
+};
+
+/* ------------------------------------------------------------------ */
+/* Actions                                                             */
+/* ------------------------------------------------------------------ */
+
+export interface PlanActions {
+  copy: () => void;
+  exportMarkdown: () => void;
+  exportJson: () => void;
+  print: () => void;
+  togglePin: () => void;
+}
+
+/**
+ * The plan's document-level actions. Takes the derived outline because the JSON
+ * export describes the outline, not the raw Markdown.
+ */
+export function usePlanActions(
+  sessionId: string | null,
+  plan: SessionPlan,
+  outline: PlanOutline,
+): PlanActions {
+  const addToast = useUIStore((s) => s.addToast);
+  const setPlanPinned = useAgentStore((s) => s.setPlanPinned);
+  return {
+    copy: () => {
+      void window.limboo?.system?.clipboardWrite(plan.markdown);
+      addToast({ title: 'Plan copied', tone: 'success' });
+    },
+    exportMarkdown: () => downloadText(`${slugify(plan.title)}.md`, plan.markdown),
+    exportJson: () => downloadText(`${slugify(plan.title)}.json`, outlineToJson(outline, plan.title)),
+    print: () => printPlan(plan.title, plan.markdown),
+    togglePin: () => {
+      if (sessionId) setPlanPinned(sessionId, !plan.pinned);
+    },
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Approval                                                            */
+/* ------------------------------------------------------------------ */
+
+export function ApprovalControls({
+  settings,
+  onApprove,
+  onRegenerate,
+  onReject,
+}: {
+  settings: { requireSecondaryConfirm: boolean };
+  onApprove: (mode: SessionPermissionMode) => void;
+  onRegenerate: () => void;
+  onReject: () => void;
+}) {
+  const [confirming, setConfirming] = useState<SessionPermissionMode | null>(null);
+
+  const approve = (mode: SessionPermissionMode) => {
+    if (settings.requireSecondaryConfirm && confirming !== mode) {
+      setConfirming(mode);
+      return;
+    }
+    setConfirming(null);
+    onApprove(mode);
+  };
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border border-accent/40 bg-accent/10 px-3 py-2.5">
+      <p className="text-[12px] text-muted">
+        Review the plan above. Approving exits Plan Mode and begins implementation against this
+        outline — choose how much to review as it works.
+      </p>
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => approve('default')}
+          className="flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-[12px] font-semibold text-base transition-opacity hover:opacity-90"
+        >
+          <CheckCircle2 size={13} />
+          {confirming === 'default' ? 'Confirm — start now' : 'Approve & ask before edits'}
+        </button>
+        <button
+          type="button"
+          onClick={() => approve('acceptEdits')}
+          className="rounded-md border border-accent/50 bg-accent/15 px-2.5 py-1.5 text-[12px] font-medium text-accent transition-colors hover:bg-accent/25"
+        >
+          {confirming === 'acceptEdits' ? 'Confirm — accept edits' : 'Approve & accept edits'}
+        </button>
+        <button
+          type="button"
+          onClick={onRegenerate}
+          className="rounded-md border border-line bg-surface-2 px-2.5 py-1.5 text-[12px] text-muted transition-colors hover:bg-elevated hover:text-fg"
+        >
+          Keep planning
+        </button>
+        <button
+          type="button"
+          onClick={onReject}
+          className="ml-auto rounded-md px-2.5 py-1.5 text-[12px] text-faint transition-colors hover:text-danger"
+        >
+          Reject
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Metadata                                                            */
+/* ------------------------------------------------------------------ */
+
+export function PlanMetaRow({ meta, highlightRisk }: { meta: PlanMeta; highlightRisk: boolean }) {
+  const chips: Array<{ label: string; cls?: string }> = [];
+  if (meta.taskCount) chips.push({ label: `${meta.taskCount} task${meta.taskCount === 1 ? '' : 's'}` });
+  if (meta.affectedFiles)
+    chips.push({ label: `~${meta.affectedFiles} file${meta.affectedFiles === 1 ? '' : 's'}` });
+  if (meta.risk) chips.push({ label: `${meta.risk} risk`, cls: highlightRisk ? RISK_CLS[meta.risk] : undefined });
+  if (meta.frameworks && meta.frameworks.length > 0)
+    chips.push({ label: meta.frameworks.slice(0, 3).join(', ') });
+  if (chips.length === 0) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {chips.map((c, i) => (
+        <span
+          key={i}
+          className={cn(
+            'rounded-md border border-line bg-surface-2 px-1.5 py-0.5 text-[10.5px] font-medium',
+            c.cls ?? 'text-muted',
+          )}
+        >
+          {c.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+export function slugify(s: string): string {
+  return (
+    s
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 60) || 'plan'
+  );
+}
+
+/** Trigger a client-side file download for the given text (no fs / IPC needed). */
+export function downloadText(filename: string, text: string): void {
+  const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Print just the plan via an offscreen iframe. A new BrowserWindow is denied by
+ * the app's window-open handler, so we print the iframe's own document instead of
+ * the whole shell. The raw Markdown is shown in a readable monospace block.
+ */
+export function printPlan(title: string, markdown: string): void {
+  const iframe = document.createElement('iframe');
+  iframe.style.position = 'fixed';
+  iframe.style.right = '0';
+  iframe.style.bottom = '0';
+  iframe.style.width = '0';
+  iframe.style.height = '0';
+  iframe.style.border = '0';
+  document.body.appendChild(iframe);
+  const doc = iframe.contentWindow?.document;
+  if (!doc) {
+    iframe.remove();
+    return;
+  }
+  const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  doc.open();
+  doc.write(
+    `<html><head><title>${esc(title)}</title><style>` +
+      'body{font:12px/1.5 -apple-system,Segoe UI,Roboto,sans-serif;color:#111;padding:24px}' +
+      'h1{font-size:18px;margin:0 0 12px}pre{white-space:pre-wrap;word-wrap:break-word;font:11px/1.5 ui-monospace,Menlo,Consolas,monospace}' +
+      `</style></head><body><h1>${esc(title)}</h1><pre>${esc(markdown)}</pre></body></html>`,
+  );
+  doc.close();
+  const win = iframe.contentWindow;
+  if (win) {
+    win.focus();
+    win.print();
+  }
+  // Give the print dialog time to read the document before tearing it down.
+  window.setTimeout(() => iframe.remove(), 1000);
+}

--- a/src/renderer/features/settings/panels/McpServerForm.tsx
+++ b/src/renderer/features/settings/panels/McpServerForm.tsx
@@ -8,7 +8,13 @@
  */
 import { useMemo, useState } from 'react';
 import { Plus, X } from 'lucide-react';
-import type { McpCategory, McpServerInfo, McpServerInput, McpTransport } from '@shared/types';
+import type {
+  McpCategory,
+  McpPlanAccess,
+  McpServerInfo,
+  McpServerInput,
+  McpTransport,
+} from '@shared/types';
 import { cn } from '@/renderer/lib/cn';
 import { ActionButton, SecretInput, SegmentedControl, Select, StackedField, TextInput, Toggle } from '../controls';
 
@@ -94,6 +100,7 @@ export function McpServerForm({
   const [envText, setEnvText] = useState(nonSecretPairs(initial?.env, '='));
   const [headersText, setHeadersText] = useState(nonSecretPairs(initial?.headers, ': '));
   const [trust, setTrust] = useState(initial?.trust ?? 'ask');
+  const [planAccess, setPlanAccess] = useState<McpPlanAccess>(initial?.planAccess ?? 'annotated');
   const [startup, setStartup] = useState(initial?.startup ?? 'on-demand');
   const [claude, setClaude] = useState(initial?.providers.claude ?? true);
   const [cursor, setCursor] = useState(initial?.providers.cursor ?? true);
@@ -127,6 +134,7 @@ export function McpServerForm({
       displayName: displayName.trim() || name.trim(),
       transport,
       trust,
+      planAccess,
       startup,
       providers: { claude, cursor },
       timeoutMs,
@@ -294,6 +302,51 @@ export function McpServerForm({
             { value: 'trusted', label: 'Trusted' },
           ]}
         />
+      </StackedField>
+      <StackedField
+        label="Plan & Ask access"
+        hint="Plan and Ask are read-only modes. Choose which of this server's tools may still run in them."
+      >
+        <SegmentedControl
+          value={planAccess}
+          onChange={setPlanAccess}
+          options={[
+            { value: 'block', label: 'Blocked' },
+            { value: 'annotated', label: 'Read-only tools' },
+            { value: 'all', label: 'Whole server' },
+          ]}
+        />
+        {planAccess === 'annotated' && (
+          <p className="mt-1.5 text-[11px] leading-relaxed text-faint">
+            Only tools this server declares read-only. Servers declare that themselves — one can
+            claim read-only and still write.
+          </p>
+        )}
+        {/* Annotations are optional in the MCP spec and plenty of servers ship
+            none, in which case this setting silently allows nothing. Say so,
+            rather than leaving the user to wonder why the tools are still
+            blocked. Requires a successful probe, so it keys off cached tools. */}
+        {planAccess === 'annotated' &&
+          !!initial &&
+          initial.runtime.tools.length > 0 &&
+          !initial.runtime.tools.some((t) => t.readOnly) && (
+            <p className="mt-1.5 text-[11px] leading-relaxed text-warning">
+              This server declares no read-only tools, so nothing is allowed through. Choose Whole
+              server if you know its tools only read.
+            </p>
+          )}
+        {planAccess === 'all' && (
+          <p className="mt-1.5 text-[11px] leading-relaxed text-warning">
+            You are asserting every tool on this server is read-only. Limboo cannot verify that.
+            App-data, workspace-secret and workspace-boundary guards still apply.
+          </p>
+        )}
+        {planAccess !== 'block' && trust !== 'trusted' && (
+          <p className="mt-1.5 text-[11px] leading-relaxed text-faint">
+            Ask mode will prompt for each call. Claude's Plan mode blocks these tools before Limboo
+            sees them, so it also needs Trust set to Trusted.
+          </p>
+        )}
       </StackedField>
       <StackedField label="Startup">
         <SegmentedControl

--- a/src/renderer/features/settings/panels/McpServerRow.tsx
+++ b/src/renderer/features/settings/panels/McpServerRow.tsx
@@ -162,6 +162,13 @@ export function McpServerRow({ server }: { server: McpServerInfo }) {
                 {server.providers.cursor && <Badge>Cursor</Badge>}
                 {server.source !== 'user' && <Badge muted>imported</Badge>}
                 {server.workspaceId ? <Badge muted>workspace</Badge> : <Badge muted>global</Badge>}
+                {/* Only when it differs from "denied in the read-only modes" —
+                    the default state earns no badge. */}
+                {server.planAccess !== 'block' && (
+                  <Badge muted>
+                    {server.planAccess === 'all' ? 'plan: all tools' : 'plan: read-only'}
+                  </Badge>
+                )}
                 {server.runtime.latencyMs != null && server.runtime.status === 'connected' && (
                   <Badge muted>{server.runtime.latencyMs}ms</Badge>
                 )}
@@ -169,15 +176,25 @@ export function McpServerRow({ server }: { server: McpServerInfo }) {
 
               {toolCount > 0 && (
                 <div className="flex flex-wrap gap-1">
-                  {server.runtime.tools.slice(0, 24).map((t) => (
-                    <span
-                      key={t.name}
-                      title={t.description}
-                      className="rounded border border-line bg-elevated px-1.5 py-0.5 font-mono text-[10px] text-muted"
-                    >
-                      {t.name}
-                    </span>
-                  ))}
+                  {server.runtime.tools.slice(0, 24).map((t) => {
+                    // Under 'annotated' the read-only claim is what decides
+                    // plan/ask reach, so surface which tools carry it — a step
+                    // up the gray ramp, not a second colour. Meaningless under
+                    // 'block' (nothing runs) and 'all' (everything does).
+                    const marked = server.planAccess === 'annotated' && t.readOnly === true;
+                    return (
+                      <span
+                        key={t.name}
+                        title={marked ? `${t.description ?? t.name} · declared read-only` : t.description}
+                        className={cn(
+                          'rounded border bg-elevated px-1.5 py-0.5 font-mono text-[10px]',
+                          marked ? 'border-line-strong text-fg' : 'border-line text-muted',
+                        )}
+                      >
+                        {t.name}
+                      </span>
+                    );
+                  })}
                   {toolCount > 24 && <span className="text-[10px] text-faint">+{toolCount - 24} more</span>}
                 </div>
               )}

--- a/src/renderer/features/workspace/ComposerBanner.tsx
+++ b/src/renderer/features/workspace/ComposerBanner.tsx
@@ -83,8 +83,10 @@ export function ComposerBanner() {
     tone = 'accent';
     Icon = ClipboardCheck;
     title = 'Plan ready for your review';
-    body = `${agentName} proposed an implementation plan. Review it in the Tasks panel, then approve to begin — nothing changes until you do.`;
-    action = { label: 'Review plan', onClick: () => runCommand('drawer.toggleTasks') };
+    // The plan itself now renders inline just above this banner, so point at the
+    // full panel (outline, revisions, filters) rather than at the plan text.
+    body = `${agentName} proposed an implementation plan, shown above. Approve it to begin — nothing changes until you do.`;
+    action = { label: 'Open full panel', onClick: () => runCommand('drawer.toggleTasks') };
   } else if (outcome === 'context-overflow') {
     tone = 'warning';
     Icon = AlertTriangle;

--- a/src/renderer/features/workspace/ConversationView.tsx
+++ b/src/renderer/features/workspace/ConversationView.tsx
@@ -31,6 +31,7 @@ import { MessageSkeleton, ThinkingPulse } from './MessageSkeleton';
 import { InlineApproval } from './InlineApproval';
 import { ToolDiff } from './ToolDiff';
 import { CodeBlock } from './CodeBlock';
+import { PlanCard } from '@/renderer/features/plan/PlanCard';
 
 /** Human label for a file-edit tool's change status, shown inline in the stream. */
 const CHANGE_WORD: Record<string, string> = {
@@ -232,6 +233,11 @@ export function ConversationView({ sessionId }: { sessionId: string }) {
           }
         />
       )}
+      {/* The session's plan, at the tail of the transcript. A plan is session
+          state rather than a turn (it is replaced, not appended), and "the most
+          recent thing said" is where it belongs — right above the composer that
+          approves it. Renders nothing when the session has no plan. */}
+      <PlanCard sessionId={sessionId} />
       {/* Scroll anchor — a small bottom margin keeps the last line off the very
           edge when auto-scrolling (honored by scrollIntoView). The composer is
           docked in flow below the scroller, so no large reserve is needed. */}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -237,6 +237,12 @@ export const MCP_LIMITS = {
   probeTimeout: { min: 1_000, max: 120_000, default: 15_000 },
   /** Max tools cached per server. */
   maxTools: 500,
+  /**
+   * Max fully-qualified MCP tool names spliced into a plan run's `allowedTools`.
+   * That list exists only to get past the Agent SDK's own plan-mode block, so it
+   * stays small and bounded — see `McpManager.planAllowedToolsFor`.
+   */
+  maxPlanAllowedTools: 256,
   /** A single MCP client stdio line beyond this is dropped, never buffered. */
   clientLineMax: 4_194_304,
   /** Max log lines kept in the per-server ring buffer. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -736,6 +736,21 @@ export type McpStartup = 'eager' | 'on-demand';
 /** Whether the server's tools auto-approve or prompt through the permission gate. */
 export type McpTrust = 'ask' | 'trusted';
 
+/**
+ * How far a server's tools may reach inside the read-only session modes
+ * (`plan` / `ask`), which otherwise deny every non-read tool outright.
+ *
+ *   block     — never (the tool is denied, as before this setting existed)
+ *   annotated — only tools whose server-declared `readOnlyHint` is true
+ *   all       — the user asserts the whole server is read-only
+ *
+ * Deliberately ORTHOGONAL to `McpTrust`: trust answers "auto-approve?", this
+ * answers "do I believe this server's read-only claims?". Coupling them would
+ * force a user who only wants read-only planning access to also grant blanket
+ * auto-approval in every mode.
+ */
+export type McpPlanAccess = 'block' | 'annotated' | 'all';
+
 /** Restart policy for a crashed stdio server. */
 export type McpRestartPolicy = 'never' | 'on-failure';
 
@@ -773,6 +788,15 @@ export type McpServerStatus =
 export interface McpToolInfo {
   name: string;
   description?: string;
+  /**
+   * The server's own `annotations.readOnlyHint` (MCP spec), narrowed by
+   * `destructiveHint`. This is a HINT the SERVER asserts about itself, never
+   * enforcement — a server can claim read-only and write anyway. Absent means
+   * "not claimed" (the spec's default is `false`). Consulted only when the user
+   * has set that server's `planAccess` to `'annotated'`; the permission gate
+   * still runs on top.
+   */
+  readOnly?: boolean;
 }
 
 /**
@@ -812,6 +836,8 @@ export interface McpServerConfig {
   enabled: boolean;
   startup: McpStartup;
   trust: McpTrust;
+  /** How far this server's tools reach inside the read-only plan/ask modes. */
+  planAccess: McpPlanAccess;
   /** Per-tool-call wall-clock cap (ms). */
   timeoutMs: number;
   restartPolicy: McpRestartPolicy;
@@ -864,6 +890,7 @@ export interface McpServerInput {
   enabled?: boolean;
   startup?: McpStartup;
   trust?: McpTrust;
+  planAccess?: McpPlanAccess;
   timeoutMs?: number;
   restartPolicy?: McpRestartPolicy;
   providers?: { claude: boolean; cursor: boolean };


### PR DESCRIPTION
<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)
