### PR TITLE
fix(agent,plan): unblock worktree writes, stop the spurious approve failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ All notable changes to Limboo are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-07-27
+
+Sessions run in a git worktree, and Limboo puts that worktree inside its own
+application data folder. A safety rule meant to keep the agent out of Limboo's
+database read the whole folder as off limits — so in a worktree session the
+agent was refused the moment it tried to write its first file, in what was
+actually its own working directory. Approving a plan could fail for a reason
+that was never true, and leave the session unable to try again. The plan card
+also stops appearing before there is a plan to read.
+
+### Fixed
+
+- **The agent could not write anything in a worktree session.** Every file it
+  tried to create was refused as "Limboo's own app data", because sessions check
+  out into a folder that lives inside Limboo's data directory. The rule now
+  covers only what it was written to protect — the database, your settings, and
+  the encrypted secret store — and the rest of that directory, including the
+  worktree the agent works in, is ordinary ground. Cursor runs were blocked by a
+  second copy of the same rule and are fixed with it.
+- **Commands were refused for mentioning a filename.** Anything containing the
+  text `limboo.db` was blocked wherever it ran, so a plain search of your own
+  source could be denied. Only the real, full path to the database is protected
+  now.
+- **Approving a plan could fail with "the agent is already working on this
+  session".** The plan appears while the run that wrote it is still finishing, so
+  a quick click arrived a fraction of a second early and was turned away.
+  Approving now waits for that run to finish instead of refusing, and the buttons
+  are held until it has.
+- **A failed approval left the plan unusable.** The plan was marked as being
+  carried out before the work had actually started, so when it did not start,
+  the approval buttons never came back and the session could not be recovered.
+  The plan is restored when the run fails to begin.
+
+### Changed
+
+- **The plan card waits for the plan.** It used to appear as soon as planning
+  started, showing a title and an "Analyzing the repository" line above the
+  composer while the agent's actual reasoning streamed past it further up. It now
+  appears with the proposal it is asking you to approve. Progress while planning
+  reads where the rest of the run does — in the conversation.
+
 ## [1.11.0] - 2026-07-27
 
 1.10.0 set out to stop Plan and Ask blocking the MCP servers you had connected.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -999,7 +999,7 @@ an active coding agent". Full research/design doc:
     `beforeReadFile`/`afterFileEdit`; payloads map via
     `translate.ts mapHookEvent` into `AgentManager.decideToolUse` — the
     decision core **extracted from `makeCanUseTool`**, so Claude's callback
-    and Cursor's hooks share one implementation (risk sets, app-data +
+    and Cursor's hooks share one implementation (risk sets, crown-jewel +
     workspace path guards, plan read-only, auto-approvals, remembered
     choices, the same PermissionRequest dialog). Duplicate concurrent hook
     events share one decision. **Hooks only ever tighten** — official docs
@@ -1082,8 +1082,11 @@ jail is the kernel-enforced net beneath it.
   `window-state.json` (`crownJewelPaths()`) — are always denied read+write. The
   floor is those SPECIFIC paths, NOT the whole `userData` root, because the
   worktree (`{userData}/worktrees`) and attachments (`{userData}/attachments`)
-  live under it and must stay usable; Layer 1's `touchesAppData` still denies
-  `userData` broadly at the authorization layer. User knobs only widen writes
+  live under it and must stay usable. **All three layers deny exactly this set**
+  — Layer 1's `touchesCrownJewel` (AgentManager) and Cursor's declarative
+  `sessionDenyRules` both consume `crownJewelPaths()` directly, so they cannot
+  drift. (Layer 1 used to deny the whole `userData` root, which hard-blocked
+  every edit the agent made inside a default-rooted worktree.) User knobs only widen writes
   (`allowWritePaths`, each screened against the floor via `screenExtraWritePath`
   — a path into a crown jewel / `/` / `$HOME` is dropped) or tighten the network;
   `excludedCommands` (Claude-only) lists commands that run outside the jail.

--- a/docs/agents/cursor-integration.txt
+++ b/docs/agents/cursor-integration.txt
@@ -371,8 +371,9 @@ Cursor's declarative format: at run start, the adapter materializes a
 session-scoped .cursor/cli.json inside the session worktree (written through
 the guarded FileSystemManager writer path so the workspace-boundary checks
 apply), containing a deny-first rule set derived from Limboo's policy —
-always-deny rules for the app-data guard (touchesAppData,
-AgentManager.ts:2236) and workspace escape, allow rules matching what the
+always-deny rules for the crown-jewel guard (touchesCrownJewel — the DB,
+config and secrets store, NOT the whole userData root, whose worktrees
+subtree is the agent's own cwd) and workspace escape, allow rules matching what the
 user's permissionMode would auto-approve (e.g. Read(**) when autoApproveReads,
 Write(**) only under acceptEdits/auto) — and only passes --force when the
 effective posture is the equivalent of Limboo's 'auto'. For the interactive
@@ -489,7 +490,9 @@ the session's effective root (the WorktreeManager-resolved checkout) as a
 writable path, the attachment staging directory (userData/attachments/
 <sessionId>) as read-only (mirroring the attachment read carve-out that
 canUseTool implements for Claude at AgentManager.ts:2220-2231), block
-userData itself (the touchesAppData guard made kernel-enforced), and keep
+Limboo's crown jewels — the DB, config files and secrets store, i.e. the
+touchesCrownJewel guard made kernel-enforced (NOT the userData root, which
+holds the worktree the agent works in) — and keep
 --network aligned with settings.agent.webSearch. A settings toggle under
 settings.agent (per-provider section) lets power users relax it. Nothing in
 the renderer changes; this is pure run-spec construction.

--- a/src/main/managers/AgentManager.ts
+++ b/src/main/managers/AgentManager.ts
@@ -93,6 +93,7 @@ import { supportsApproveMcps } from './cursor/exec';
 import { mapHookEvent } from './cursor/translate';
 import { withSessionSandboxJson } from './cursor/sandbox';
 import {
+  crownJewelPaths,
   mapClaudeSandbox,
   resolveSandboxConfig,
   type EffectiveSandbox,
@@ -215,6 +216,15 @@ const IDLE_REQUEST: RequestState = {
  */
 const DELTA_FLUSH_CHARS = 24;
 const DELTA_FLUSH_MS = 16;
+
+/**
+ * How long a plan approval waits for the run that produced the plan to finish
+ * tearing down (see {@link AgentManager.waitForRunSettle}). The wait is normally
+ * a few milliseconds — an SDK interrupt unwinding — so this is only a ceiling on
+ * how long a genuinely wedged run can hold the click hostage before the user
+ * gets the "already working" refusal back. Internal timing, not a user setting.
+ */
+const RUN_SETTLE_TIMEOUT_MS = 8_000;
 
 /* ------------------------------------------------------------------ */
 /* Git commit-message sub-agent — an isolated, tool-less one-shot run. */
@@ -499,6 +509,14 @@ interface SessionRuntime {
 interface ActiveRun {
   abort: AbortController;
   query: { close?: () => void } | null;
+  /**
+   * Resolves once `send()`'s `finally` has torn this run down and removed it
+   * from {@link AgentManager.runs}. A captured plan is published to the renderer
+   * from INSIDE the still-live run, so an Approve click legitimately arrives
+   * while the entry is still here — {@link AgentManager.waitForRunSettle} awaits
+   * this instead of rejecting the user outright.
+   */
+  settled: Promise<void>;
   /** Whether this run is a read-only plan run or a normal implement run. */
   mode: AgentMode;
   /** Terminal SDK result for the active attempt (drives outcome classification). */
@@ -1313,6 +1331,38 @@ export class AgentManager {
     this.pushEvent({ kind: 'activity', sessionId, item: this.activity(sessionId, 'status', 'Run stopped', undefined, 'warning') });
   }
 
+  /**
+   * Await the teardown of an in-flight run for this session, then confirm it is
+   * idle. A captured plan is published from INSIDE the still-live run — Claude's
+   * ExitPlanMode interrupt has not finished unwinding the SDK, and Cursor's
+   * promise has not settled — so the Approve/Keep-planning click a user makes the
+   * instant the plan appears legitimately lands while `runs` still holds the
+   * entry. Waiting for the settle is the correct answer there; rejecting it (as
+   * `send`'s own guard does) surfaced as a spurious "the agent is already working
+   * on this session".
+   *
+   * Falls back to the same refusal if the run is genuinely still going after the
+   * timeout — a busy session must still say no.
+   */
+  private async waitForRunSettle(sessionId: string): Promise<void> {
+    const run = this.runs.get(sessionId);
+    if (!run) return;
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        run.settled,
+        new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, RUN_SETTLE_TIMEOUT_MS);
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+    if (this.runs.has(sessionId)) {
+      throw new Error('The agent is already working on this session.');
+    }
+  }
+
   /** Forget a session entirely (transcript, activity, runtime state). */
   clearSession(sessionId: string): void {
     this.stop(sessionId);
@@ -1613,9 +1663,17 @@ export class AgentManager {
 
     const cfg = this.settings.getAll().agent.connection;
     const abort = new AbortController();
+    // Deferred settled in the `finally` below, after the map entry is gone.
+    // Definite assignment: a Promise executor runs synchronously, so this is
+    // bound before the constructor returns, let alone before anything awaits it.
+    let markSettled!: () => void;
+    const settled = new Promise<void>((resolve) => {
+      markSettled = resolve;
+    });
     this.runs.set(sessionId, {
       abort,
       query: null,
+      settled,
       mode: isPlan ? 'plan' : 'implement',
       attachmentIds: attachmentIds && attachmentIds.length > 0 ? attachmentIds : undefined,
     });
@@ -1641,6 +1699,10 @@ export class AgentManager {
     } finally {
       const captured = this.runs.get(sessionId)?.planCaptured;
       this.runs.delete(sessionId);
+      // Release waiters immediately after the map entry is gone, so anyone who
+      // wakes on it observes an idle session. Kept ahead of the teardown work
+      // below (and outside its failure modes) so a throw can never strand them.
+      markSettled();
       this.emitHook(sessionId, 'run-finished', { summary: 'Run finished' });
       // Re-anchor the session's repository snapshot — the agent may have
       // changed the repo. Fire-and-forget; never delays run teardown.
@@ -2473,10 +2535,10 @@ export class AgentManager {
     }
 
     // Declarative posture (documented CLI feature — the enforced layer): the
-    // deny-first cli.json now wraps EVERY run (the app-data Read/Write guard
+    // deny-first cli.json now wraps EVERY run (the crown-jewel Read/Write guard
     // matters even propose-only), with allow rules translated from the
     // standing posture. Deny beats allow, so the merge only tightens.
-    const denyRules = sessionDenyRules(app.getPath('userData'));
+    const denyRules = sessionDenyRules(crownJewelPaths());
     const allowRules = [
       ...sessionAllowRules({
         autoApproveReads: agent.autoApproveReads && agent.permissionMode !== 'approve-all',
@@ -2955,6 +3017,16 @@ export class AgentManager {
    * the plan in context. The only transition that lets the agent touch the repo.
    */
   async approvePlan(sessionId: string, execMode: SessionPermissionMode = 'default'): Promise<void> {
+    if (this.loadPlan(sessionId)?.status !== 'ready') {
+      throw new Error('There is no plan ready to approve for this session.');
+    }
+    // The plan run that produced this plan is usually still unwinding — wait for
+    // it BEFORE mutating anything, so a timeout leaves the plan 'ready' and the
+    // Approve button retryable rather than stranding the session.
+    await this.waitForRunSettle(sessionId);
+    // Re-read: the settling run republishes the plan on its way out (the
+    // planning→rejected settle in send's finally), so the pre-wait snapshot may
+    // be stale. Bail without mutating if it moved off 'ready'.
     const plan = this.loadPlan(sessionId);
     if (!plan || plan.status !== 'ready') {
       throw new Error('There is no plan ready to approve for this session.');
@@ -2964,6 +3036,8 @@ export class AgentManager {
     const mode: SessionPermissionMode =
       execMode === 'plan' || execMode === 'ask' ? 'default' : execMode;
     const approved: SessionPlan = { ...plan, status: 'implementing', approvedAt: Date.now() };
+    // Committed BEFORE the send on purpose: runCursorOnce re-reads this row to
+    // decide whether the implement pass runs with --force.
     this.savePlan(approved);
     this.pushEvent({ kind: 'plan', sessionId, plan: approved });
     this.pushActivity(sessionId, 'status', 'Plan approved — implementing', undefined, 'success');
@@ -2975,7 +3049,23 @@ export class AgentManager {
       providerForModel(this.settings.getAll().agent.model) === 'cursor'
         ? 'The plan is approved — implement it now, applying the proposed changes exactly as planned, working through the steps in order.'
         : 'The plan is approved. Implement it now, working through the steps in order and tracking your progress with the TodoWrite tool. Ask for approval before any change you are unsure about.';
-    await this.send(sessionId, prompt, mode);
+    try {
+      await this.send(sessionId, prompt, mode);
+    } catch (err) {
+      // The approval never took effect — put the plan back so Approve renders
+      // again. Without this the session is stranded: 'implementing' hides the
+      // controls forever AND makes every later Cursor run silently --force.
+      this.savePlan(plan);
+      this.pushEvent({ kind: 'plan', sessionId, plan });
+      this.pushActivity(
+        sessionId,
+        'status',
+        'Could not start implementing — plan restored',
+        err instanceof Error ? err.message : undefined,
+        'warning',
+      );
+      throw err;
+    }
   }
 
   /** Pin / unpin the current plan so it is preserved even after a new plan begins. */
@@ -3000,6 +3090,9 @@ export class AgentManager {
 
   /** Discard the current plan and run a fresh planning pass (optionally guided). */
   async regeneratePlan(sessionId: string, extra?: string): Promise<void> {
+    // Same race as approvePlan: "Keep planning" is offered the instant the plan
+    // renders, while the run that produced it is still tearing down.
+    await this.waitForRunSettle(sessionId);
     const plan = this.loadPlan(sessionId);
     // Preserve the outgoing plan as a revision before the new pass overwrites it,
     // so iterative planning cycles can be compared/restored.
@@ -3417,12 +3510,12 @@ export class AgentManager {
         );
       }
 
-      // Attachment carve-out (before the app-data guard, which would otherwise
-      // block the staging dir inside userData): READ tools may open files inside
-      // THIS session's own attachments dir — the userData staging dir (Claude)
-      // or the per-run in-workspace mirror (Cursor). Writes/edits there stay
-      // denied below, and Bash referencing userData is still blocked by
-      // touchesAppData.
+      // Attachment carve-out: READ tools may open files inside THIS session's own
+      // attachments dir — the userData staging dir (Claude) or the per-run
+      // in-workspace mirror (Cursor) — without a prompt. Both live outside the
+      // workspace root, so this short-circuits the path guard below; the crown-jewel
+      // guard no longer covers the staging dir (it denies only the DB/config/secrets),
+      // but the ordering is kept so the allow stays ahead of every gate.
       {
         const attachmentTarget = filePathOf(input);
         if (attachmentTarget && classifyTool(toolName) === 'read') {
@@ -3438,15 +3531,24 @@ export class AgentManager {
         }
       }
 
-      // App-data guard (defense in depth): the agent must never reach Limboo's own
-      // store directly — the memory tools are the only sanctioned read path. This is
-      // checked before any auto-allow so a Bash `sqlite3 …/limboo.db` can't slip past.
-      if (touchesAppData(toolName, input)) {
-        this.pushActivity(sessionId, 'permission', `Blocked ${toolName} on Limboo app data`, undefined, 'danger');
+      // Crown-jewel guard (defense in depth): the agent must never reach Limboo's own
+      // database, config, or safeStorage secrets directly — the memory tools are the
+      // only sanctioned read path. Checked before any auto-allow so a Bash
+      // `sqlite3 …/limboo.db` can't slip past. Scoped to those specific paths, NOT
+      // the whole userData root — the session worktree and attachment staging dir
+      // live under it (see protectedPaths / sandbox/policy.ts).
+      if (touchesCrownJewel(toolName, input)) {
+        this.pushActivity(
+          sessionId,
+          'permission',
+          `Blocked ${toolName} on Limboo's database/settings`,
+          undefined,
+          'danger',
+        );
         return {
           behavior: 'deny',
           message:
-            "Reading Limboo's own app data (the local database/settings) is not allowed — use the memory tools instead.",
+            "Limboo's own database, settings, and stored secrets are off limits — use the memory tools instead.",
         };
       }
 
@@ -4306,51 +4408,94 @@ function shortPath(p: string): string {
 }
 
 /**
- * Limboo's own data directory (the `userData` root holding `limboo.db`,
- * `settings.json`, `window-state.json`, logs and safeStorage material). The agent
- * must never read or write inside it: the Local Memory System (the
- * `mcp__limboo_memory__*` tools) is the *only* sanctioned read path into that DB,
- * and direct access would bypass scoping and leak other workspaces' memories and
- * app internals. Resolved once (lazily, so a non-Electron test context can't crash).
+ * Limboo's **crown jewels** — the safeStorage `secrets/` store, the SQLite DB (and
+ * its WAL/SHM siblings), and the `settings.json` / `window-state.json` config
+ * files. These are the only parts of `userData` the agent must never reach: the
+ * Local Memory System (the `mcp__limboo_memory__*` tools) is the sole sanctioned
+ * read path into the DB, and a direct write to the live store would corrupt the
+ * running app.
+ *
+ * This is deliberately NOT the whole `userData` root. The session worktree
+ * (default `{userData}/worktrees/…`) and the attachment staging dir
+ * (`{userData}/attachments/…`) legitimately live under it and ARE the agent's
+ * working directories — a blanket root deny fought the agent's own cwd and
+ * hard-blocked every edit in a default-rooted worktree. Same narrowing, same
+ * reason, as the OS sandbox floor: `crownJewelPaths()` in sandbox/policy.ts is
+ * the shared source, so Layer 1 and Layer 3 can never drift.
+ *
+ * Resolved once (lazily, so a non-Electron test context can't crash).
  */
-let protectedRoot: string | null | undefined;
-function appDataRoot(): string | null {
-  if (protectedRoot === undefined) {
+let crownJewels: string[] | undefined;
+function protectedPaths(): string[] {
+  if (crownJewels === undefined) {
     try {
-      protectedRoot = fs.realpathSync(app.getPath('userData'));
-    } catch {
+      const base = crownJewelPaths();
+      // The DB's WAL/SHM siblings are the same secret by another name; derive
+      // them here rather than widening the Layer 3 sandbox floor's contract.
+      const db = base.find((p) => p.endsWith('limboo.db'));
+      const named = db ? [...base, `${db}-wal`, `${db}-shm`] : base;
+      // Cover the realpath of the userData root too (a symlinked `~/.config`
+      // is common), so a resolved target still matches. NOT `isInside` per
+      // jewel: that realpaths its root argument and therefore silently fails
+      // open for a jewel that does not exist yet — `secrets/` and
+      // `window-state.json` are both absent on a fresh install, and those are
+      // exactly the ones a first write must not be allowed to create.
+      const raw = app.getPath('userData');
+      let real = raw;
       try {
-        protectedRoot = app.getPath('userData');
+        real = fs.realpathSync(raw);
       } catch {
-        protectedRoot = null;
+        /* not yet created — the lexical path is the only truth we have */
       }
+      const variants = new Set<string>();
+      for (const jewel of named) {
+        variants.add(path.resolve(jewel));
+        if (real !== raw) variants.add(path.resolve(real, path.relative(raw, jewel)));
+      }
+      crownJewels = [...variants];
+    } catch {
+      crownJewels = [];
     }
   }
-  return protectedRoot;
+  return crownJewels;
+}
+
+/** Resolve a path through symlinks where possible, else lexically. */
+function resolveLoosely(target: string): string {
+  const abs = path.resolve(target);
+  try {
+    return fs.realpathSync(abs);
+  } catch {
+    return abs;
+  }
 }
 
 /**
- * True when a tool call would touch Limboo's own app data — either a path-bearing
- * tool resolving inside `userData` (defense in depth) or a `Bash`/command tool whose
- * command string references the data dir or the SQLite DB by name. Heuristic for
- * shell, but deliberately broad: there is no legitimate reason for the agent to
- * reach the app's private store.
+ * True when a tool call would touch one of the crown jewels — either a path-bearing
+ * tool resolving to (or inside) one, or a `Bash`/command tool whose command string
+ * names one by absolute path. The shell check is intentionally absolute-path only:
+ * a bare-name match blocked innocent commands like `grep limboo.db src/` that never
+ * leave the workspace.
  */
-function touchesAppData(toolName: string, input: Record<string, unknown>): boolean {
-  const root = appDataRoot();
-  if (!root) return false;
+function touchesCrownJewel(toolName: string, input: Record<string, unknown>): boolean {
+  const jewels = protectedPaths();
+  if (jewels.length === 0) return false;
 
   const file = filePathOf(input);
-  if (file && isInside(root, file)) return true;
+  if (file) {
+    // Compare both the raw and the symlink-resolved form: the raw catches a
+    // not-yet-existing jewel, the resolved catches a symlink aimed at one.
+    const abs = path.resolve(file);
+    const real = resolveLoosely(file);
+    const hit = (t: string) =>
+      jewels.some((jewel) => t === jewel || t.startsWith(jewel + path.sep));
+    if (hit(abs) || hit(real)) return true;
+  }
 
   if (toolName === 'Bash') {
     const cmd = String(input.command ?? '');
     if (!cmd) return false;
-    // The absolute userData path, or the DB / config dir by name (covers WAL/SHM
-    // siblings and `sqlite3 .../limboo.db` style access regardless of cwd).
-    if (cmd.includes(root)) return true;
-    if (/limboo\.db\b/i.test(cmd)) return true;
-    if (/[\\/]limboo[\\/](limboo\.db|settings\.json|window-state\.json)/i.test(cmd)) return true;
+    if (jewels.some((jewel) => cmd.includes(jewel))) return true;
   }
   return false;
 }
@@ -4398,7 +4543,7 @@ function isSshNonSecret(base: string): boolean {
  * declarative `ask` rules in cursor/permissions.ts; the caller turns a hit into a
  * human-approval prompt (not a hard block) for BOTH providers — Cursor's
  * absolute-path glob normalization is unreliable, so this app-level guard is the
- * dependable catch (defense in depth, like touchesAppData).
+ * dependable catch (defense in depth, like touchesCrownJewel).
  */
 function touchesSensitiveFile(toolName: string, input: Record<string, unknown>): boolean {
   const sshDir = path.join(os.homedir(), '.ssh');

--- a/src/main/managers/agent/readOnlyCommands.ts
+++ b/src/main/managers/agent/readOnlyCommands.ts
@@ -9,9 +9,9 @@
  * read-only invocation from the allowlist below, the answer is `false`.
  *
  * The classifier only ever RELAXES risk from `command` to `read`; it is
- * consulted AFTER the app-data guard (which string-matches the whole command
- * against userData/limboo.db), so a read of app internals stays blocked
- * regardless of what this module says.
+ * consulted AFTER the crown-jewel guard (which string-matches the whole command
+ * against the absolute DB/config/secrets paths), so a read of those stays
+ * blocked regardless of what this module says.
  */
 
 /** Whole-command rejects: substitution, expansion, redirection, background.

--- a/src/main/managers/cursor/permissions.ts
+++ b/src/main/managers/cursor/permissions.ts
@@ -4,13 +4,14 @@
  * Cursor's declarative permission system is the INVERSE of Claude's callback
  * one: allow/deny rule lists, deny beats allow, and in print mode `--force`
  * allows everything not explicitly denied. Limboo therefore materializes a
- * deny-first cli.json for EVERY run (the app-data guard applies even to
+ * deny-first cli.json for EVERY run (the crown-jewel guard applies even to
  * propose-only runs) and translates the user's standing posture into allow
  * rules; `--force` is only ever issued together with this rule set. The file
  * is written just for the run and the pre-run bytes are restored in `finally`
  * (see sessionFile.ts). Self-deny rules prevent the agent from editing its
  * own gates (cli.json / hooks.json / mcp.json) mid-run.
  */
+import path from 'node:path';
 import { readOnlyShellRuleSpecs } from '../agent/readOnlyCommands';
 import { copySafeKeys, safeParseObject, withSessionFile } from './sessionFile';
 
@@ -32,12 +33,17 @@ function absRulePath(p: string): string {
 }
 
 /**
- * The minimal deny-first rule set for any Cursor run. Mirrors the app-data
- * guard the Claude path enforces in canUseTool (touchesAppData) plus
+ * The minimal deny-first rule set for any Cursor run. Mirrors the crown-jewel
+ * guard the Claude path enforces in canUseTool (touchesCrownJewel) plus
  * repo-integrity, self-gate, and destructive-shell basics.
+ *
+ * `jewels` are absolute OS paths — pass `crownJewelPaths()`. They are the DB,
+ * config files, and safeStorage store ONLY, never the whole `userData` root:
+ * deny beats allow in Cursor's grammar, and the session worktree defaults to
+ * `{userData}/worktrees/…`, so a blanket root deny silently blocked every edit
+ * the agent made in its own working directory.
  */
-export function sessionDenyRules(userDataPath: string): string[] {
-  const userData = absRulePath(userDataPath);
+export function sessionDenyRules(jewels: string[]): string[] {
   return [
     // Repo integrity: never let a force run rewrite git internals or its own gates.
     'Write(.git/**)',
@@ -48,17 +54,22 @@ export function sessionDenyRules(userDataPath: string): string[] {
     // Limboo's reserved workspace namespace (per-run attachment staging).
     'Write(.limboo/**)',
     'Write(**/.limboo/**)',
-    // App data: Limboo's own database/settings/secrets are never a tool target.
-    // Absolute rule path (`//…`) — a single leading slash would be read as
-    // project-relative and never match (see absRulePath).
-    `Read(${userData}/**)`,
-    `Write(${userData}/**)`,
-    // Named belt-and-suspenders denies for the two the design note calls out by
-    // name (both already inside the userData tree above, but explicit here).
-    // Limboo's own app data stays HARD-denied — the memory tools are the only
-    // sanctioned path in; workspace secrets (below) are ask-for-approval instead.
-    `Read(${userData}/secrets/**)`,
-    `Read(${userData}/limboo.db)`,
+    // Crown jewels: Limboo's own database, config, and safeStorage store are
+    // never a tool target — the memory tools are the only sanctioned path in
+    // (workspace secrets, below, are ask-for-approval instead). Both verbs per
+    // jewel: writes used to ride a blanket `Write(userData/**)` rule, which also
+    // swallowed the worktree. Absolute rule paths (`//…`) — a single leading
+    // slash would be read as project-relative and never match (see absRulePath).
+    ...jewels.flatMap((jewel) => {
+      const p = absRulePath(jewel);
+      const rules = [`Read(${p})`, `Write(${p})`];
+      // The DB's WAL/SHM siblings are the same secret under another name.
+      if (jewel.endsWith('.db')) rules.push(`Read(${p}-*)`, `Write(${p}-*)`);
+      // A directory jewel (`secrets/`) also needs the recursive form; a file
+      // jewel is matched exactly (a `settings.json/**` rule can never match).
+      else if (!path.extname(jewel)) rules.push(`Read(${p}/**)`, `Write(${p}/**)`);
+      return rules;
+    }),
     // Destructive-shell basics (deny-first; everything else rides --force).
     'Shell(rm)',
     'Shell(rmdir)',

--- a/src/main/managers/sandbox/policy.ts
+++ b/src/main/managers/sandbox/policy.ts
@@ -22,8 +22,9 @@
  * session worktree (default `{userData}/worktrees/…`) and the attachment staging
  * dir (`{userData}/attachments/…`) legitimately live under `userData` and MUST
  * stay usable; a blanket `userData` deny would fight the agent's own working dir.
- * Layer 1's `touchesAppData` guard still denies `userData` broadly at the
- * authorization layer, so the crown-jewel OS deny is pure defense-in-depth.
+ * Layer 1's `touchesCrownJewel` guard (AgentManager) and Cursor's declarative
+ * `sessionDenyRules` both deny this SAME set at the authorization layer — they
+ * consume `crownJewelPaths()` directly — so the three layers cannot drift.
  * The user-configurable knobs only ever *widen* writes (extra paths, screened
  * against the floor) or tighten the network — they can never re-expose a crown
  * jewel or escape the worktree.

--- a/src/renderer/features/activity/PlanPanel.tsx
+++ b/src/renderer/features/activity/PlanPanel.tsx
@@ -293,6 +293,7 @@ function PlanView({
       {ready && (
         <ApprovalControls
           settings={settings}
+          busy={running}
           onApprove={(mode) => sessionId && approvePlan(sessionId, mode)}
           onRegenerate={() => sessionId && regeneratePlan(sessionId)}
           onReject={() => sessionId && rejectPlan(sessionId)}

--- a/src/renderer/features/plan/PlanCard.tsx
+++ b/src/renderer/features/plan/PlanCard.tsx
@@ -29,7 +29,7 @@ import {
   PinOff,
 } from 'lucide-react';
 import type { SessionPlan, TaskItem } from '@shared/types';
-import { IconButton, Spinner } from '@/renderer/components/ui';
+import { IconButton } from '@/renderer/components/ui';
 import { cn } from '@/renderer/lib/cn';
 import { applyRuntime, parsePlanOutline } from '@/renderer/lib/planOutline';
 import { RUNNING_PHASES } from '@/renderer/features/sessions/useSessionRunning';
@@ -40,18 +40,31 @@ import { useSettingsStore } from '@/renderer/stores/useSettingsStore';
 import { ApprovalControls, PlanMetaRow, STATUS_BADGE, usePlanActions } from './parts';
 
 /**
- * Statuses at which the plan is over. A plan row is never deleted — `rejectPlan`
- * and the implement-run completion only rewrite `status`, and `getSnapshot`
- * rehydrates it on every boot — so gating on `plan != null` alone left a dead
- * card pinned above the composer for the life of the session, collapsing to a
- * bare header once there was nothing left to act on. The card belongs to work in
- * progress; the finished plan stays reachable in the Tasks drawer.
+ * Statuses at which the inline card renders nothing.
+ *
+ * `planning` — there is no plan yet. The card used to appear the moment a plan
+ * run started, showing a title, a "Planning" badge and an "Analyzing the
+ * repository…" row: a fixed block above the composer restating what the live
+ * status row and the activity timeline already say, while pushing the analysis
+ * the agent is actually streaming further up the transcript. The card exists to
+ * present a proposal for approval, so it now arrives WITH that proposal — at
+ * `ready` — and not before.
+ *
+ * `completed`/`rejected` — the plan is over. A plan row is never deleted
+ * (`rejectPlan` and the implement-run completion only rewrite `status`, and
+ * `getSnapshot` rehydrates it on every boot), so gating on `plan != null` alone
+ * left a dead card pinned above the composer for the life of the session. The
+ * card belongs to work in progress; the finished plan stays reachable in the
+ * Tasks drawer.
+ *
+ * That leaves `ready` (the approval surface) and `implementing` (self-folding,
+ * so the run has the room) as the only states with a card.
  */
-const FINISHED = new Set<SessionPlan['status']>(['completed', 'rejected']);
+const HIDDEN = new Set<SessionPlan['status']>(['planning', 'completed', 'rejected']);
 
 export function PlanCard({ sessionId }: { sessionId: string }) {
   const plan = useAgentStore((s) => s.bySession[sessionId]?.plan) ?? null;
-  if (!plan || FINISHED.has(plan.status)) return null;
+  if (!plan || HIDDEN.has(plan.status)) return null;
   return <PlanCardBody sessionId={sessionId} plan={plan} />;
 }
 
@@ -84,7 +97,6 @@ function PlanCardBody({ sessionId, plan }: { sessionId: string; plan: SessionPla
 
   const actions = usePlanActions(sessionId, plan, outline);
 
-  const planning = plan.status === 'planning';
   const ready = plan.status === 'ready';
   const badge = STATUS_BADGE[plan.status];
 
@@ -102,7 +114,7 @@ function PlanCardBody({ sessionId, plan }: { sessionId: string; plan: SessionPla
       : { completed: outline.completed, active: 0, total: outline.taskCount };
   }, [tasks, outline]);
 
-  const showBody = open && !planning && !!plan.markdown && settings.showReasoning;
+  const showBody = open && !!plan.markdown && settings.showReasoning;
 
   return (
     <div className="flex flex-col gap-2 rounded-md border border-line bg-surface-2/50 animate-fade-in">
@@ -111,78 +123,62 @@ function PlanCardBody({ sessionId, plan }: { sessionId: string; plan: SessionPla
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
-          disabled={planning}
-          className={cn(
-            'flex min-w-0 flex-1 items-start gap-1.5 rounded text-left',
-            planning ? 'cursor-default' : 'transition-colors hover:opacity-80',
-          )}
+          className="flex min-w-0 flex-1 items-start gap-1.5 rounded text-left transition-colors hover:opacity-80"
         >
-          {!planning &&
-            (open ? (
-              <ChevronDown size={13} className="mt-0.5 shrink-0 text-faint" />
-            ) : (
-              <ChevronRight size={13} className="mt-0.5 shrink-0 text-faint" />
-            ))}
+          {open ? (
+            <ChevronDown size={13} className="mt-0.5 shrink-0 text-faint" />
+          ) : (
+            <ChevronRight size={13} className="mt-0.5 shrink-0 text-faint" />
+          )}
           <span className="flex min-w-0 flex-col">
             <span className="flex items-center gap-1.5 truncate text-[13px] font-semibold text-fg" title={plan.title}>
               {plan.pinned && <Pin size={11} className="shrink-0 text-accent" />}
               {plan.title}
             </span>
             <span className={cn('text-[11px] font-medium', badge.cls)}>
-              {(planning || progress.active > 0) && (
-                <Loader2 size={10} className="mr-1 inline animate-spin" />
-              )}
+              {progress.active > 0 && <Loader2 size={10} className="mr-1 inline animate-spin" />}
               {badge.label}
               {progress.total > 0 && ` · ${progress.completed}/${progress.total}`}
               {progress.active > 0 && <span className="ml-1 text-accent">· {progress.active} running</span>}
             </span>
           </span>
         </button>
-        {!planning && (
-          <div className="flex shrink-0 items-center gap-0.5">
-            <IconButton size="sm" label="Copy plan as Markdown" onClick={actions.copy}>
-              <Copy size={13} />
-            </IconButton>
-            <IconButton
-              size="sm"
-              label={raw ? 'Show rendered plan' : 'View as Markdown'}
-              active={raw}
-              onClick={() => setRaw((v) => !v)}
-            >
-              <Code2 size={13} />
-            </IconButton>
-            <IconButton
-              size="sm"
-              label={plan.pinned ? 'Unpin plan' : 'Pin plan'}
-              active={plan.pinned}
-              onClick={actions.togglePin}
-            >
-              {plan.pinned ? <PinOff size={13} /> : <Pin size={13} />}
-            </IconButton>
-            <IconButton size="sm" label="Collapse plan" onClick={() => setOpen(false)}>
-              <Minimize2 size={13} />
-            </IconButton>
-            <IconButton
-              size="sm"
-              label="Open the full plan panel"
-              onClick={() => useLayoutStore.getState().setActiveTab('tasks')}
-            >
-              <Maximize2 size={13} />
-            </IconButton>
-          </div>
-        )}
+        <div className="flex shrink-0 items-center gap-0.5">
+          <IconButton size="sm" label="Copy plan as Markdown" onClick={actions.copy}>
+            <Copy size={13} />
+          </IconButton>
+          <IconButton
+            size="sm"
+            label={raw ? 'Show rendered plan' : 'View as Markdown'}
+            active={raw}
+            onClick={() => setRaw((v) => !v)}
+          >
+            <Code2 size={13} />
+          </IconButton>
+          <IconButton
+            size="sm"
+            label={plan.pinned ? 'Unpin plan' : 'Pin plan'}
+            active={plan.pinned}
+            onClick={actions.togglePin}
+          >
+            {plan.pinned ? <PinOff size={13} /> : <Pin size={13} />}
+          </IconButton>
+          <IconButton size="sm" label="Collapse plan" onClick={() => setOpen(false)}>
+            <Minimize2 size={13} />
+          </IconButton>
+          <IconButton
+            size="sm"
+            label="Open the full plan panel"
+            onClick={() => useLayoutStore.getState().setActiveTab('tasks')}
+          >
+            <Maximize2 size={13} />
+          </IconButton>
+        </div>
       </div>
 
-      {settings.showEstimates && !planning && open && (
+      {settings.showEstimates && open && (
         <div className="px-3">
           <PlanMetaRow meta={plan.meta} highlightRisk={settings.highlightRisk} />
-        </div>
-      )}
-
-      {planning && (
-        <div className="flex items-center gap-2 px-3 pb-2.5 text-[12px] text-muted">
-          <Spinner size={12} />
-          Analyzing the repository — reading files and dependencies (read-only)…
         </div>
       )}
 
@@ -201,6 +197,7 @@ function PlanCardBody({ sessionId, plan }: { sessionId: string; plan: SessionPla
         <div className="px-3 pb-3">
           <ApprovalControls
             settings={settings}
+            busy={running}
             onApprove={(mode) => approvePlan(sessionId, mode)}
             onRegenerate={() => regeneratePlan(sessionId)}
             onReject={() => rejectPlan(sessionId)}
@@ -209,7 +206,7 @@ function PlanCardBody({ sessionId, plan }: { sessionId: string; plan: SessionPla
       )}
 
       {/* Keep a bottom edge when nothing below the header rendered. */}
-      {!ready && !showBody && !planning && <div className="pb-1" />}
+      {!ready && !showBody && <div className="pb-1" />}
     </div>
   );
 }

--- a/src/renderer/features/plan/parts.tsx
+++ b/src/renderer/features/plan/parts.tsx
@@ -8,7 +8,7 @@
  * status reads. Presentational + pure helpers only — no store subscriptions
  * beyond the toast used by the copy action, and no business logic.
  */
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { CheckCircle2 } from 'lucide-react';
 import type { PlanMeta, PlanStatus, SessionPermissionMode, SessionPlan } from '@shared/types';
 import { cn } from '@/renderer/lib/cn';
@@ -71,20 +71,35 @@ export function usePlanActions(
 /* Approval                                                            */
 /* ------------------------------------------------------------------ */
 
+/**
+ * `busy` = the run that produced this plan is still tearing down. The plan is
+ * published to the renderer from inside that run, so the controls appear a beat
+ * before the session is actually idle; acting in that window used to fail with
+ * "the agent is already working on this session".
+ */
 export function ApprovalControls({
   settings,
+  busy = false,
   onApprove,
   onRegenerate,
   onReject,
 }: {
   settings: { requireSecondaryConfirm: boolean };
+  busy?: boolean;
   onApprove: (mode: SessionPermissionMode) => void;
   onRegenerate: () => void;
   onReject: () => void;
 }) {
   const [confirming, setConfirming] = useState<SessionPermissionMode | null>(null);
 
+  // Drop a half-finished secondary confirmation if the session goes busy again,
+  // so the next click can't fire an approval the user staged a run ago.
+  useEffect(() => {
+    if (busy) setConfirming(null);
+  }, [busy]);
+
   const approve = (mode: SessionPermissionMode) => {
+    if (busy) return;
     if (settings.requireSecondaryConfirm && confirming !== mode) {
       setConfirming(mode);
       return;
@@ -93,32 +108,52 @@ export function ApprovalControls({
     onApprove(mode);
   };
 
+  const regenerate = () => {
+    if (busy) return;
+    onRegenerate();
+  };
+
+  const DISABLED = 'disabled:cursor-not-allowed disabled:opacity-50';
+
   return (
     <div className="flex flex-col gap-2 rounded-md border border-accent/40 bg-accent/10 px-3 py-2.5">
       <p className="text-[12px] text-muted">
-        Review the plan above. Approving exits Plan Mode and begins implementation against this
-        outline — choose how much to review as it works.
+        {busy
+          ? 'Finishing the planning run — the controls unlock in a moment.'
+          : 'Review the plan above. Approving exits Plan Mode and begins implementation against this outline — choose how much to review as it works.'}
       </p>
       <div className="flex flex-wrap items-center gap-2">
         <button
           type="button"
+          disabled={busy}
           onClick={() => approve('default')}
-          className="flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-[12px] font-semibold text-base transition-opacity hover:opacity-90"
+          className={cn(
+            'flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-[12px] font-semibold text-base transition-opacity hover:opacity-90',
+            DISABLED,
+          )}
         >
           <CheckCircle2 size={13} />
           {confirming === 'default' ? 'Confirm — start now' : 'Approve & ask before edits'}
         </button>
         <button
           type="button"
+          disabled={busy}
           onClick={() => approve('acceptEdits')}
-          className="rounded-md border border-accent/50 bg-accent/15 px-2.5 py-1.5 text-[12px] font-medium text-accent transition-colors hover:bg-accent/25"
+          className={cn(
+            'rounded-md border border-accent/50 bg-accent/15 px-2.5 py-1.5 text-[12px] font-medium text-accent transition-colors hover:bg-accent/25',
+            DISABLED,
+          )}
         >
           {confirming === 'acceptEdits' ? 'Confirm — accept edits' : 'Approve & accept edits'}
         </button>
         <button
           type="button"
-          onClick={onRegenerate}
-          className="rounded-md border border-line bg-surface-2 px-2.5 py-1.5 text-[12px] text-muted transition-colors hover:bg-elevated hover:text-fg"
+          disabled={busy}
+          onClick={regenerate}
+          className={cn(
+            'rounded-md border border-line bg-surface-2 px-2.5 py-1.5 text-[12px] text-muted transition-colors hover:bg-elevated hover:text-fg',
+            DISABLED,
+          )}
         >
           Keep planning
         </button>

--- a/src/renderer/stores/useAgentStore.ts
+++ b/src/renderer/stores/useAgentStore.ts
@@ -38,6 +38,14 @@ function emptySnapshot(): AgentSessionSnapshot {
   return { messages: [], activity: [], changes: [], tasks: [], toolCalls: [], plan: null };
 }
 
+/**
+ * Sessions with an approval in flight. Deliberately module state, not store
+ * state: nothing renders from it (the buttons gate on the run phase), it exists
+ * only to keep a double-click — or a command-palette invoke racing the button —
+ * from issuing two approvals for one plan.
+ */
+const approvalsInFlight = new Set<string>();
+
 const IDLE_REQUEST: RequestState = {
   sessionId: null,
   phase: 'idle',
@@ -580,19 +588,32 @@ export const useAgentStore = create<AgentStoreState>((set, get) => {
     approvePlan: (sessionId, execMode) => {
       const api = window.limboo?.agent;
       if (!api?.approvePlan) return;
+      if (approvalsInFlight.has(sessionId)) return;
+      approvalsInFlight.add(sessionId);
       // Flip the composer out of Plan mode immediately — mirror main's coercion
       // (approving never starts another planning pass) so the composer shows the
-      // exact mode the implementation run will use.
+      // exact mode the implementation run will use. The invoke below only
+      // settles when the whole run does, so this cannot wait on it.
+      const previousMode = get().composerModeBySession[sessionId];
       const mode: SessionPermissionMode =
         !execMode || execMode === 'plan' ? 'default' : execMode;
       get().setComposerMode(sessionId, mode);
-      api.approvePlan(sessionId, execMode).catch((err: unknown) => {
-        useUIStore.getState().addToast({
-          title: 'Could not start implementation',
-          description: err instanceof Error ? err.message : String(err),
-          tone: 'danger',
+      api
+        .approvePlan(sessionId, execMode)
+        .catch((err: unknown) => {
+          // The run never started: main has already restored the plan to
+          // 'ready', so put the composer back too rather than leaving it in an
+          // implement mode with nothing running.
+          if (previousMode) get().setComposerMode(sessionId, previousMode);
+          useUIStore.getState().addToast({
+            title: 'Could not start implementation',
+            description: err instanceof Error ? err.message : String(err),
+            tone: 'danger',
+          });
+        })
+        .finally(() => {
+          approvalsInFlight.delete(sessionId);
         });
-      });
     },
 
     rejectPlan: (sessionId) => {

--- a/src/shared/releaseManifest.generated.ts
+++ b/src/shared/releaseManifest.generated.ts
@@ -24,6 +24,72 @@ import type { ReleaseIndexEntry, ReleaseManifestEntry } from './release';
 /** Newest first. */
 export const RELEASE_MANIFESTS: ReleaseManifestEntry[] = [
   {
+    "version": "1.12.0",
+    "date": "2026-07-27",
+    "channel": "stable",
+    "codename": null,
+    "gitTag": "v1.12.0",
+    "commit": null,
+    "buildNumber": null,
+    "summary": "Sessions run in a git worktree, and Limboo puts that worktree inside its own\napplication data folder. A safety rule meant to keep the agent out of Limboo's\ndatabase read the whole folder as off limits — so in a worktree session the\nagent was refused the moment it tried to write its first file, in what was\nactually its own working directory. Approving a plan could fail for a reason\nthat was never true, and leave the session unable to try again. The plan card\nalso stops appearing before there is a plan to read.",
+    "sections": [
+      {
+        "category": "fixed",
+        "title": "Fixed",
+        "items": [
+          {
+            "lead": "The agent could not write anything in a worktree session",
+            "text": "Every file it\n  tried to create was refused as \"Limboo's own app data\", because sessions check\n  out into a folder that lives inside Limboo's data directory. The rule now\n  covers only what it was written to protect — the database, your settings, and\n  the encrypted secret store — and the rest of that directory, including the\n  worktree the agent works in, is ordinary ground. Cursor runs were blocked by a\n  second copy of the same rule and are fixed with it."
+          },
+          {
+            "lead": "Commands were refused for mentioning a filename",
+            "text": "Anything containing the\n  text `limboo.db` was blocked wherever it ran, so a plain search of your own\n  source could be denied. Only the real, full path to the database is protected\n  now."
+          },
+          {
+            "lead": "Approving a plan could fail with \"the agent is already working on this\n  session\"",
+            "text": "The plan appears while the run that wrote it is still finishing, so\n  a quick click arrived a fraction of a second early and was turned away.\n  Approving now waits for that run to finish instead of refusing, and the buttons\n  are held until it has."
+          },
+          {
+            "lead": "A failed approval left the plan unusable",
+            "text": "The plan was marked as being\n  carried out before the work had actually started, so when it did not start,\n  the approval buttons never came back and the session could not be recovered.\n  The plan is restored when the run fails to begin."
+          }
+        ],
+        "markdown": "- **The agent could not write anything in a worktree session.** Every file it\n  tried to create was refused as \"Limboo's own app data\", because sessions check\n  out into a folder that lives inside Limboo's data directory. The rule now\n  covers only what it was written to protect — the database, your settings, and\n  the encrypted secret store — and the rest of that directory, including the\n  worktree the agent works in, is ordinary ground. Cursor runs were blocked by a\n  second copy of the same rule and are fixed with it.\n- **Commands were refused for mentioning a filename.** Anything containing the\n  text `limboo.db` was blocked wherever it ran, so a plain search of your own\n  source could be denied. Only the real, full path to the database is protected\n  now.\n- **Approving a plan could fail with \"the agent is already working on this\n  session\".** The plan appears while the run that wrote it is still finishing, so\n  a quick click arrived a fraction of a second early and was turned away.\n  Approving now waits for that run to finish instead of refusing, and the buttons\n  are held until it has.\n- **A failed approval left the plan unusable.** The plan was marked as being\n  carried out before the work had actually started, so when it did not start,\n  the approval buttons never came back and the session could not be recovered.\n  The plan is restored when the run fails to begin."
+      },
+      {
+        "category": "changed",
+        "title": "Changed",
+        "items": [
+          {
+            "lead": "The plan card waits for the plan",
+            "text": "It used to appear as soon as planning\n  started, showing a title and an \"Analyzing the repository\" line above the\n  composer while the agent's actual reasoning streamed past it further up. It now\n  appears with the proposal it is asking you to approve. Progress while planning\n  reads where the rest of the run does — in the conversation."
+          }
+        ],
+        "markdown": "- **The plan card waits for the plan.** It used to appear as soon as planning\n  started, showing a title and an \"Analyzing the repository\" line above the\n  composer while the agent's actual reasoning streamed past it further up. It now\n  appears with the proposal it is asking you to approve. Progress while planning\n  reads where the rest of the run does — in the conversation."
+      }
+    ],
+    "contributors": [],
+    "pullRequests": [],
+    "mergedBranches": [],
+    "assets": [],
+    "signing": [],
+    "stats": {
+      "commits": null,
+      "filesChanged": null,
+      "additions": null,
+      "deletions": null
+    },
+    "links": {
+      "release": "https://github.com/limboo-ai/limboo/releases/tag/v1.12.0",
+      "compare": null,
+      "tag": "https://github.com/limboo-ai/limboo/releases/tag/v1.12.0",
+      "milestone": null
+    },
+    "checksumManifest": "SHA256SUMS",
+    "provenanceRepo": "limboo-ai/limboo",
+    "markdown": "Sessions run in a git worktree, and Limboo puts that worktree inside its own\napplication data folder. A safety rule meant to keep the agent out of Limboo's\ndatabase read the whole folder as off limits — so in a worktree session the\nagent was refused the moment it tried to write its first file, in what was\nactually its own working directory. Approving a plan could fail for a reason\nthat was never true, and leave the session unable to try again. The plan card\nalso stops appearing before there is a plan to read.\n\n### Fixed\n\n- **The agent could not write anything in a worktree session.** Every file it\n  tried to create was refused as \"Limboo's own app data\", because sessions check\n  out into a folder that lives inside Limboo's data directory. The rule now\n  covers only what it was written to protect — the database, your settings, and\n  the encrypted secret store — and the rest of that directory, including the\n  worktree the agent works in, is ordinary ground. Cursor runs were blocked by a\n  second copy of the same rule and are fixed with it.\n- **Commands were refused for mentioning a filename.** Anything containing the\n  text `limboo.db` was blocked wherever it ran, so a plain search of your own\n  source could be denied. Only the real, full path to the database is protected\n  now.\n- **Approving a plan could fail with \"the agent is already working on this\n  session\".** The plan appears while the run that wrote it is still finishing, so\n  a quick click arrived a fraction of a second early and was turned away.\n  Approving now waits for that run to finish instead of refusing, and the buttons\n  are held until it has.\n- **A failed approval left the plan unusable.** The plan was marked as being\n  carried out before the work had actually started, so when it did not start,\n  the approval buttons never came back and the session could not be recovered.\n  The plan is restored when the run fails to begin.\n\n### Changed\n\n- **The plan card waits for the plan.** It used to appear as soon as planning\n  started, showing a title and an \"Analyzing the repository\" line above the\n  composer while the agent's actual reasoning streamed past it further up. It now\n  appears with the proposal it is asking you to approve. Progress while planning\n  reads where the rest of the run does — in the conversation."
+  },
+  {
     "version": "1.11.0",
     "date": "2026-07-27",
     "channel": "stable",
@@ -443,139 +509,18 @@ export const RELEASE_MANIFESTS: ReleaseManifestEntry[] = [
     "checksumManifest": "SHA256SUMS",
     "provenanceRepo": "limboo-ai/limboo",
     "markdown": "Turns an update from a maintenance task into a workspace document. The release\nnotes added in 1.7.0 were one blob of Markdown; they are now a structured release\ndashboard driven by a real release manifest that the CI pipeline publishes\nalongside the binaries — so the release page, the changelog and the app all\ndescribe a release from the same file.\n\n### Added\n\n- **A structured release document.** The What's New tab becomes a full release\n  view: version, codename, channel, git tag, commit, build number, platform and\n  Electron versions; every changelog section as its own collapsible, copyable,\n  filterable card ordered by consequence (breaking and security first);\n  contributors with commit counts; merged pull requests and branches; published\n  assets with sizes; and a verification block carrying the `sha256sum -c` and\n  `gh attestation verify` commands. A release-history list browses every version\n  the changelog knows and can diff any two bundled releases category by category.\n- **A published release manifest.** Every release now ships\n  `release-manifest.json` — the same structured notes the app carries, plus every\n  artifact's size and SHA-256 and the signing posture per platform. It is written\n  before `SHA256SUMS` so the checksum manifest covers it, and\n  `ci/scripts/check-release-manifest.mjs` proves the two describe the same\n  downloads before anything is published.\n- **Release notes are searchable and agent-reachable.** They federate into Global\n  Search as a `release` source, and the agent can answer \"what changed in 1.7.0?\"\n  through read-only `list_releases` / `release_notes` tools on the existing\n  `limboo_search` server. Both providers get them from one implementation.\n  Nothing is injected into a system prompt — Claude Code shipped a fix for\n  exactly that bug, where its release-notes view leaked the whole changelog into\n  every subsequent request.\n- **Export and copy.** A release can be copied as Markdown or written to a file\n  from the document or the command palette. Main owns the save dialog; the\n  renderer never supplies a path.\n\n### Changed\n\n- **A release tab is its label.** It carries no icon — every other tab in the\n  strip names an object you could point at on disk, and this one names a version,\n  so the version is the identity.\n- **The accent underline is gone from the document and worktree tab strips.** An\n  active tab is marked by its raised seat and a heavier label instead. A 2px\n  accent bar under a tab that already sits on a plate says the same thing twice,\n  and on pure black it reads as a second element rather than an emphasis of the\n  first. Worktree tabs also gained the focus ring they were missing.\n- **`npm run gen:notes` generates the manifest too**, and CI enforces that both\n  generated modules stay in sync with `CHANGELOG.md` (`gen:notes --check`).\n  Keeping them in sync was a checklist item with nothing behind it, so a\n  changelog edit could ship with stale in-app notes and nobody would find out\n  until after the release.\n\n### Fixed\n\n- **The release notes could reappear on every launch.** With no session selected\n  the notes render inline rather than as a tab, and acknowledgement is a tab\n  being closed — so nothing ever marked the version seen. That path now has its\n  own dismissal.\n- **The tab's document id was spelled by hand** in one place instead of derived\n  through `documentId()`, which exists precisely so the format cannot drift. A\n  mismatch there would have left the tab looking permanently closed, silently\n  reopening it forever.\n\n### Security\n\n- **Release metadata is compiled into the build, never fetched.** There is no\n  network path to widen and nothing to verify at runtime, which is also the only\n  design that works under the production CSP (`connect-src 'self'`). Contributor\n  avatars are drawn locally from initials rather than loaded from a forge.\n- **Every manifest URL is screened before it becomes a link** — https only, no\n  embedded credentials, and the host must be a forge host or a subdomain of one,\n  matched on a dot boundary so `evil-github.com` cannot pass. Unscreened URLs\n  render as plain text.\n- **The document never claims verification it cannot perform.** A build cannot\n  contain the hash of an installer produced from it, so asset digests live only\n  in the published manifest; the app shows where they are and how to check them\n  instead of printing a digest it cannot stand behind. Facts about the running\n  process are shown separately from claims about the published artifact.\n- **Markdown rendering is unchanged and still sanitized** (`rehype-sanitize`, no\n  raw HTML), the document performs no writes, and the export handler bounds its\n  input and owns its own path."
-  },
-  {
-    "version": "1.7.0",
-    "date": "2026-07-26",
-    "channel": "stable",
-    "codename": null,
-    "gitTag": "v1.7.0",
-    "commit": null,
-    "buildNumber": null,
-    "summary": "Adds the **Work Graph** — a typed, queryable graph of what a session actually\ndid, built from both coding agents' event streams and owned entirely by Limboo —\nalong with a document-oriented workspace where diffs open as first-class tabs,\nand an in-app **What's New** tab so an update can finally tell you what changed.",
-    "sections": [
-      {
-        "category": "added",
-        "title": "Added",
-        "items": [
-          {
-            "lead": "The Work Graph (DAWG)",
-            "text": "Every session's execution is recorded as a Directed\n  Acyclic Work Graph — objectives, plans, tasks, subagents, investigations,\n  searches, memory lookups, MCP calls, commands, files, commits, approvals and\n  results — connected by nine typed relationships (`follows`, `contains`,\n  `generated`, `depends-on`, `implemented-in`, `verified-by`, `blocked-by`,\n  `reviewed-by`, `produced-artifact`). Neither Claude nor Cursor exposes a work\n  graph; both are conversation-driven. This is Limboo's own layer, derived from\n  the structured events they *do* emit, so it records both agents identically and\n  every future adapter contributes nodes for free. It is deliberately shaped like\n  a git history — vertical execution lanes, one node per row, commits in a\n  right-hand gutter — rather than a free-floating node diagram, because that is\n  the mental model developers already have. Layout runs in a Web Worker and rows\n  virtualize, so a long session stays responsive."
-          },
-          {
-            "lead": "Structural search over the graph",
-            "text": "Queries traverse *shape*, not just text:\n  an FTS5 seed set (free text, node kinds, statuses, time range) expanded by a\n  bounded closure over the edge table. \"Every task blocked by X\" is a traversal,\n  not a transcript scroll."
-          },
-          {
-            "lead": "Eight export formats",
-            "text": "JSON, Markdown, Mermaid, Graphviz DOT, CSV and a\n  self-contained HTML report are rendered from the stored graph; SVG and PNG are\n  rendered from the layout. Exports go to the clipboard or to a file you pick."
-          },
-          {
-            "lead": "A document-oriented workspace",
-            "text": "Diffs promote out of the Changes panel into\n  first-class tabs with their own icons, pinning, reordering, close/reopen and\n  per-document view state. `ChangesNavigator` unifies file browsing across the Git\n  panel and Changes; `DiffEditor` adds syntax highlighting and word-level diffs."
-          },
-          {
-            "lead": "A \"What's New\" tab",
-            "text": "When Limboo starts on a version it has not shown you\n  before, the release notes for *that* version open as a workspace tab. Closing it\n  is remembered until the next update. It is available any time from the command\n  palette, and — like Claude Code's own `/release-notes` — it is display-only and\n  never enters the agent's context."
-          }
-        ],
-        "markdown": "- **The Work Graph (DAWG).** Every session's execution is recorded as a Directed\n  Acyclic Work Graph — objectives, plans, tasks, subagents, investigations,\n  searches, memory lookups, MCP calls, commands, files, commits, approvals and\n  results — connected by nine typed relationships (`follows`, `contains`,\n  `generated`, `depends-on`, `implemented-in`, `verified-by`, `blocked-by`,\n  `reviewed-by`, `produced-artifact`). Neither Claude nor Cursor exposes a work\n  graph; both are conversation-driven. This is Limboo's own layer, derived from\n  the structured events they *do* emit, so it records both agents identically and\n  every future adapter contributes nodes for free. It is deliberately shaped like\n  a git history — vertical execution lanes, one node per row, commits in a\n  right-hand gutter — rather than a free-floating node diagram, because that is\n  the mental model developers already have. Layout runs in a Web Worker and rows\n  virtualize, so a long session stays responsive.\n- **Structural search over the graph.** Queries traverse *shape*, not just text:\n  an FTS5 seed set (free text, node kinds, statuses, time range) expanded by a\n  bounded closure over the edge table. \"Every task blocked by X\" is a traversal,\n  not a transcript scroll.\n- **Eight export formats.** JSON, Markdown, Mermaid, Graphviz DOT, CSV and a\n  self-contained HTML report are rendered from the stored graph; SVG and PNG are\n  rendered from the layout. Exports go to the clipboard or to a file you pick.\n- **A document-oriented workspace.** Diffs promote out of the Changes panel into\n  first-class tabs with their own icons, pinning, reordering, close/reopen and\n  per-document view state. `ChangesNavigator` unifies file browsing across the Git\n  panel and Changes; `DiffEditor` adds syntax highlighting and word-level diffs.\n- **A \"What's New\" tab.** When Limboo starts on a version it has not shown you\n  before, the release notes for *that* version open as a workspace tab. Closing it\n  is remembered until the next update. It is available any time from the command\n  palette, and — like Claude Code's own `/release-notes` — it is display-only and\n  never enters the agent's context."
-      },
-      {
-        "category": "fixed",
-        "title": "Fixed",
-        "items": [
-          {
-            "lead": "The work graph silently discarded whole batches of its own data",
-            "text": "A node\n  whose payload exceeded the size cap was skipped, but the edges pointing at it\n  were still written. `INSERT OR IGNORE` does not suppress a FOREIGN KEY\n  violation, so the failing edge aborted the entire transaction and took every\n  other node and edge in that flush with it — behind a single `logger.warn`.\n  Oversized nodes are now shrunk rather than dropped, every edge's endpoints are\n  proven to exist before insert, and persistent failures surface as a banner in\n  the panel instead of an innocent-looking empty graph."
-          },
-          {
-            "lead": "Orphan cleanup deleted real work",
-            "text": "It removed any node with no edge, which is\n  the normal state of a terminal opened outside a run, a commit made with no agent\n  active, or a service started before the first prompt. Those kinds are now exempt."
-          },
-          {
-            "lead": "Commits could be attributed to the wrong session, or lost entirely",
-            "text": "An\n  unattributable commit was still recorded as \"seen\", so it was dropped\n  permanently at the exact moment its session next became active. It is now only\n  marked seen once it has been attributed. Separately, a `git pull` bringing in\n  upstream commits claimed the current run had implemented its files in every one\n  of them; that fan-out is now limited to commits made after the run started."
-          },
-          {
-            "lead": "Subagent work was spliced into the main timeline",
-            "text": "The `contains`\n  relationship was defined, drawn by the layouter and listed in the legend, but\n  nothing ever emitted it. Subagent nesting now rides the Agent SDK's\n  `parent_tool_use_id`, so a subagent's steps sit inside the node that spawned\n  them. (Cursor's print mode has no subagents, so the branch simply never forks\n  there.)"
-          },
-          {
-            "lead": "Permission decisions were never recorded",
-            "text": "Approval nodes were inferred by\n  string-matching a log line's `\"Blocked…\"` prefix, which could not see the answer\n  the user actually gave. They now come from the one decision gate both providers\n  call, carrying the real decision, tool and risk."
-          },
-          {
-            "lead": "Nodes were labelled with the wrong agent",
-            "text": "Provider and mode were read from\n  current settings at write time rather than captured per run, so switching models\n  mid-session silently relabelled a run's history."
-          },
-          {
-            "lead": "Two release gates were not actually verifying anything",
-            "text": "Both were found by\n  checking the published v1.6.0 artifacts by hand rather than trusting a green\n  pipeline:\n  - The Squirrel.Mac layout check — the gate that exists to catch the defect that\n    made every macOS update in v1.5.x impossible — reported \"no macOS update zips\n    in this build\" and passed. It matched on a `-mac.zip` filename suffix, and\n    the packaging fix in 1.6.0 renamed the artifacts to `-<arch>.zip`. The zip\n    list now comes from `latest-mac.yml`, which is naming-independent and\n    authoritative, and a macOS feed with no matching zip is a failure rather than\n    a skip — a build can no longer opt out of its own regression gate.\n  - `SHA256SUMS` listed `limboo-package.cyclonedx.json`, a side-file the SBOM\n    action writes but the upload globs exclude, so `sha256sum -c SHA256SUMS`\n    exited non-zero on an otherwise correct release — discrediting the one\n    verification command the README and release notes give users. It is excluded\n    from the publish set, and a new check fails the build if the manifest names\n    anything that is not being published. (The v1.6.0 manifest was corrected in\n    place; its remaining hashes were always valid.)"
-          }
-        ],
-        "markdown": "- **The work graph silently discarded whole batches of its own data.** A node\n  whose payload exceeded the size cap was skipped, but the edges pointing at it\n  were still written. `INSERT OR IGNORE` does not suppress a FOREIGN KEY\n  violation, so the failing edge aborted the entire transaction and took every\n  other node and edge in that flush with it — behind a single `logger.warn`.\n  Oversized nodes are now shrunk rather than dropped, every edge's endpoints are\n  proven to exist before insert, and persistent failures surface as a banner in\n  the panel instead of an innocent-looking empty graph.\n- **Orphan cleanup deleted real work.** It removed any node with no edge, which is\n  the normal state of a terminal opened outside a run, a commit made with no agent\n  active, or a service started before the first prompt. Those kinds are now exempt.\n- **Commits could be attributed to the wrong session, or lost entirely.** An\n  unattributable commit was still recorded as \"seen\", so it was dropped\n  permanently at the exact moment its session next became active. It is now only\n  marked seen once it has been attributed. Separately, a `git pull` bringing in\n  upstream commits claimed the current run had implemented its files in every one\n  of them; that fan-out is now limited to commits made after the run started.\n- **Subagent work was spliced into the main timeline.** The `contains`\n  relationship was defined, drawn by the layouter and listed in the legend, but\n  nothing ever emitted it. Subagent nesting now rides the Agent SDK's\n  `parent_tool_use_id`, so a subagent's steps sit inside the node that spawned\n  them. (Cursor's print mode has no subagents, so the branch simply never forks\n  there.)\n- **Permission decisions were never recorded.** Approval nodes were inferred by\n  string-matching a log line's `\"Blocked…\"` prefix, which could not see the answer\n  the user actually gave. They now come from the one decision gate both providers\n  call, carrying the real decision, tool and risk.\n- **Nodes were labelled with the wrong agent.** Provider and mode were read from\n  current settings at write time rather than captured per run, so switching models\n  mid-session silently relabelled a run's history.\n- **Two release gates were not actually verifying anything.** Both were found by\n  checking the published v1.6.0 artifacts by hand rather than trusting a green\n  pipeline:\n  - The Squirrel.Mac layout check — the gate that exists to catch the defect that\n    made every macOS update in v1.5.x impossible — reported \"no macOS update zips\n    in this build\" and passed. It matched on a `-mac.zip` filename suffix, and\n    the packaging fix in 1.6.0 renamed the artifacts to `-<arch>.zip`. The zip\n    list now comes from `latest-mac.yml`, which is naming-independent and\n    authoritative, and a macOS feed with no matching zip is a failure rather than\n    a skip — a build can no longer opt out of its own regression gate.\n  - `SHA256SUMS` listed `limboo-package.cyclonedx.json`, a side-file the SBOM\n    action writes but the upload globs exclude, so `sha256sum -c SHA256SUMS`\n    exited non-zero on an otherwise correct release — discrediting the one\n    verification command the README and release notes give users. It is excluded\n    from the publish set, and a new check fails the build if the manifest names\n    anything that is not being published. (The v1.6.0 manifest was corrected in\n    place; its remaining hashes were always valid.)"
-      },
-      {
-        "category": "changed",
-        "title": "Changed",
-        "items": [
-          {
-            "lead": "Release notes now come from this file",
-            "text": "The GitHub release body was\n  generated from commit subjects while the changelog was written by hand, so the\n  two said different things about the same release and nothing connected them.\n  The notes generator now reads the section for the tag being released and falls\n  back to the previous commit-subject behaviour only when there isn't one — which\n  also means the notes shown inside the app, the notes on the release page, and\n  this file are the same text by construction."
-          },
-          {
-            "lead": "An active icon is marked by its own color, not a filled block behind it",
-            "text": "In\n  the activity rail, the title-bar tab strip and the settings navigation, the\n  background plate is gone and the glyph takes the accent color. On a pure-black\n  canvas the plate read as a second element competing with the icon it sat\n  behind. Hover still shows it, where it is feedback rather than state."
-          }
-        ],
-        "markdown": "- **Release notes now come from this file.** The GitHub release body was\n  generated from commit subjects while the changelog was written by hand, so the\n  two said different things about the same release and nothing connected them.\n  The notes generator now reads the section for the tag being released and falls\n  back to the previous commit-subject behaviour only when there isn't one — which\n  also means the notes shown inside the app, the notes on the release page, and\n  this file are the same text by construction.\n- **An active icon is marked by its own color, not a filled block behind it.** In\n  the activity rail, the title-bar tab strip and the settings navigation, the\n  background plate is gone and the glyph takes the accent color. On a pure-black\n  canvas the plate read as a second element competing with the icon it sat\n  behind. Hover still shows it, where it is feedback rather than state."
-      },
-      {
-        "category": "security",
-        "title": "Security",
-        "items": [
-          {
-            "lead": "The graph's secret redactor missed the case its own guide calls out",
-            "text": "It is\n  shared with the Hook Engine, so a gap in it was a gap in two subsystems. It now\n  covers credential-bearing URLs (`https://user:token@host` — a remote typed into\n  a terminal became a node title verbatim), GitHub, AWS and Slack tokens, PEM\n  private-key blocks, JWTs, and generic `secret=`-shaped assignments. Redaction\n  also runs recursively over a node's whole metadata on the single path into the\n  database, rather than only over its title and detail, so a future field is\n  covered without having to opt in."
-          },
-          {
-            "lead": "Export writes to disk without the renderer ever naming a path",
-            "text": "Saving a\n  graph sends only a session id and a format; the main process opens the save\n  dialog and writes wherever you chose. There is no renderer-supplied path, and\n  therefore no traversal surface to defend."
-          },
-          {
-            "lead": "Query inputs are bounded before they are examined",
-            "text": "Array arguments are\n  capped before filtering (an oversized array was previously walked in full),\n  export results are byte-capped, and edge reads are limited instead of unbounded\n  table scans."
-          }
-        ],
-        "markdown": "- **The graph's secret redactor missed the case its own guide calls out.** It is\n  shared with the Hook Engine, so a gap in it was a gap in two subsystems. It now\n  covers credential-bearing URLs (`https://user:token@host` — a remote typed into\n  a terminal became a node title verbatim), GitHub, AWS and Slack tokens, PEM\n  private-key blocks, JWTs, and generic `secret=`-shaped assignments. Redaction\n  also runs recursively over a node's whole metadata on the single path into the\n  database, rather than only over its title and detail, so a future field is\n  covered without having to opt in.\n- **Export writes to disk without the renderer ever naming a path.** Saving a\n  graph sends only a session id and a format; the main process opens the save\n  dialog and writes wherever you chose. There is no renderer-supplied path, and\n  therefore no traversal surface to defend.\n- **Query inputs are bounded before they are examined.** Array arguments are\n  capped before filtering (an oversized array was previously walked in full),\n  export results are byte-capped, and edge reads are limited instead of unbounded\n  table scans."
-      }
-    ],
-    "contributors": [],
-    "pullRequests": [],
-    "mergedBranches": [],
-    "assets": [],
-    "signing": [],
-    "stats": {
-      "commits": null,
-      "filesChanged": null,
-      "additions": null,
-      "deletions": null
-    },
-    "links": {
-      "release": "https://github.com/limboo-ai/limboo/releases/tag/v1.7.0",
-      "compare": "https://github.com/limboo-ai/limboo/compare/v1.6.0...v1.7.0",
-      "tag": "https://github.com/limboo-ai/limboo/releases/tag/v1.7.0",
-      "milestone": null
-    },
-    "checksumManifest": "SHA256SUMS",
-    "provenanceRepo": "limboo-ai/limboo",
-    "markdown": "Adds the **Work Graph** — a typed, queryable graph of what a session actually\ndid, built from both coding agents' event streams and owned entirely by Limboo —\nalong with a document-oriented workspace where diffs open as first-class tabs,\nand an in-app **What's New** tab so an update can finally tell you what changed.\n\n### Added\n\n- **The Work Graph (DAWG).** Every session's execution is recorded as a Directed\n  Acyclic Work Graph — objectives, plans, tasks, subagents, investigations,\n  searches, memory lookups, MCP calls, commands, files, commits, approvals and\n  results — connected by nine typed relationships (`follows`, `contains`,\n  `generated`, `depends-on`, `implemented-in`, `verified-by`, `blocked-by`,\n  `reviewed-by`, `produced-artifact`). Neither Claude nor Cursor exposes a work\n  graph; both are conversation-driven. This is Limboo's own layer, derived from\n  the structured events they *do* emit, so it records both agents identically and\n  every future adapter contributes nodes for free. It is deliberately shaped like\n  a git history — vertical execution lanes, one node per row, commits in a\n  right-hand gutter — rather than a free-floating node diagram, because that is\n  the mental model developers already have. Layout runs in a Web Worker and rows\n  virtualize, so a long session stays responsive.\n- **Structural search over the graph.** Queries traverse *shape*, not just text:\n  an FTS5 seed set (free text, node kinds, statuses, time range) expanded by a\n  bounded closure over the edge table. \"Every task blocked by X\" is a traversal,\n  not a transcript scroll.\n- **Eight export formats.** JSON, Markdown, Mermaid, Graphviz DOT, CSV and a\n  self-contained HTML report are rendered from the stored graph; SVG and PNG are\n  rendered from the layout. Exports go to the clipboard or to a file you pick.\n- **A document-oriented workspace.** Diffs promote out of the Changes panel into\n  first-class tabs with their own icons, pinning, reordering, close/reopen and\n  per-document view state. `ChangesNavigator` unifies file browsing across the Git\n  panel and Changes; `DiffEditor` adds syntax highlighting and word-level diffs.\n- **A \"What's New\" tab.** When Limboo starts on a version it has not shown you\n  before, the release notes for *that* version open as a workspace tab. Closing it\n  is remembered until the next update. It is available any time from the command\n  palette, and — like Claude Code's own `/release-notes` — it is display-only and\n  never enters the agent's context.\n\n### Fixed\n\n- **The work graph silently discarded whole batches of its own data.** A node\n  whose payload exceeded the size cap was skipped, but the edges pointing at it\n  were still written. `INSERT OR IGNORE` does not suppress a FOREIGN KEY\n  violation, so the failing edge aborted the entire transaction and took every\n  other node and edge in that flush with it — behind a single `logger.warn`.\n  Oversized nodes are now shrunk rather than dropped, every edge's endpoints are\n  proven to exist before insert, and persistent failures surface as a banner in\n  the panel instead of an innocent-looking empty graph.\n- **Orphan cleanup deleted real work.** It removed any node with no edge, which is\n  the normal state of a terminal opened outside a run, a commit made with no agent\n  active, or a service started before the first prompt. Those kinds are now exempt.\n- **Commits could be attributed to the wrong session, or lost entirely.** An\n  unattributable commit was still recorded as \"seen\", so it was dropped\n  permanently at the exact moment its session next became active. It is now only\n  marked seen once it has been attributed. Separately, a `git pull` bringing in\n  upstream commits claimed the current run had implemented its files in every one\n  of them; that fan-out is now limited to commits made after the run started.\n- **Subagent work was spliced into the main timeline.** The `contains`\n  relationship was defined, drawn by the layouter and listed in the legend, but\n  nothing ever emitted it. Subagent nesting now rides the Agent SDK's\n  `parent_tool_use_id`, so a subagent's steps sit inside the node that spawned\n  them. (Cursor's print mode has no subagents, so the branch simply never forks\n  there.)\n- **Permission decisions were never recorded.** Approval nodes were inferred by\n  string-matching a log line's `\"Blocked…\"` prefix, which could not see the answer\n  the user actually gave. They now come from the one decision gate both providers\n  call, carrying the real decision, tool and risk.\n- **Nodes were labelled with the wrong agent.** Provider and mode were read from\n  current settings at write time rather than captured per run, so switching models\n  mid-session silently relabelled a run's history.\n- **Two release gates were not actually verifying anything.** Both were found by\n  checking the published v1.6.0 artifacts by hand rather than trusting a green\n  pipeline:\n  - The Squirrel.Mac layout check — the gate that exists to catch the defect that\n    made every macOS update in v1.5.x impossible — reported \"no macOS update zips\n    in this build\" and passed. It matched on a `-mac.zip` filename suffix, and\n    the packaging fix in 1.6.0 renamed the artifacts to `-<arch>.zip`. The zip\n    list now comes from `latest-mac.yml`, which is naming-independent and\n    authoritative, and a macOS feed with no matching zip is a failure rather than\n    a skip — a build can no longer opt out of its own regression gate.\n  - `SHA256SUMS` listed `limboo-package.cyclonedx.json`, a side-file the SBOM\n    action writes but the upload globs exclude, so `sha256sum -c SHA256SUMS`\n    exited non-zero on an otherwise correct release — discrediting the one\n    verification command the README and release notes give users. It is excluded\n    from the publish set, and a new check fails the build if the manifest names\n    anything that is not being published. (The v1.6.0 manifest was corrected in\n    place; its remaining hashes were always valid.)\n\n### Changed\n\n- **Release notes now come from this file.** The GitHub release body was\n  generated from commit subjects while the changelog was written by hand, so the\n  two said different things about the same release and nothing connected them.\n  The notes generator now reads the section for the tag being released and falls\n  back to the previous commit-subject behaviour only when there isn't one — which\n  also means the notes shown inside the app, the notes on the release page, and\n  this file are the same text by construction.\n- **An active icon is marked by its own color, not a filled block behind it.** In\n  the activity rail, the title-bar tab strip and the settings navigation, the\n  background plate is gone and the glyph takes the accent color. On a pure-black\n  canvas the plate read as a second element competing with the icon it sat\n  behind. Hover still shows it, where it is feedback rather than state.\n\n### Security\n\n- **The graph's secret redactor missed the case its own guide calls out.** It is\n  shared with the Hook Engine, so a gap in it was a gap in two subsystems. It now\n  covers credential-bearing URLs (`https://user:token@host` — a remote typed into\n  a terminal became a node title verbatim), GitHub, AWS and Slack tokens, PEM\n  private-key blocks, JWTs, and generic `secret=`-shaped assignments. Redaction\n  also runs recursively over a node's whole metadata on the single path into the\n  database, rather than only over its title and detail, so a future field is\n  covered without having to opt in.\n- **Export writes to disk without the renderer ever naming a path.** Saving a\n  graph sends only a session id and a format; the main process opens the save\n  dialog and writes wherever you chose. There is no renderer-supplied path, and\n  therefore no traversal surface to defend.\n- **Query inputs are bounded before they are examined.** Array arguments are\n  capped before filtering (an oversized array was previously walked in full),\n  export results are byte-capped, and edge reads are limited instead of unbounded\n  table scans."
   }
 ];
 
 /** Every released version, newest first. */
 export const RELEASE_INDEX: ReleaseIndexEntry[] = [
+  {
+    "version": "1.12.0",
+    "date": "2026-07-27",
+    "channel": "stable",
+    "summary": "Sessions run in a git worktree, and Limboo puts that worktree inside its own\napplication data folder. A safety rule meant to keep the agent out of Limboo's\ndatabase read the whole folder as off limits — so in a worktree session the\nagent was refused the moment it tried to write its first file, in what was\nactually its own working directory. Approving a plan could fail for a reason\nthat was never true, and leave the session unable to try again. The plan card\nalso stops appearing before there is a plan to read.",
+    "detailed": true
+  },
   {
     "version": "1.11.0",
     "date": "2026-07-27",
@@ -609,7 +554,7 @@ export const RELEASE_INDEX: ReleaseIndexEntry[] = [
     "date": "2026-07-26",
     "channel": "stable",
     "summary": "Adds the **Work Graph** — a typed, queryable graph of what a session actually\ndid, built from both coding agents' event streams and owned entirely by Limboo —\nalong with a document-oriented workspace where diffs open as first-class tabs,\nand an in-app **What's New** tab so an update can finally tell you what changed.",
-    "detailed": true
+    "detailed": false
   },
   {
     "version": "1.6.0",

--- a/src/shared/releaseNotes.generated.ts
+++ b/src/shared/releaseNotes.generated.ts
@@ -22,6 +22,48 @@ export interface ReleaseNotesEntry {
 /** Newest first. */
 export const RELEASE_NOTES: ReleaseNotesEntry[] = [
   {
+    version: '1.12.0',
+    date: '2026-07-27',
+    markdown: `Sessions run in a git worktree, and Limboo puts that worktree inside its own
+application data folder. A safety rule meant to keep the agent out of Limboo's
+database read the whole folder as off limits — so in a worktree session the
+agent was refused the moment it tried to write its first file, in what was
+actually its own working directory. Approving a plan could fail for a reason
+that was never true, and leave the session unable to try again. The plan card
+also stops appearing before there is a plan to read.
+
+### Fixed
+
+- **The agent could not write anything in a worktree session.** Every file it
+  tried to create was refused as "Limboo's own app data", because sessions check
+  out into a folder that lives inside Limboo's data directory. The rule now
+  covers only what it was written to protect — the database, your settings, and
+  the encrypted secret store — and the rest of that directory, including the
+  worktree the agent works in, is ordinary ground. Cursor runs were blocked by a
+  second copy of the same rule and are fixed with it.
+- **Commands were refused for mentioning a filename.** Anything containing the
+  text \`limboo.db\` was blocked wherever it ran, so a plain search of your own
+  source could be denied. Only the real, full path to the database is protected
+  now.
+- **Approving a plan could fail with "the agent is already working on this
+  session".** The plan appears while the run that wrote it is still finishing, so
+  a quick click arrived a fraction of a second early and was turned away.
+  Approving now waits for that run to finish instead of refusing, and the buttons
+  are held until it has.
+- **A failed approval left the plan unusable.** The plan was marked as being
+  carried out before the work had actually started, so when it did not start,
+  the approval buttons never came back and the session could not be recovered.
+  The plan is restored when the run fails to begin.
+
+### Changed
+
+- **The plan card waits for the plan.** It used to appear as soon as planning
+  started, showing a title and an "Analyzing the repository" line above the
+  composer while the agent's actual reasoning streamed past it further up. It now
+  appears with the proposal it is asking you to approve. Progress while planning
+  reads where the rest of the run does — in the conversation.`,
+  },
+  {
     version: '1.11.0',
     date: '2026-07-27',
     markdown: `1.10.0 set out to stop Plan and Ask blocking the MCP servers you had connected.
@@ -317,130 +359,6 @@ describe a release from the same file.
 - **Markdown rendering is unchanged and still sanitized** (\`rehype-sanitize\`, no
   raw HTML), the document performs no writes, and the export handler bounds its
   input and owns its own path.`,
-  },
-  {
-    version: '1.7.0',
-    date: '2026-07-26',
-    markdown: `Adds the **Work Graph** — a typed, queryable graph of what a session actually
-did, built from both coding agents' event streams and owned entirely by Limboo —
-along with a document-oriented workspace where diffs open as first-class tabs,
-and an in-app **What's New** tab so an update can finally tell you what changed.
-
-### Added
-
-- **The Work Graph (DAWG).** Every session's execution is recorded as a Directed
-  Acyclic Work Graph — objectives, plans, tasks, subagents, investigations,
-  searches, memory lookups, MCP calls, commands, files, commits, approvals and
-  results — connected by nine typed relationships (\`follows\`, \`contains\`,
-  \`generated\`, \`depends-on\`, \`implemented-in\`, \`verified-by\`, \`blocked-by\`,
-  \`reviewed-by\`, \`produced-artifact\`). Neither Claude nor Cursor exposes a work
-  graph; both are conversation-driven. This is Limboo's own layer, derived from
-  the structured events they *do* emit, so it records both agents identically and
-  every future adapter contributes nodes for free. It is deliberately shaped like
-  a git history — vertical execution lanes, one node per row, commits in a
-  right-hand gutter — rather than a free-floating node diagram, because that is
-  the mental model developers already have. Layout runs in a Web Worker and rows
-  virtualize, so a long session stays responsive.
-- **Structural search over the graph.** Queries traverse *shape*, not just text:
-  an FTS5 seed set (free text, node kinds, statuses, time range) expanded by a
-  bounded closure over the edge table. "Every task blocked by X" is a traversal,
-  not a transcript scroll.
-- **Eight export formats.** JSON, Markdown, Mermaid, Graphviz DOT, CSV and a
-  self-contained HTML report are rendered from the stored graph; SVG and PNG are
-  rendered from the layout. Exports go to the clipboard or to a file you pick.
-- **A document-oriented workspace.** Diffs promote out of the Changes panel into
-  first-class tabs with their own icons, pinning, reordering, close/reopen and
-  per-document view state. \`ChangesNavigator\` unifies file browsing across the Git
-  panel and Changes; \`DiffEditor\` adds syntax highlighting and word-level diffs.
-- **A "What's New" tab.** When Limboo starts on a version it has not shown you
-  before, the release notes for *that* version open as a workspace tab. Closing it
-  is remembered until the next update. It is available any time from the command
-  palette, and — like Claude Code's own \`/release-notes\` — it is display-only and
-  never enters the agent's context.
-
-### Fixed
-
-- **The work graph silently discarded whole batches of its own data.** A node
-  whose payload exceeded the size cap was skipped, but the edges pointing at it
-  were still written. \`INSERT OR IGNORE\` does not suppress a FOREIGN KEY
-  violation, so the failing edge aborted the entire transaction and took every
-  other node and edge in that flush with it — behind a single \`logger.warn\`.
-  Oversized nodes are now shrunk rather than dropped, every edge's endpoints are
-  proven to exist before insert, and persistent failures surface as a banner in
-  the panel instead of an innocent-looking empty graph.
-- **Orphan cleanup deleted real work.** It removed any node with no edge, which is
-  the normal state of a terminal opened outside a run, a commit made with no agent
-  active, or a service started before the first prompt. Those kinds are now exempt.
-- **Commits could be attributed to the wrong session, or lost entirely.** An
-  unattributable commit was still recorded as "seen", so it was dropped
-  permanently at the exact moment its session next became active. It is now only
-  marked seen once it has been attributed. Separately, a \`git pull\` bringing in
-  upstream commits claimed the current run had implemented its files in every one
-  of them; that fan-out is now limited to commits made after the run started.
-- **Subagent work was spliced into the main timeline.** The \`contains\`
-  relationship was defined, drawn by the layouter and listed in the legend, but
-  nothing ever emitted it. Subagent nesting now rides the Agent SDK's
-  \`parent_tool_use_id\`, so a subagent's steps sit inside the node that spawned
-  them. (Cursor's print mode has no subagents, so the branch simply never forks
-  there.)
-- **Permission decisions were never recorded.** Approval nodes were inferred by
-  string-matching a log line's \`"Blocked…"\` prefix, which could not see the answer
-  the user actually gave. They now come from the one decision gate both providers
-  call, carrying the real decision, tool and risk.
-- **Nodes were labelled with the wrong agent.** Provider and mode were read from
-  current settings at write time rather than captured per run, so switching models
-  mid-session silently relabelled a run's history.
-- **Two release gates were not actually verifying anything.** Both were found by
-  checking the published v1.6.0 artifacts by hand rather than trusting a green
-  pipeline:
-  - The Squirrel.Mac layout check — the gate that exists to catch the defect that
-    made every macOS update in v1.5.x impossible — reported "no macOS update zips
-    in this build" and passed. It matched on a \`-mac.zip\` filename suffix, and
-    the packaging fix in 1.6.0 renamed the artifacts to \`-<arch>.zip\`. The zip
-    list now comes from \`latest-mac.yml\`, which is naming-independent and
-    authoritative, and a macOS feed with no matching zip is a failure rather than
-    a skip — a build can no longer opt out of its own regression gate.
-  - \`SHA256SUMS\` listed \`limboo-package.cyclonedx.json\`, a side-file the SBOM
-    action writes but the upload globs exclude, so \`sha256sum -c SHA256SUMS\`
-    exited non-zero on an otherwise correct release — discrediting the one
-    verification command the README and release notes give users. It is excluded
-    from the publish set, and a new check fails the build if the manifest names
-    anything that is not being published. (The v1.6.0 manifest was corrected in
-    place; its remaining hashes were always valid.)
-
-### Changed
-
-- **Release notes now come from this file.** The GitHub release body was
-  generated from commit subjects while the changelog was written by hand, so the
-  two said different things about the same release and nothing connected them.
-  The notes generator now reads the section for the tag being released and falls
-  back to the previous commit-subject behaviour only when there isn't one — which
-  also means the notes shown inside the app, the notes on the release page, and
-  this file are the same text by construction.
-- **An active icon is marked by its own color, not a filled block behind it.** In
-  the activity rail, the title-bar tab strip and the settings navigation, the
-  background plate is gone and the glyph takes the accent color. On a pure-black
-  canvas the plate read as a second element competing with the icon it sat
-  behind. Hover still shows it, where it is feedback rather than state.
-
-### Security
-
-- **The graph's secret redactor missed the case its own guide calls out.** It is
-  shared with the Hook Engine, so a gap in it was a gap in two subsystems. It now
-  covers credential-bearing URLs (\`https://user:token@host\` — a remote typed into
-  a terminal became a node title verbatim), GitHub, AWS and Slack tokens, PEM
-  private-key blocks, JWTs, and generic \`secret=\`-shaped assignments. Redaction
-  also runs recursively over a node's whole metadata on the single path into the
-  database, rather than only over its title and detail, so a future field is
-  covered without having to opt in.
-- **Export writes to disk without the renderer ever naming a path.** Saving a
-  graph sends only a session id and a format; the main process opens the save
-  dialog and writes wherever you chose. There is no renderer-supplied path, and
-  therefore no traversal surface to defend.
-- **Query inputs are bounded before they are examined.** Array arguments are
-  capped before filtering (an oversized array was previously walked in full),
-  export results are byte-capped, and edge reads are limited instead of unbounded
-  table scans.`,
   },
 ];
 


### PR DESCRIPTION
Three defects, all of which surface while approving a plan in a worktree session.

## The agent could not write in its own working directory

`touchesAppData` denied any tool call resolving inside `app.getPath('userData')`. But the default worktree root **is** `{userData}/worktrees` (`worktree/paths.ts:26`), so the guard hard-denied every file in the session's own checkout — before the workspace path guard could confirm the file was legitimately inside `cwd`. First write of a session, every time:

```
src/main/offline/sqlite.js — denied: "Limboo's own app data"
```

It is now `touchesCrownJewel`, scoped to `crownJewelPaths()` (+ the DB's WAL/SHM siblings) — the same list the OS sandbox floor already used, so Layer 1 and Layer 3 now share one source and cannot drift. `sandbox/policy.ts` had documented this exact narrowing and why; Layer 1 never got it.

The name-based Bash regexes went with it. `/limboo\.db\b/i` blocked any command merely *containing* that string — `grep limboo.db src/` was refused. Only absolute crown-jewel paths match now.

**Cursor's declarative mirror had the same bug.** `sessionDenyRules` wrote `Read/Write(${userData}/**)` into every run's `cli.json`, where deny beats allow — fixing only the callback would have left Cursor blocked. It now emits per-jewel `Read`+`Write` rules. Note writes previously rode the blanket rule (the named rules were `Read`-only), so dropping it without a replacement would have been a regression.

## Approving a plan failed with "the agent is already working on this session"

`capturePlan` publishes `status: 'ready'` from *inside* the still-live run — Claude's `ExitPlanMode` interrupt has not unwound the SDK yet — while the `runs` entry is only cleared in `send()`'s `finally`. The button rendered on the next React commit with no busy state, so a fast click hit `send()`'s guard.

`approvePlan` and `regeneratePlan` now await the run's teardown (a `settled` deferred on `ActiveRun`, 8s ceiling) instead of rejecting the click; a genuinely busy session still refuses. `ApprovalControls` gained a `busy` prop, fed by the `running` signal both call sites already computed and discarded.

## A failed approval stranded the session

`approvePlan` persisted `status: 'implementing'` *before* calling `send()`. On a throw the plan was stuck: `PlanCard` only renders the controls at `ready`, so approval never reappeared — and `runCursorOnce` reads that same row to decide `--force`, so every later Cursor run on the session silently became a forced run. The status is now restored when the run fails to start, and the composer mode reverts with it.

## The plan card no longer appears during planning

It showed a title, a badge and an "Analyzing the repository…" row above the composer — restating what the live status row and activity timeline already say, while pushing the analysis the agent was streaming further up the transcript. The card exists to present a proposal for approval, so it now arrives with one, at `ready`. The dead `planning` branches are removed from the body along with it.

## Deliberately unchanged

The workspace-boundary, symlink-escape, `.git` and root-refusal guards in `fs/writer.ts` / `fs/reader.ts`; `touchesSensitiveFile`; `crownJewelPaths()` itself; Cursor's destructive-shell and self-gate deny rules; `AttachmentManager`'s inbound userData rejection.

## Verification

- `npm run lint` clean; renderer build and main-process bundle clean; app boots with no errors.
- Ran the real `sessionDenyRules`/`crownJewelPaths` with electron stubbed: no blanket `userData` rule, nothing matches a worktree path, all five jewels denied for both read and write.
- The reported failure is in the shipped 1.11.0 log, stack-traced through `approvePlan` → `send`.

Not verified end-to-end: the interactive click race and a live worktree write both need a real agent run with credentials.
