### PR TITLE
fix(conversation): scope message actions to the user turn, tighten th…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -845,16 +845,32 @@ Memory, Search, Resume and the Work Graph. Full doc:
 
 ### The conversation timeline: message actions + conversation revert
 
-Every block in the stream is actionable, and Plan Mode has exactly two surfaces.
+Every turn in the stream is actionable, and Plan Mode has exactly two surfaces.
 All of it is provider-neutral — nothing below reads which adapter produced the
 message.
 
 - **Message actions** (`features/workspace/MessageActions.tsx`) — an icon-only
-  toolbar on every user and assistant message, revealed by `group-hover` **and**
+  toolbar on the **user turn only**, revealed by `group-hover` **and**
   `focus-within` (a toolbar reachable only by mouse is not reachable). Copy,
   Copy as Markdown, Quote, Reference in Prompt, Select Text, View Raw, Export,
   Open in New Session, Pin to Memory, Regenerate, Revert. Active state is the
   **accent icon**, never a strip (§4b).
+  - **There is no toolbar in the assistant stream, and none may be added.** A
+    reply is not one document: it arrives as several text blocks split by tool
+    calls, so a per-block toolbar meant several per answer — each reserving a
+    row of layout (they hide with `opacity`, not `display`) and cutting a
+    continuous stream into separately-framed cards. The prompt is the turn's one
+    stable anchor and carries its actions. Export is therefore **turn-scoped**:
+    `TurnView` hands `UserBubble` the turn's `replies` alongside `toolCalls`, and
+    `turnToMarkdown` writes prompt + replies + tools as one document. Copy and
+    Copy as Markdown stay **message-scoped** — their labels say "Copy", and
+    widening them to a whole turn would make them a different button. Copying a
+    reply is served by `CodeBlock`'s own `CopyButton`.
+  - **`AssistantBlock`'s content column is `gap-1.5`** — the single class
+    governing the distance between every consecutive assistant sub-item (text,
+    tool group, marker, subagent row, trailing status). Deliberately tight: the
+    larger spacing lives on turn boundaries (`gap-4` within a turn, `gap-6`
+    between turns), so the reply itself reads as one continuous stream.
   - **`ChatMessage.text` is already Markdown** — both providers stream Markdown
     source and the renderer only ever parses it for display. So
     `lib/messageMarkdown.ts` returns the SOURCE; it never serializes rendered

--- a/src/renderer/features/workspace/ConversationView.tsx
+++ b/src/renderer/features/workspace/ConversationView.tsx
@@ -391,6 +391,13 @@ const TurnView = memo(function TurnView({
     .filter((b): b is Extract<Block, { kind: 'tool' }> => b.kind === 'tool')
     .map((b) => b.call);
 
+  // The turn's assistant replies. The action toolbar mounts on the user bubble
+  // only, so Export has to reach the answers from there — otherwise it would
+  // write out a prompt with nothing following it.
+  const replies = turn.blocks
+    .filter((b): b is Extract<Block, { kind: 'text' }> => b.kind === 'text')
+    .map((b) => b.message);
+
   return (
     // The anchor the ConversationRail scrolls to (and observes for the "current
     // turn" tick). `scroll-mt-4` keeps the prompt clear of the scroller's top
@@ -405,20 +412,12 @@ const TurnView = memo(function TurnView({
           sessionId={sessionId}
           message={user}
           toolCalls={userToolCalls}
+          replies={replies}
           onRegenerate={onRegenerate}
           onRevert={onRevert}
         />
       )}
-      {showAssistant && (
-        <AssistantBlock
-          sessionId={sessionId}
-          blocks={turn.blocks}
-          trailing={trailing}
-          prompt={user}
-          onRegenerate={onRegenerate}
-          onRevert={onRevert}
-        />
-      )}
+      {showAssistant && <AssistantBlock blocks={turn.blocks} trailing={trailing} />}
     </div>
   );
 }, turnsEqual);
@@ -540,12 +539,15 @@ function UserBubble({
   sessionId,
   message,
   toolCalls,
+  replies,
   onRegenerate,
   onRevert,
 }: {
   sessionId: string;
   message: ChatMessage;
   toolCalls: AgentToolCall[];
+  /** This turn's assistant replies — the toolbar's Export covers the whole turn. */
+  replies: ChatMessage[];
   onRegenerate?: () => void;
   onRevert?: () => void;
 }) {
@@ -589,6 +591,7 @@ function UserBubble({
         onRegenerate={onRegenerate}
         onRevert={onRevert}
         toolCalls={toolCalls}
+        replies={replies}
       />
     </div>
   );
@@ -624,20 +627,11 @@ function MessageAttachments({
  *  chronologically-interleaved sub-items (text, tool rows, status markers, and an
  *  optional trailing approval). */
 const AssistantBlock = memo(function AssistantBlock({
-  sessionId,
   blocks,
   trailing,
-  prompt = null,
-  onRegenerate,
-  onRevert,
 }: {
-  sessionId?: string;
   blocks: Block[];
   trailing?: ReactNode;
-  /** The user prompt this block answers — carried into exports and regenerate. */
-  prompt?: ChatMessage | null;
-  onRegenerate?: () => void;
-  onRevert?: () => void;
 }) {
   const streaming = blocks.some((b) => b.kind === 'text' && b.message.streaming);
   // A boolean from the store keeps this memo-safe; threading it as a prop would
@@ -649,35 +643,19 @@ const AssistantBlock = memo(function AssistantBlock({
     () => groupBlocks(blocks, inlineSubagents),
     [blocks, inlineSubagents],
   );
-  const toolCalls = useMemo(
-    () => blocks.filter((b): b is Extract<Block, { kind: 'tool' }> => b.kind === 'tool').map((b) => b.call),
-    [blocks],
-  );
   return (
     <div className="flex gap-3 animate-fade-in">
       <div className="mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-surface-2">
         <Logo size={16} className={streaming ? 'animate-pulse' : undefined} />
       </div>
-      <div className="flex min-w-0 flex-1 flex-col gap-3 pt-0.5">
+      {/* The stream's vertical rhythm. This single gap separates every consecutive
+          sub-item (text, tool group, marker, subagent row, trailing status), and it
+          is deliberately tight: the agent's output is one continuous reply, not a
+          stack of cards. Turn boundaries are what carry the larger spacing. */}
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5 pt-0.5">
         {items.map((it) => {
           if (it.kind === 'text') {
-            // Without a session there is nowhere for the actions to write
-            // (quote, new session, memory), so the plain body renders instead.
-            return sessionId ? (
-              <AssistantText
-                key={it.message.id}
-                sessionId={sessionId}
-                message={it.message}
-                prompt={prompt}
-                toolCalls={toolCalls}
-                onRegenerate={onRegenerate}
-                onRevert={onRevert}
-              />
-            ) : (
-              <div key={it.message.id}>
-                <Markdown text={it.message.text} streaming={it.message.streaming} />
-              </div>
-            );
+            return <AssistantText key={it.message.id} message={it.message} />;
           }
           if (it.kind === 'marker') return <InlineMarkerRow key={it.item.id} item={it.item} />;
           if (it.kind === 'subagent') {
@@ -691,53 +669,19 @@ const AssistantBlock = memo(function AssistantBlock({
   );
 });
 
-function AssistantText({
-  sessionId,
-  message,
-  prompt,
-  toolCalls,
-  onRegenerate,
-  onRevert,
-}: {
-  sessionId: string;
-  message: ChatMessage;
-  prompt: ChatMessage | null;
-  toolCalls: AgentToolCall[];
-  onRegenerate?: () => void;
-  onRevert?: () => void;
-}) {
-  const [raw, setRaw] = useState(false);
-  const body = useRef<HTMLDivElement>(null);
+/** One streamed assistant text block. Purely presentational: the turn's actions
+ *  live on the user bubble, so the agent's output stays chrome-free and reads as
+ *  one continuous stream rather than a stack of separately-framed blocks. */
+function AssistantText({ message }: { message: ChatMessage }) {
   // A streaming message with no text yet is the pre-first-token moment — reserve
-  // the reply's shape with a shimmer skeleton until the first delta lands. No
-  // toolbar either: there is nothing to copy, quote or export yet.
+  // the reply's shape with a shimmer skeleton until the first delta lands.
   if (message.streaming && message.text.trim().length === 0) return <MessageSkeleton />;
   return (
-    <div className="group">
-      <div ref={body}>
-        {raw ? (
-          <pre className="overflow-auto rounded-md border border-line bg-surface-2 px-3 py-2 font-mono text-[11.5px] leading-relaxed text-muted">
-            {message.text}
-          </pre>
-        ) : (
-          <Markdown text={message.text} streaming={message.streaming} />
-        )}
-        {message.streaming && !raw && (
-          <span className="ml-0.5 inline-block h-3.5 w-[2px] translate-y-0.5 animate-pulse bg-accent align-middle" />
-        )}
-      </div>
-      <MessageActions
-        sessionId={sessionId}
-        message={message}
-        raw={raw}
-        onToggleRaw={() => setRaw((v) => !v)}
-        onSelectText={() => selectNodeText(body.current)}
-        onRegenerate={onRegenerate}
-        onRevert={onRevert}
-        toolCalls={toolCalls}
-        promptMessage={prompt}
-        className="mt-1"
-      />
+    <div>
+      <Markdown text={message.text} streaming={message.streaming} />
+      {message.streaming && (
+        <span className="ml-0.5 inline-block h-3.5 w-[2px] translate-y-0.5 animate-pulse bg-accent align-middle" />
+      )}
     </div>
   );
 }

--- a/src/renderer/features/workspace/MessageActions.tsx
+++ b/src/renderer/features/workspace/MessageActions.tsx
@@ -1,14 +1,24 @@
 /**
- * The per-message action toolbar.
+ * The per-turn action toolbar.
  *
- * Every block in the timeline — the user's prompt as much as the agent's reply —
- * is a thing you should be able to take away with you: copy it, quote it, reuse
- * it as the seed of another session, pin it as project memory, or roll the
- * repository back to just before it. Until now the conversation was read-only
- * presentation and the only copy affordance was on code blocks.
+ * A turn is a thing you should be able to take away with you: copy it, quote it,
+ * reuse it as the seed of another session, pin it as project memory, or roll the
+ * repository back to just before it.
  *
  * Rules this file encodes:
  *
+ *  - **It mounts on the USER bubble only.** The assistant's reply is a stream,
+ *    not a series of documents: it arrives as several text blocks split by tool
+ *    calls, so a per-block toolbar meant several toolbars per answer, each
+ *    reserving a row of layout (they hide with opacity, not display) and cutting
+ *    the output into separately-framed cards. The user's prompt is the one stable
+ *    anchor of a turn, and it is where the turn's actions belong. **Do not
+ *    reintroduce a toolbar in the assistant stream.** Code blocks keep their own
+ *    `CopyButton`, which is where copying a reply is actually wanted.
+ *  - **It acts on the turn, not just the bubble.** Export writes the prompt, the
+ *    replies (`replies`) and the tool calls as one document. Copy and Copy as
+ *    Markdown deliberately stay message-scoped — their labels say "Copy", and
+ *    silently widening them to a whole turn would make them a different button.
  *  - **Icon-only, revealed on hover OR keyboard focus.** `focus-within` matters
  *    as much as `group-hover`: a toolbar you can only reach with a mouse is not
  *    reachable. It never occupies layout when hidden (opacity, not display, so
@@ -56,8 +66,8 @@ export interface MessageActionsProps {
   onRevert?: () => void;
   /** Tool calls belonging to this turn, included in the export. */
   toolCalls?: AgentToolCall[];
-  /** The prompt this reply answered, included in the export. */
-  promptMessage?: ChatMessage | null;
+  /** The assistant messages this prompt produced, included in the export. */
+  replies?: ChatMessage[];
   className?: string;
 }
 
@@ -70,7 +80,7 @@ export function MessageActions({
   onRegenerate,
   onRevert,
   toolCalls,
-  promptMessage,
+  replies,
   className,
 }: MessageActionsProps) {
   const addToast = useUIStore((s) => s.addToast);
@@ -81,7 +91,6 @@ export function MessageActions({
   const createMemory = useMemoryStore((s) => s.create);
   const [pinning, setPinning] = useState(false);
 
-  const isUser = message.role === 'user';
   const streaming = !!message.streaming;
 
   const quote = () => {
@@ -95,11 +104,11 @@ export function MessageActions({
   };
 
   const exportTurn = () => {
-    const text = isUser
-      ? turnToMarkdown(message, [], toolCalls ?? [])
-      : turnToMarkdown(promptMessage ?? null, [message], toolCalls ?? []);
-    const stem = (isUser ? message.text : (promptMessage?.text ?? message.text)).slice(0, 40);
-    downloadText(`${slugify(stem, 'message')}.md`, text);
+    // The whole turn — the prompt, what came back, and what the agent ran. The
+    // toolbar is anchored to the prompt, so the replies are handed in rather
+    // than read off `message`.
+    const text = turnToMarkdown(message, replies ?? [], toolCalls ?? []);
+    downloadText(`${slugify(message.text.slice(0, 40), 'message')}.md`, text);
   };
 
   const openInNewSession = async () => {


### PR DESCRIPTION
…e assistant stream

The action toolbar rendered on every assistant TEXT BLOCK, not per turn — a reply split by tool calls got one toolbar per fragment. Each hid with `opacity` rather than `display`, so it kept its full ~24px row even when invisible, and the assistant column separated items with `gap-3`. Consecutive blocks sat ~40px apart and the stream read as a stack of cards instead of one continuous reply.

The prompt is a turn's one stable anchor, so it now carries the turn's actions alone:

- `AssistantText` becomes presentational — the toolbar, the `raw` state and its `<pre>` branch, and the `body` ref are gone. `AssistantBlock` sheds the props that only fed them, which collapses its `sessionId` fork (both branches now render the same thing) and drops the inline `onRegenerate` whose per-render identity was defeating its own memo.
- Export becomes turn-scoped: `TurnView` derives the turn's `replies` beside the existing `toolCalls` and hands both to `UserBubble`, so `turnToMarkdown` writes prompt + replies + tools. Previously the user-side branch exported a prompt with no answer. Copy / Copy as Markdown stay message-scoped — their labels say "Copy", and widening them silently would make them a different button.
- The content column goes `gap-3` -> `gap-1.5`, the single class governing the distance between every consecutive assistant sub-item. The larger spacing stays on turn boundaries.

Regenerate and Revert are unaffected: both were already built from `turn.user` and passed to both toolbars. Code blocks keep their own `CopyButton`.

Verified with `npx vite build --config vite.renderer.config.mts` and `npm run lint` (0 errors).

<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)
