### PR TITLE
Correct typo in project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A local-first desktop workspace that gives a coding agent everything it needs to
 real engineering: projects, sessions, file watching, repository indexing, git,
 worktrees, terminals, memory, search, permissions, and context. Limboo is not an AI
 model, and it is not an agent. It is the environment around one — and it works with
-more than one.
+more than one..
 
 [![Release](https://img.shields.io/github/v/release/limboo-ai/limboo?label=release&color=6e9bff)](https://github.com/limboo-ai/limboo/releases/latest)
 [![CI](https://github.com/limboo-ai/limboo/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/limboo-ai/limboo/actions/workflows/ci.yml)


### PR DESCRIPTION
Fix typo in README.md by removing extra period.

<!--
Thanks for contributing to Limboo. Please fill in this template so reviewers have
the context they need. Keep the boxes honest — an unchecked box is fine, it just
tells the reviewer what is left.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue (e.g. "Closes #123"). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling

## Architectural reasoning

<!--
For anything non-trivial: how does this fit the process boundary? Did you add a new
IPC channel (channel -> handler -> preload method -> renderer call)? Any new Zustand
store or feature folder? Any new dependency, and is it compatible with Vite 5 /
Electron 42?
-->

## Verification

- [ ] `npm run lint` passes
- [ ] `npx vite build --config vite.renderer.config.mts` passes
- [ ] App still starts with `npm start` (for main/preload changes)
- [ ] Manual testing steps described below

<!-- Describe how you tested this. -->

## Security checklist (if touching main process)

- [ ] All renderer-supplied IPC inputs are validated in the main process
- [ ] SQL uses bound parameters only
- [ ] Any spawned process uses argv arrays (no `shell: true`)
- [ ] Renderer-supplied paths are guarded against traversal
- [ ] No weakening of `contextIsolation` / `sandbox` / CSP / navigation lockdown

## Documentation and changelog

- [ ] Updated the relevant page(s) under `docs/`
- [ ] Added a `CHANGELOG.md` entry (if user-facing)
- [ ] Screenshots attached (for UI changes)

## Theme discipline (for UI changes)

- [ ] Uses design tokens only (no off-palette hex, no `dark:` variants, no gradients)
