### PR TITLE
fix(harness): ship the adapters' bridge assets and fail closed without them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ All notable changes to Limboo are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.19.0] - 2026-08-30
+
+Limboo 1.19.0 repairs the agent harness, which could not install itself in any
+packaged build, and gives workspaces a way out of the app.
+
+### Fixed
+
+- **The harness could never complete its one-time setup.** Packaging stripped
+  every `pnpm-lock.yaml` in the tree — a rule meant for the project's own
+  lockfile that also removed one the harness adapter reads at runtime. Without
+  it the adapter could not describe its setup step, so runs died with
+  `ENOENT … not found in app.asar` and Settings reported the harness needed no
+  setup at all. The adapters' bridge assets now ship, and the project's own
+  lockfiles are still excluded.
+- **A harness that could not describe its setup ran anyway, ungated.** "This
+  adapter installs nothing" and "this adapter could not say what it installs"
+  were the same value internally, and the second silently skipped the approval
+  gate, the sandbox network check and the prerequisite check along with it. They
+  are now different states: the run is refused, and Settings says why instead of
+  claiming there is nothing to approve.
+- **The setup panel contradicted itself.** It described an install that needed
+  your approval and, immediately below, said no setup was needed. Five different
+  conditions — including a request still in flight and an outright failure —
+  collapsed into that one sentence. Each now reports itself, and a failed request
+  no longer reads as an absence of work.
+- **Removing a workspace left almost everything behind.** Only the workspace's
+  own record was deleted; its sessions, memories, search index, checkpoints,
+  work-graph nodes and MCP entries stayed in the database permanently, since a
+  re-added folder is issued a new id and can never reclaim them. Removal now
+  clears all of it in one transaction, after tearing down each session's
+  worktree, services and terminals — which is what the confirmation dialog had
+  been promising all along. Global, non-workspace data is untouched.
+
+### Added
+
+- **Workspaces can be removed from the title-bar switcher.** Removal existed only
+  in the launcher, which appears when no workspace is open — so once you opened
+  one there was no way to remove any. Each row in the dropdown now has a remove
+  control, with the same confirmation dialog and the same guarantee that your
+  project folder on disk is never touched.
+- **Missing setup prerequisites are named before you approve, not after a run
+  fails.** The check also stopped assuming pnpm: it reads whichever tools the
+  adapter's own commands invoke, so an adapter that bootstraps with yarn, bun or
+  corepack is checked just as precisely. Limboo still never substitutes one tool
+  for another — the commands you approve are the commands that run.
+- **Tools installed in a user directory are found again.** An app started from a
+  desktop launcher inherits a much smaller `PATH` than a shell, so an installed
+  pnpm, bun or nvm-managed Node could be reported missing. Setup now also looks
+  where those install themselves.
+
+### Changed
+
+- **The title bar shows the workspace name alone.** The initials badge in front
+  of it repeated what the name already said. It remains in the launcher and the
+  remove dialog, where a workspace has to be picked out of a set at a glance.
+
 ## [1.18.2] - 2026-08-13
 
 ### Fixed

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -75,10 +75,20 @@ const config: ForgeConfig = {
       // DEFAULT_IGNORES (lockfiles, .git, node_modules/.bin, native build
       // artifacts) — these are skipped entirely once a custom `ignore` function
       // is supplied.
+      //
+      // The three lockfiles are matched by EXACT ROOT PATH, not by a trailing
+      // `/pnpm-lock.yaml$`-style pattern. DEFAULT_IGNORES means "drop this
+      // project's own lockfiles"; as an unanchored suffix match it also stripped
+      // `node_modules/@ai-sdk/harness-*/dist/bridge/pnpm-lock.yaml`, which is a
+      // REQUIRED RUNTIME ASSET — the harness adapter reads it in `getBootstrap()`
+      // to describe (and then perform) its one-time setup. Shipping without it
+      // made every harness run die with `ENOENT … not found in app.asar`, and
+      // made the consent surface in Settings report "no setup step" because
+      // `readBootstrapPlan` could not read a plan at all.
       if (
-        /\/package-lock\.json$/.test(file) ||
-        /\/yarn\.lock$/.test(file) ||
-        /\/pnpm-lock\.yaml$/.test(file) ||
+        file === '/package-lock.json' ||
+        file === '/yarn.lock' ||
+        file === '/pnpm-lock.yaml' ||
         /\/\.git($|\/)/.test(file) ||
         /\/node_modules\/\.bin($|\/)/.test(file) ||
         /\.o(bj)?$/.test(file) ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -8184,6 +8184,7 @@
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
       "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.0.0"

--- a/src/main/ipc/agentHandlers.ts
+++ b/src/main/ipc/agentHandlers.ts
@@ -24,6 +24,7 @@ import type {
 import type { PlanDecisionKind } from '@shared/plan';
 import { isPlanDecisionKind } from '@shared/plan';
 import type { AgentManager } from '../managers/AgentManager';
+import { harnessById } from '../managers/agent/harnessRegistry';
 import { handle } from './registry';
 
 const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
@@ -102,14 +103,26 @@ export function registerAgentHandlers(agent: AgentManager): void {
   handle<[], AgentInstall>(IpcChannels.agentGetInstall, () => agent.getInstall());
 
   /**
-   * The active harness's one-time setup plan, for the consent dialog.
+   * A harness's one-time setup plan, for the consent dialog.
    *
-   * Read-only and secret-free: command strings and file names the adapter
-   * itself declares. Approving is an ordinary settings write of the returned
-   * fingerprint, so no channel here can grant anything.
+   * Read-only and secret-free: command strings, file names and prerequisite tool
+   * names the adapter itself declares. Approving is an ordinary settings write
+   * of the returned fingerprint, so no channel here can grant anything.
+   *
+   * `harnessId` is optional and validated against the registry before it reaches
+   * the manager — a renderer must not be able to name an arbitrary module
+   * specifier for `loadHarness` to dynamic-import.
    */
-  handle<[], HarnessBootstrapInfo>(IpcChannels.agentHarnessBootstrapPlan, () =>
-    agent.harnessBootstrapPlan(),
+  handle<[string?], HarnessBootstrapInfo>(
+    IpcChannels.agentHarnessBootstrapPlan,
+    (_event, harnessId) => {
+      if (harnessId !== undefined) {
+        if (typeof harnessId !== 'string' || !harnessById(harnessId)) {
+          throw new Error('agent:harnessBootstrapPlan: unknown harness id');
+        }
+      }
+      return agent.harnessBootstrapPlan(harnessId);
+    },
   );
 
   handle<[], AgentState>(IpcChannels.agentGetState, () => agent.getState());

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -100,7 +100,16 @@ export function registerAllIpc(deps: IpcDeps): void {
   registerWindowHandlers();
   registerSettingsHandlers(deps.settings);
   registerSystemHandlers(deps.notifications);
-  registerWorkspaceHandlers(deps.workspace);
+  // Workspace removal cascades through the same session teardown `session:purge`
+  // uses, so it needs the same managers.
+  registerWorkspaceHandlers(
+    deps.workspace,
+    deps.session,
+    deps.worktree,
+    deps.services,
+    deps.terminal,
+    deps.attachments,
+  );
   registerSessionHandlers(deps.session, deps.worktree, deps.services, deps.terminal, deps.attachments);
   registerAgentHandlers(deps.agent);
   registerFsHandlers(deps.fs);

--- a/src/main/ipc/sessionHandlers.ts
+++ b/src/main/ipc/sessionHandlers.ts
@@ -18,6 +18,7 @@ import type { WorktreeManager } from '../managers/worktree/WorktreeManager';
 import type { ServiceManager } from '../managers/services/ServiceManager';
 import type { TerminalManager } from '../managers/TerminalManager';
 import type { AttachmentManager } from '../managers/attachments/AttachmentManager';
+import { purgeSessionCompletely } from './sessionTeardown';
 import { logger } from '../logger';
 
 /** Bounds for session organization inputs (folder / tags). */
@@ -209,21 +210,10 @@ export function registerSessionHandlers(
 
   handle<[string], void>(IpcChannels.sessionPurge, async (_e, id) => {
     assertValidId(id);
-    // A purged session must not leak its worktree directory — force-remove it
-    // (keeping the branch: permanent data loss stays a separate, explicit act).
-    try {
-      await worktrees.removeForSession(id, { force: true, deleteBranch: false });
-    } catch (err) {
-      logger.warn('session:purge worktree removal failed', err);
-    }
-    // Purge is permanent: delete the session's staged attachments too (trash
-    // keeps them so a restored session still has its files).
-    try {
-      await attachments.purgeSession(id);
-    } catch (err) {
-      logger.warn('session:purge attachment cleanup failed', err);
-    }
-    sessions.purge(id);
+    // Shared with the workspace-removal cascade, so the two can never disagree
+    // about what "permanently deleted" means — see sessionTeardown.ts for why
+    // the order (processes → worktree → attachments → rows) matters.
+    await purgeSessionCompletely({ sessions, worktrees, services, terminals, attachments }, id);
   });
 
   handle<[string, { title?: string; baseRef?: string; branch?: string }?], Session>(

--- a/src/main/ipc/sessionTeardown.ts
+++ b/src/main/ipc/sessionTeardown.ts
@@ -1,0 +1,73 @@
+/**
+ * Permanently destroying one session, everywhere it exists.
+ *
+ * WHY THIS FILE EXISTS
+ * A session is not just a row. It can own a git worktree on disk, a supervised
+ * service, live PTYs, and staged attachment files — and the order those come
+ * down in is load-bearing, not incidental. This sequence lived inline in the
+ * `session:purge` handler, and when workspace removal needed exactly the same
+ * teardown the choice was to duplicate it or to extract it. Duplicated, the two
+ * copies would drift, and the one that drifted would leave worktrees behind.
+ *
+ * ORDER MATTERS:
+ *  1. Services and PTYs die first. On Windows a process holding a cwd inside a
+ *     worktree keeps `git worktree remove` failing with EBUSY, which is the
+ *     reason `disposeSession` exists at all.
+ *  2. The worktree is removed with `force`, but the BRANCH is kept — permanent
+ *     loss of committed work stays a separate, explicit act.
+ *  3. Staged attachments are deleted. Trash keeps them so a restored session
+ *     still has its files; a purge is where they actually go.
+ *  4. The database rows go last, so a failure above still leaves a session the
+ *     user can see and retry rather than an orphaned directory nobody owns.
+ *
+ * Every step is individually contained: a session that cannot give up its
+ * worktree must not block the purge of the rest, or a single stuck directory
+ * makes an entire workspace unremovable.
+ */
+import type { SessionManager } from '../managers/SessionManager';
+import type { WorktreeManager } from '../managers/worktree/WorktreeManager';
+import type { ServiceManager } from '../managers/services/ServiceManager';
+import type { TerminalManager } from '../managers/TerminalManager';
+import type { AttachmentManager } from '../managers/attachments/AttachmentManager';
+import { logger } from '../logger';
+
+export interface SessionTeardownDeps {
+  sessions: SessionManager;
+  worktrees: WorktreeManager;
+  services: ServiceManager;
+  terminals: TerminalManager;
+  attachments: AttachmentManager;
+}
+
+/** Stop everything a session is running, without touching its records. */
+export async function stopSessionProcesses(
+  deps: Pick<SessionTeardownDeps, 'services' | 'terminals'>,
+  sessionId: string,
+): Promise<void> {
+  await deps.services.stopForSession(sessionId).catch(() => undefined);
+  deps.terminals.disposeSession(sessionId);
+}
+
+/**
+ * Purge one session permanently: processes, worktree, attachments, then rows.
+ *
+ * Used by `session:purge` and by the workspace cascade, so the two can never
+ * disagree about what "permanently deleted" means.
+ */
+export async function purgeSessionCompletely(
+  deps: SessionTeardownDeps,
+  sessionId: string,
+): Promise<void> {
+  await stopSessionProcesses(deps, sessionId);
+  try {
+    await deps.worktrees.removeForSession(sessionId, { force: true, deleteBranch: false });
+  } catch (err) {
+    logger.warn(`session purge: worktree removal failed for ${sessionId}`, err);
+  }
+  try {
+    await deps.attachments.purgeSession(sessionId);
+  } catch (err) {
+    logger.warn(`session purge: attachment cleanup failed for ${sessionId}`, err);
+  }
+  deps.sessions.purge(sessionId);
+}

--- a/src/main/ipc/workspaceHandlers.ts
+++ b/src/main/ipc/workspaceHandlers.ts
@@ -11,6 +11,12 @@ import { WORKSPACE_LIMITS } from '@shared/constants';
 import type { DeepPartial, Workspace, WorkspaceConfig, WorkspaceStats } from '@shared/types';
 import { handle } from './registry';
 import { WorkspaceManager, WorkspaceValidationError } from '../managers/WorkspaceManager';
+import type { SessionManager } from '../managers/SessionManager';
+import type { WorktreeManager } from '../managers/worktree/WorktreeManager';
+import type { ServiceManager } from '../managers/services/ServiceManager';
+import type { TerminalManager } from '../managers/TerminalManager';
+import type { AttachmentManager } from '../managers/attachments/AttachmentManager';
+import { purgeSessionCompletely } from './sessionTeardown';
 import { logger } from '../logger';
 
 const FORBIDDEN_KEYS = ['__proto__', 'constructor', 'prototype'];
@@ -126,7 +132,14 @@ function rethrow(err: unknown): never {
 /** True while a native directory picker is open (see the pickDirectory handler). */
 let pickerOpen = false;
 
-export function registerWorkspaceHandlers(workspace: WorkspaceManager): void {
+export function registerWorkspaceHandlers(
+  workspace: WorkspaceManager,
+  sessions: SessionManager,
+  worktrees: WorktreeManager,
+  services: ServiceManager,
+  terminals: TerminalManager,
+  attachments: AttachmentManager,
+): void {
   handle<[], Workspace[]>(IpcChannels.workspaceList, () => workspace.list());
 
   handle<[], Workspace | null>(IpcChannels.workspaceGet, () => workspace.getActive());
@@ -207,8 +220,42 @@ export function registerWorkspaceHandlers(workspace: WorkspaceManager): void {
     return workspace.switch(id);
   });
 
-  handle<[string, boolean?], void>(IpcChannels.workspaceRemove, (_e, id, deleteFiles) => {
+  /**
+   * Remove a workspace and everything scoped to it.
+   *
+   * The cross-manager choreography lives HERE rather than inside
+   * `WorkspaceManager`, which owns only its own tables — the same split
+   * `session:delete` / `session:purge` already use. Sessions come down first
+   * through the shared teardown (worktree, services, PTYs, attachments, rows),
+   * because a PTY holding a cwd inside a worktree keeps `git worktree remove`
+   * failing with EBUSY on Windows. Only then are the workspace's own rows swept.
+   *
+   * A session that will not tear down is logged and skipped, not fatal: one
+   * stuck worktree must not make an entire workspace permanently unremovable.
+   * `WorkspaceManager.remove` sweeps `sessions` last as the backstop.
+   */
+  handle<[string, boolean?], void>(IpcChannels.workspaceRemove, async (_e, id, deleteFiles) => {
     assertValidId(id);
+    if (!workspace.getById(id)) return;
+    const deps = { sessions, worktrees, services, terminals, attachments };
+    // Trashed sessions own worktrees and staged files too — a recoverable
+    // session whose workspace is gone is not recoverable, so it purges as well.
+    const owned = [...sessions.list(id), ...sessions.listTrash(id)];
+    for (const session of owned) {
+      try {
+        await purgeSessionCompletely(deps, session.id);
+      } catch (err) {
+        logger.warn(`workspace:remove could not purge session ${session.id}`, err);
+      }
+    }
+    // Terminals not owned by any session (workspace-scoped shells) outlive the
+    // loop above. `disposeWorkspace` has existed for exactly this and was never
+    // called by anything.
+    try {
+      terminals.disposeWorkspace(id);
+    } catch (err) {
+      logger.warn('workspace:remove terminal cleanup failed', err);
+    }
     workspace.remove(id, deleteFiles === true);
   });
 

--- a/src/main/managers/AgentManager.ts
+++ b/src/main/managers/AgentManager.ts
@@ -156,6 +156,7 @@ import type { HarnessRuntime, HarnessRunHandle } from './harness/HarnessRuntime'
 import type { LocalWorktreeSandboxProvider } from './harness/sandbox/LocalWorktreeSandbox';
 import { buildToolApprovalMap } from './harness/approval';
 import { readBootstrapPlan } from './harness/bootstrap';
+import { resolveTools } from './harness/toolchain';
 import { loadHarness } from './harness';
 import { harnessById } from './agent/harnessRegistry';
 import { isSubagentTool } from '@shared/subagents';
@@ -2331,32 +2332,57 @@ export class AgentManager {
   }
 
   /**
-   * The active harness's one-time setup plan, for the consent surface.
+   * A harness's one-time setup plan, for the consent surface.
    *
    * Loads the adapter to ask it — which is also a useful availability probe —
    * and reports `available: false` with the reason when it cannot be loaded, so
    * the UI can distinguish "nothing to approve" from "this harness is broken".
+   *
+   * `harnessId` is a PARAMETER, not read from settings, because the consent
+   * surface is per-harness: `ClaudeCodeControls` is mounted as the body of the
+   * Claude Code card regardless of which harness is currently selected. Reading
+   * the global setting made that card describe — and claim "no setup step" for —
+   * a harness it was not showing. Defaults to the selected harness for callers
+   * that genuinely mean "the active one".
    */
-  async harnessBootstrapPlan(): Promise<HarnessBootstrapInfo> {
+  async harnessBootstrapPlan(harnessId?: string): Promise<HarnessBootstrapInfo> {
     const agent = this.settings.getAll().agent;
-    const descriptor = harnessById(agent.harness.id);
+    const id = harnessId ?? agent.harness.id;
+    const descriptor = harnessById(id);
     if (!descriptor || !descriptor.module) {
-      return { available: true, harnessId: agent.harness.id, plan: null, acked: true };
+      return { available: true, harnessId: id, plan: null, acked: true };
     }
     try {
-      const { adapter, createAdapter } = await loadHarness(agent.harness.id);
+      const { adapter, createAdapter } = await loadHarness(id);
       const built = createAdapter ? createAdapter({}) : adapter;
-      const plan = await readBootstrapPlan(built);
+      const read = await readBootstrapPlan(built);
+      if (read.kind === 'unreadable') {
+        // NOT `plan: null` — that is the "installs nothing" claim, and reporting
+        // it here is what made the panel contradict its own copy.
+        return {
+          available: false,
+          harnessId: id,
+          plan: null,
+          acked: false,
+          planError: redact(read.error).slice(0, 300),
+        };
+      }
+      if (read.kind === 'none') {
+        return { available: true, harnessId: id, plan: null, acked: true };
+      }
       return {
         available: true,
-        harnessId: agent.harness.id,
-        plan,
-        acked: plan == null || plan.fingerprint === agent.harness.bootstrapAck,
+        harnessId: id,
+        plan: read.plan,
+        acked: read.plan.fingerprint === agent.harness.bootstrapAck,
+        // Surfaced BEFORE approval. Previously the only way to learn a required
+        // tool was missing was a run that failed after you had already approved.
+        prerequisites: resolveTools(read.plan),
       };
     } catch (err) {
       return {
         available: false,
-        harnessId: agent.harness.id,
+        harnessId: id,
         plan: null,
         acked: false,
         error: redact(err instanceof Error ? err.message : String(err)).slice(0, 300),

--- a/src/main/managers/WorkspaceManager.ts
+++ b/src/main/managers/WorkspaceManager.ts
@@ -30,6 +30,35 @@ import { detectWorkspace } from './workspace/detect';
 import { computeStats } from './workspace/stats';
 import { validateWorkspacePath, isInsideRoot } from './workspace/validate';
 
+/**
+ * Every table carrying a `workspace_id`, swept when a workspace is removed.
+ *
+ * `sessions` is LAST on purpose: the caller purges each session properly first
+ * (worktree, services, PTYs, attachments, child rows), and this is the backstop
+ * that guarantees no invisible row survives if one of those purges failed. A
+ * failure is logged there, so a leftover worktree directory is discoverable
+ * rather than merely absent from a query nobody will ever run again.
+ *
+ * A NULL `workspace_id` means global scope (user preferences, global memories,
+ * global saved searches). SQL never matches NULL with `=`, so those rows are
+ * untouched by construction — do not "fix" this with `IS NOT DISTINCT FROM`.
+ */
+const WORKSPACE_SCOPED_TABLES = [
+  'plan_state',
+  'git_checkpoints',
+  'session_snapshots',
+  'attachments',
+  'work_graph_nodes',
+  'memories',
+  'search_files',
+  'search_symbols',
+  'search_refs',
+  'search_history',
+  'saved_searches',
+  'mcp_servers',
+  'sessions',
+] as const;
+
 interface WorkspaceRow {
   id: string;
   name: string;
@@ -201,6 +230,25 @@ export class WorkspaceManager {
     return this.requireById(id);
   }
 
+  /**
+   * Delete a workspace and every row scoped to it.
+   *
+   * This used to be `DELETE FROM workspaces` alone, which orphaned every
+   * session, memory, search-index entry, checkpoint and MCP row that named the
+   * workspace — permanently, since a re-added folder is issued a NEW id and can
+   * never reclaim them. `WorkspaceRemoveDialog` told the user all of it was
+   * cleaned up, so the fix is here rather than in the copy.
+   *
+   * SESSIONS ARE NOT PURGED HERE. They own worktrees on disk, PTYs and services,
+   * and this manager owns none of those — the caller purges each session through
+   * `purgeSessionCompletely` FIRST, then calls this. The sweep below is by
+   * `workspace_id`, so it also catches whatever that purge leaves behind rather
+   * than depending on an audit of every foreign key.
+   *
+   * One transaction: a half-removed workspace is worse than a failed removal.
+   * The FTS mirrors (`memories_fts`, `search_*_fts`, `work_graph_nodes_fts`) are
+   * kept in sync by triggers, so deleting the base rows is sufficient.
+   */
   remove(id: string, deleteFiles = false): void {
     const ws = this.byId(id);
     if (!ws) return;
@@ -210,7 +258,14 @@ export class WorkspaceManager {
       // future, separate, audited path will handle on-disk removal.
       logger.warn('remove(deleteFiles=true) requested; files preserved by policy', ws.path);
     }
-    this.db.prepare('DELETE FROM workspaces WHERE id = ?').run(id);
+    const purge = this.db.transaction(() => {
+      for (const table of WORKSPACE_SCOPED_TABLES) {
+        this.db.prepare(`DELETE FROM ${table} WHERE workspace_id = ?`).run(id);
+      }
+      this.db.prepare('DELETE FROM workspaces WHERE id = ?').run(id);
+    });
+    purge();
+    logger.info(`Workspace removed: ${id}`);
     if (this.activeId() === id) this.clearActive();
     this.broadcast();
   }

--- a/src/main/managers/agent/harnessRegistry.ts
+++ b/src/main/managers/agent/harnessRegistry.ts
@@ -147,7 +147,7 @@ export const HARNESSES: readonly HarnessDescriptor[] = [
       'AI_GATEWAY_BASE_URL',
     ],
     capabilities: {
-      // VERIFIED FALSE in @ai-sdk/harness-codex@1.0.67: the adapter declares
+      // VERIFIED FALSE in @ai-sdk/harness-codex@1.0.79: the adapter declares
       // `supportsBuiltinToolApprovals: false`, so its `bash` tool would run with
       // Limboo's permission gate bypassed. It is therefore refused at preflight
       // and given no selectable model. Flip this — and add a model — only after

--- a/src/main/managers/harness/HarnessRuntime.ts
+++ b/src/main/managers/harness/HarnessRuntime.ts
@@ -28,7 +28,7 @@ import {
   assertBootstrapPossible,
   readBootstrapPlan,
 } from './bootstrap';
-import { HarnessUngatedError } from './errors';
+import { HarnessBootstrapUnreadableError, HarnessUngatedError } from './errors';
 import { harnessPermissionMode } from './permissions';
 import { newTranslateContext, translatePart, type HarnessApprovalRequest } from './translate';
 import type { HarnessAdapterFlags, HarnessSession, HarnessToolApproval } from './types';
@@ -185,11 +185,19 @@ export class HarnessRuntime {
     // the sandbox network policy permits the download, and the tools the
     // commands invoke exist. Each failure is named — the alternative is a
     // bootstrap that times out inside the sandbox with nothing to act on.
-    const bootstrap = await readBootstrapPlan(harness);
-    if (bootstrap) {
-      const label = spec.harnessLabel ?? spec.harnessId;
-      assertBootstrapConsent(bootstrap, spec.bootstrapAck ?? '', label);
-      assertBootstrapPossible(bootstrap, spec.sandbox);
+    //
+    // `unreadable` REFUSES rather than falling through. It used to be
+    // indistinguishable from "this adapter installs nothing", and that single
+    // `null` disabled all three guards below — so an adapter broken by a
+    // packaging bug ran ungated while Settings reported "no setup step".
+    const read = await readBootstrapPlan(harness);
+    const label = spec.harnessLabel ?? spec.harnessId;
+    if (read.kind === 'unreadable') {
+      throw new HarnessBootstrapUnreadableError(label, read.error);
+    }
+    if (read.kind === 'plan') {
+      assertBootstrapConsent(read.plan, spec.bootstrapAck ?? '', label);
+      assertBootstrapPossible(read.plan, spec.sandbox);
       bridge.onSandboxStatus?.('preparing', 'Preparing the agent runtime…');
     }
 

--- a/src/main/managers/harness/bootstrap.ts
+++ b/src/main/managers/harness/bootstrap.ts
@@ -21,8 +21,9 @@
  */
 import crypto from 'node:crypto';
 import type { EffectiveSandbox } from '../sandbox/policy';
+import { logger } from '../../logger';
 import { HarnessBootstrapBlockedError, HarnessConsentRequiredError } from './errors';
-import { probeCommand } from './probe';
+import { resolveTools } from './toolchain';
 
 /** What the adapter says it will do before the first session. */
 export interface BootstrapPlan {
@@ -41,36 +42,75 @@ interface RawBootstrap {
 }
 
 /**
- * Read the adapter's bootstrap plan, or `null` when it has none.
+ * The outcome of asking an adapter to describe its setup step.
+ *
+ * Three distinct states, deliberately NOT collapsed into `BootstrapPlan | null`.
+ * They used to be: a `getBootstrap()` that threw was caught and reported as
+ * "no plan", which is a different claim entirely, and the `if (plan)` guard in
+ * HarnessRuntime then skipped consent, the network check and the toolchain probe
+ * — a broken adapter ran with every guard disabled while Settings said "this
+ * harness needs no setup step". "Not measured" and "empty" are opposite claims
+ * and must not look alike.
+ */
+export type BootstrapRead =
+  /** The adapter has no setup step at all (Pi exposes no `getBootstrap`). */
+  | { kind: 'none' }
+  /** The adapter described a setup step. */
+  | { kind: 'plan'; plan: BootstrapPlan }
+  /** The adapter HAS a setup step but could not describe it. Fail closed. */
+  | { kind: 'unreadable'; error: string };
+
+/**
+ * Read the adapter's bootstrap plan.
  *
  * A host-process adapter (Pi) may not install anything, in which case there is
- * nothing to consent to and nothing to block on.
+ * nothing to consent to and nothing to block on — that is `none`. An adapter
+ * that HAS a `getBootstrap` but throws from it is `unreadable`, and the caller
+ * must refuse the run: approving commands nobody can read is not something
+ * Limboo can ask a user to do.
  */
-export async function readBootstrapPlan(adapter: unknown): Promise<BootstrapPlan | null> {
+export async function readBootstrapPlan(adapter: unknown): Promise<BootstrapRead> {
   const get = (adapter as { getBootstrap?: () => Promise<RawBootstrap> } | null)?.getBootstrap;
-  if (typeof get !== 'function') return null;
+  if (typeof get !== 'function') return { kind: 'none' };
   let raw: RawBootstrap;
   try {
     raw = await get.call(adapter);
-  } catch {
-    // An adapter that cannot describe its own setup is not one we can ask the
-    // user to approve. Treat as "no plan" and let the run proceed — the
-    // sandbox's own containment is unaffected either way.
-    return null;
+  } catch (err) {
+    // The real-world trigger for this was a packaging bug: the adapter reads its
+    // bridge assets off disk here, and they were being stripped from the asar.
+    // Surfacing the adapter's own message is what makes that diagnosable.
+    return { kind: 'unreadable', error: err instanceof Error ? err.message : String(err) };
   }
   const commands = (raw?.commands ?? [])
     .map((c) => (typeof c?.command === 'string' ? c.command : ''))
     .filter((c) => c.length > 0);
-  if (commands.length === 0) return null;
+  if (commands.length === 0) {
+    // An adapter may legitimately declare files and no commands, so this is not
+    // an error — but it is also how silent shape drift after an upgrade would
+    // present, and that must not pass unnoticed.
+    if ((raw?.commands ?? []).length > 0) {
+      logger.warn(
+        'Harness adapter declared bootstrap commands in an unrecognised shape; treating as no setup step.',
+      );
+    }
+    return { kind: 'none' };
+  }
   const files = (raw?.files ?? [])
     .map((f) => (typeof f?.path === 'string' ? f.path : ''))
     .filter((f) => f.length > 0);
   return {
-    commands,
-    files,
-    // Only the COMMANDS are fingerprinted. File contents change on every
-    // adapter patch release; what the user is consenting to is what executes.
-    fingerprint: crypto.createHash('sha256').update(commands.join('\n')).digest('hex').slice(0, 16),
+    kind: 'plan',
+    plan: {
+      commands,
+      files,
+      // Only the COMMANDS are fingerprinted. File contents change on every
+      // adapter patch release; what the user is consenting to is what executes.
+      fingerprint: crypto
+        .createHash('sha256')
+        .update(commands.join('\n'))
+        .digest('hex')
+        .slice(0, 16),
+    },
   };
 }
 
@@ -114,23 +154,18 @@ export function assertBootstrapPossible(plan: BootstrapPlan, eff: EffectiveSandb
       );
     }
   }
-  // Only assert on a tool the plan actually invokes, so this stays true for a
-  // future adapter with a different setup.
-  for (const [tool, hint] of REQUIRED_TOOLS) {
-    if (!plan.commands.some((c) => c.startsWith(`${tool} `) || c.includes(` ${tool} `))) continue;
-    if (!probeCommand(tool)) {
-      throw new HarnessBootstrapBlockedError(
-        `it runs \`${tool}\`, which is not installed or not on PATH. ${hint}`,
-      );
-    }
+  // Only ever assert on tools the plan ITSELF invokes, derived from the command
+  // strings rather than a hardcoded package-manager list — so an adapter that
+  // bootstraps with yarn, bun or corepack is checked just as precisely. Limboo
+  // never substitutes one tool for another: the approved string is the executed
+  // string, so a missing tool is reported, not worked around.
+  for (const { tool, found, hint } of resolveTools(plan)) {
+    if (found) continue;
+    throw new HarnessBootstrapBlockedError(
+      `it runs \`${tool}\`, which is not installed or not on PATH. ${hint}`,
+    );
   }
 }
-
-/** Command → how the user fixes its absence. */
-const REQUIRED_TOOLS: readonly [string, string][] = [
-  ['pnpm', 'Install pnpm (https://pnpm.io/installation) and restart Limboo.'],
-  ['npm', 'Install Node.js, which provides npm, and restart Limboo.'],
-];
 
 /** Hosts the npm client needs. Matched permissively — wildcards are allowed. */
 const REGISTRY_HOSTS = ['registry.npmjs.org', 'npmjs.org', 'npmjs.com'];

--- a/src/main/managers/harness/errors.ts
+++ b/src/main/managers/harness/errors.ts
@@ -67,3 +67,30 @@ export class HarnessConsentRequiredError extends Error {
     );
   }
 }
+
+/**
+ * The adapter has a bootstrap step but could not describe it.
+ *
+ * FAIL CLOSED. This used to be indistinguishable from "this harness installs
+ * nothing": `readBootstrapPlan` swallowed the throw and returned `null`, and the
+ * `if (plan)` in HarnessRuntime then skipped the consent gate, the sandbox
+ * network check AND the toolchain probe — so a broken adapter ran with every
+ * guard the consent surface promises silently disabled, while Settings reported
+ * "no setup step".
+ *
+ * The real-world trigger was a packaging bug: the adapter reads its bridge
+ * assets (including `pnpm-lock.yaml`) off disk in `getBootstrap()`, and those
+ * files were being stripped from the packaged asar. An adapter that cannot say
+ * what it will do is not one we can ask the user to approve, so the run stops.
+ */
+export class HarnessBootstrapUnreadableError extends Error {
+  readonly name = 'HarnessBootstrapUnreadableError';
+
+  constructor(label: string, detail: string) {
+    super(
+      `${label} has a one-time setup step but could not describe it, so Limboo ` +
+        'will not run it — approving commands it cannot read is not something ' +
+        `Limboo can ask you to do. The adapter reported: ${detail}`,
+    );
+  }
+}

--- a/src/main/managers/harness/probe.ts
+++ b/src/main/managers/harness/probe.ts
@@ -6,8 +6,14 @@
  * only, no shell, bounded, and memoised for the process lifetime — a prereq
  * appearing mid-session is not worth re-probing on every run, and the user is
  * told to restart when one is missing.
+ *
+ * Resolution runs against `augmentedPath()`, not the raw `process.env.PATH`: an
+ * Electron app launched from a `.desktop` entry or the Dock inherits a much
+ * smaller PATH than the user's shell, so an installed pnpm/bun/nvm-node would
+ * otherwise be reported as missing. See `toolchain.ts`.
  */
 import { spawnSync } from 'node:child_process';
+import { augmentedPath } from './toolchain';
 
 const cache = new Map<string, boolean>();
 
@@ -26,6 +32,9 @@ export function probeCommand(name: string): boolean {
       timeout: 3_000,
       shell: false,
       windowsHide: true,
+      // Only PATH is overridden — the finder needs the rest of the environment
+      // (COMSPEC/PATHEXT on Windows) exactly as it is.
+      env: { ...process.env, PATH: augmentedPath() },
     });
     found = r.status === 0 && typeof r.stdout === 'string' && r.stdout.trim().length > 0;
   } catch {

--- a/src/main/managers/harness/sandbox/LocalWorktreeSandbox.ts
+++ b/src/main/managers/harness/sandbox/LocalWorktreeSandbox.ts
@@ -46,6 +46,7 @@ import path from 'node:path';
 import { Readable } from 'node:stream';
 import { crownJewelPaths, type EffectiveSandbox } from '../../sandbox/policy';
 import { killTree } from '../../agent/killTree';
+import { augmentedPath } from '../toolchain';
 import { resolveJail } from './jail';
 import { patchBootstrapFile } from './patchBridge';
 import { assertLoopbackOnly, reserveLoopbackPort, type PortReservation } from './ports';
@@ -74,7 +75,7 @@ export interface LocalSandboxDeps {
 /**
  * The adapter state directories permitted as SIBLINGS of the worktree.
  *
- * Third-party constants, verified in @ai-sdk/harness-claude-code@1.0.67:
+ * Third-party constants, verified in @ai-sdk/harness-claude-code@1.0.80:
  * `BOOTSTRAP_DIR = ".harness-bootstrap/claude-code"` and the per-session
  * `.agent-runs/<sessionId>/bridge`, both resolved against the sandbox's
  * `defaultWorkingDirectory`. Kept as literals rather than a prefix rule so a
@@ -106,6 +107,14 @@ const ENV_ALLOWLIST = [
  * only when it is already present on the host — Limboo stores no provider
  * credential, accepts none over IPC, and puts none in argv; this is pure
  * passthrough of what the user's own shell already has.
+ *
+ * PATH is the one key not passed through verbatim. An Electron app launched from
+ * a `.desktop` entry or the Dock inherits a much smaller PATH than the user's
+ * shell, so the bootstrap child would fail to find a pnpm/bun/nvm-node that IS
+ * installed. `augmentedPath()` prepends the user-local tool directories that
+ * exist — DISCOVERY of what is already there, never provisioning, so CLAUDE.md
+ * §1 is untouched. It must match what `probeCommand` resolves against, or the
+ * preflight check and the child would disagree about the same machine.
  */
 function baseEnv(extraKeys: readonly string[] = []): Record<string, string> {
   const out: Record<string, string> = {};
@@ -113,6 +122,7 @@ function baseEnv(extraKeys: readonly string[] = []): Record<string, string> {
     const v = process.env[key];
     if (typeof v === 'string') out[key] = v;
   }
+  out.PATH = augmentedPath();
   return out;
 }
 
@@ -201,7 +211,7 @@ class LocalSandboxSession {
     // worktree (slugs come from `sanitizeBranchName`, which cannot emit a
     // leading dot). The crown-jewel loop above already ran unconditionally, so
     // nothing here can reach a protected file. Both names are third-party
-    // constants verified in @ai-sdk/harness-claude-code@1.0.67 — an upgrade
+    // constants verified in @ai-sdk/harness-claude-code@1.0.80 — an upgrade
     // that renames them fails loudly at the first write rather than silently
     // writing somewhere else.
     const realState = realpathNearest(this.defaultWorkingDirectory);

--- a/src/main/managers/harness/sandbox/patchBridge.ts
+++ b/src/main/managers/harness/sandbox/patchBridge.ts
@@ -31,7 +31,7 @@
  * either one into a warning.
  */
 
-/** The exact literal the adapter ships. Verified in 1.0.67. */
+/** The exact literal the adapter ships. Verified in 1.0.80 (exactly one site). */
 const BIND_ALL = /host:\s*(["'])0\.0\.0\.0\1/g;
 const LOOPBACK = 'host: "127.0.0.1"';
 

--- a/src/main/managers/harness/toolchain.ts
+++ b/src/main/managers/harness/toolchain.ts
@@ -1,0 +1,248 @@
+/**
+ * What an adapter's bootstrap commands actually need on the machine, and where
+ * to find it.
+ *
+ * WHY THIS FILE EXISTS
+ * The prerequisite check used to be a two-entry table (`pnpm`, `npm`) matched
+ * with `command.startsWith('pnpm ')`. Two things were wrong with that. It missed
+ * every other tool a command invokes — the claude-code adapter's second command
+ * also runs `node` — and it hardcoded one package manager, so an adapter that
+ * bootstraps with yarn, bun or corepack would report a clean bill of health and
+ * then fail at run time with a non-zero exit from a command the user never saw.
+ *
+ * THE CONSTRAINT THIS FILE DOES NOT BREAK
+ * Limboo never rewrites a bootstrap command. `pnpm install …` is not silently
+ * retargeted at `npm`, ever: the consent contract in `bootstrap.ts` is that the
+ * string the user approved is the string that executes, and the approval is
+ * keyed to a fingerprint of exactly those strings. So "support every package
+ * manager" means DETECT AND RESOLVE whatever the plan itself invokes — never
+ * substitute one tool for another.
+ *
+ * The second job here is discovery. `probeCommand` resolves against the Electron
+ * process's own PATH, and an app launched from a `.desktop` entry or a Dock icon
+ * inherits a far smaller PATH than the user's shell — one that routinely omits
+ * `~/.local/share/pnpm`, `~/.bun/bin`, nvm and Homebrew. A pnpm that IS
+ * installed then reads as missing. `augmentedPath()` prepends the user-local bin
+ * directories that exist, following the install-directory probe idiom
+ * `managers/cursor/exec.ts` already uses for `cursor-agent`.
+ *
+ * This is DISCOVERY, not provisioning: nothing is downloaded, installed or
+ * written. CLAUDE.md §1's three outbound requests are untouched.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { BootstrapPlan } from './bootstrap';
+import { probeCommand } from './probe';
+
+/** One prerequisite of a bootstrap plan, resolved. */
+export interface HarnessToolStatus {
+  /** Executable name, exactly as the command invokes it. */
+  tool: string;
+  found: boolean;
+  /** How the user fixes its absence. Code-supplied; never echoes the environment. */
+  hint: string;
+}
+
+/**
+ * Shell words that begin a command position but are not executables.
+ *
+ * The claude-code plan's second command is a full `if … then … fi && ./…`
+ * pipeline, so command positions genuinely contain control words. Probing for a
+ * binary called `then` would report a missing prerequisite that does not exist.
+ */
+const SHELL_WORDS = new Set([
+  'if', 'then', 'else', 'elif', 'fi', 'for', 'while', 'do', 'done', 'case', 'esac',
+  'test', '[', '[[', 'cd', 'echo', 'exit', 'export', 'set', 'unset', 'true', 'false',
+  'read', 'shift', 'return', 'local', 'eval', 'exec', 'source', '.', ':',
+]);
+
+/** Command → how the user fixes its absence. */
+const TOOL_HINTS: Readonly<Record<string, string>> = {
+  pnpm:
+    'Install pnpm (https://pnpm.io/installation), or run `corepack enable pnpm` — ' +
+    'corepack ships with Node.js. Restart Limboo afterwards.',
+  npm: 'Install Node.js, which provides npm, and restart Limboo.',
+  npx: 'Install Node.js, which provides npx, and restart Limboo.',
+  node: 'Install Node.js (https://nodejs.org) and restart Limboo.',
+  yarn:
+    'Install Yarn (https://yarnpkg.com/getting-started/install), or run ' +
+    '`corepack enable yarn`. Restart Limboo afterwards.',
+  bun: 'Install Bun (https://bun.sh) and restart Limboo.',
+  deno: 'Install Deno (https://deno.land) and restart Limboo.',
+  corepack: 'Corepack ships with Node.js — install or update Node.js, then restart Limboo.',
+  git: 'Install Git (https://git-scm.com/downloads) and restart Limboo.',
+  python: 'Install Python (https://python.org) and restart Limboo.',
+  python3: 'Install Python 3 (https://python.org) and restart Limboo.',
+  uv: 'Install uv (https://docs.astral.sh/uv/getting-started/installation/) and restart Limboo.',
+  pip: 'Install Python, which provides pip, and restart Limboo.',
+  cargo: 'Install the Rust toolchain (https://rustup.rs) and restart Limboo.',
+  go: 'Install Go (https://go.dev/dl/) and restart Limboo.',
+};
+
+/** Anything not in the table still gets a usable sentence. */
+function hintFor(tool: string): string {
+  return (
+    TOOL_HINTS[tool] ??
+    `Install \`${tool}\` and make sure it is on your PATH, then restart Limboo.`
+  );
+}
+
+/**
+ * The executables a plan's commands invoke.
+ *
+ * Splits on the shell operators that open a new command position (`&&`, `||`,
+ * `;`, `|`, and the `(`/`{` group openers), then walks each segment left to
+ * right for the first real executable. Walking rather than just taking word[0]
+ * matters: the claude-code plan's second command is
+ * `… ; then node node_modules/…/install.cjs ; fi && …`, where `then` holds the
+ * first position and `node` — an actual prerequisite — is the second.
+ *
+ * Deliberately conservative. This decides what to PROBE, and a false positive
+ * becomes a prerequisite the user is told to install for no reason, so the walk
+ * stops at the first token that is not a shell word: either it is the
+ * executable, or the segment has none worth probing.
+ *
+ * Anything containing a path separator ends the walk without a result:
+ * `./node_modules/.bin/claude` is PRODUCED by the bootstrap, not required
+ * before it, and is resolved by the shell against the directory, not PATH.
+ */
+export function requiredTools(plan: Pick<BootstrapPlan, 'commands'>): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const command of plan.commands) {
+    for (const segment of command.split(/(?:&&|\|\||[;|(){}\n])/)) {
+      for (const word of segment.trim().split(/\s+/)) {
+        if (!word) continue;
+        // A leading `VAR=value` assignment prefixes the real command word.
+        if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(word)) continue;
+        if (SHELL_WORDS.has(word)) continue;
+        // Past this point the word IS the command position, whatever it is —
+        // so the walk ends here either way.
+        if (!word.includes('/') && !word.includes('\\')) {
+          // Same charset guard `probeCommand` enforces, so a shell token that
+          // survived the split (a redirection, glob or quote) is never probed.
+          if (/^[a-z][a-z0-9._-]{0,31}$/i.test(word) && !seen.has(word)) {
+            seen.add(word);
+            out.push(word);
+          }
+        }
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+/** Resolve every prerequisite of a plan, in the order the commands invoke them. */
+export function resolveTools(plan: Pick<BootstrapPlan, 'commands'>): HarnessToolStatus[] {
+  return requiredTools(plan).map((tool) => ({
+    tool,
+    found: probeCommand(tool),
+    hint: hintFor(tool),
+  }));
+}
+
+/**
+ * Directories a user-installed toolchain commonly lands in, relative to `$HOME`.
+ *
+ * Existence-checked before use, so a missing one costs a `statSync` and nothing
+ * else. Order matters only in that a user-local install should win over a
+ * system one, which is why these are PREPENDED.
+ */
+const HOME_BIN_DIRS = [
+  '.local/bin',
+  '.local/share/pnpm',
+  '.bun/bin',
+  '.yarn/bin',
+  '.config/yarn/global/node_modules/.bin',
+  '.npm-global/bin',
+  '.npm-packages/bin',
+  '.cargo/bin',
+  '.deno/bin',
+  'go/bin',
+];
+
+/** System directories a GUI-launched process often lacks. */
+const SYSTEM_BIN_DIRS =
+  process.platform === 'darwin'
+    ? ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin']
+    : ['/usr/local/bin', '/usr/bin', '/bin', '/snap/bin'];
+
+let cachedPath: string | undefined;
+
+/**
+ * `process.env.PATH`, widened with the user-local tool directories that exist.
+ *
+ * Memoised for the process lifetime, matching `probeCommand`: a toolchain
+ * appearing mid-session is not worth re-scanning the filesystem for on every
+ * probe, and the missing-prerequisite message tells the user to restart Limboo.
+ */
+export function augmentedPath(): string {
+  if (cachedPath !== undefined) return cachedPath;
+  const sep = process.platform === 'win32' ? ';' : ':';
+  const existing = (process.env.PATH ?? '').split(sep).filter((p) => p.length > 0);
+  const seen = new Set(existing.map((p) => path.normalize(p)));
+  const extra: string[] = [];
+
+  const add = (dir: string): void => {
+    const normalized = path.normalize(dir);
+    if (seen.has(normalized)) return;
+    try {
+      if (!fs.statSync(normalized).isDirectory()) return;
+    } catch {
+      return; // Not present on this machine — nothing to add.
+    }
+    seen.add(normalized);
+    extra.push(normalized);
+  };
+
+  const home = os.homedir();
+  if (process.platform === 'win32') {
+    const local = process.env.LOCALAPPDATA;
+    const roaming = process.env.APPDATA;
+    if (local) {
+      add(path.join(local, 'pnpm'));
+      add(path.join(local, 'Yarn', 'bin'));
+      add(path.join(local, 'Microsoft', 'WindowsApps'));
+    }
+    if (roaming) add(path.join(roaming, 'npm'));
+    add(path.join(home, '.bun', 'bin'));
+    add(path.join(home, '.cargo', 'bin'));
+  } else {
+    for (const rel of HOME_BIN_DIRS) add(path.join(home, rel));
+    // nvm keeps one bin dir per installed Node; take the newest by name so a
+    // `node`/`npm`/`corepack` installed that way is discoverable.
+    addNewestNvmBin(home, add);
+    for (const dir of SYSTEM_BIN_DIRS) add(dir);
+  }
+
+  cachedPath = [...extra, ...existing].join(sep);
+  return cachedPath;
+}
+
+/** Append nvm's newest `versions/node/<v>/bin`, when nvm is installed. */
+function addNewestNvmBin(home: string, add: (dir: string) => void): void {
+  const root = path.join(process.env.NVM_DIR || path.join(home, '.nvm'), 'versions', 'node');
+  let versions: string[];
+  try {
+    versions = fs.readdirSync(root);
+  } catch {
+    return;
+  }
+  // Numeric-aware descending sort, so v20 beats v9 and v10.10 beats v10.9.
+  const newest = versions
+    .filter((v) => /^v\d+\.\d+\.\d+/.test(v))
+    .sort((a, b) => compareVersions(b, a))[0];
+  if (newest) add(path.join(root, newest, 'bin'));
+}
+
+function compareVersions(a: string, b: string): number {
+  const pa = a.slice(1).split('.').map(Number);
+  const pb = b.slice(1).split('.').map(Number);
+  for (let i = 0; i < 3; i += 1) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -283,9 +283,14 @@ const servicesApi = {
 
 const agentApi = {
   getInstall: (): Promise<AgentInstall> => ipcRenderer.invoke(IpcChannels.agentGetInstall),
-  /** The active harness's setup plan, for the one-time consent surface. */
-  harnessBootstrapPlan: (): Promise<HarnessBootstrapInfo> =>
-    ipcRenderer.invoke(IpcChannels.agentHarnessBootstrapPlan),
+  /**
+   * A harness's setup plan, for the one-time consent surface.
+   *
+   * Pass the harness the surface is describing; omit it only when you genuinely
+   * mean whichever harness is currently selected.
+   */
+  harnessBootstrapPlan: (harnessId?: string): Promise<HarnessBootstrapInfo> =>
+    ipcRenderer.invoke(IpcChannels.agentHarnessBootstrapPlan, harnessId),
   getState: (): Promise<AgentState> => ipcRenderer.invoke(IpcChannels.agentGetState),
   getSnapshot: (sessionId: string): Promise<AgentSessionSnapshot> =>
     ipcRenderer.invoke(IpcChannels.agentGetSnapshot, sessionId),

--- a/src/renderer/features/settings/panels/ClaudeCodeControls.tsx
+++ b/src/renderer/features/settings/panels/ClaudeCodeControls.tsx
@@ -11,11 +11,23 @@
  * consent surface that shows something other than what will run is worse than
  * no consent surface. Approving stores a fingerprint of those exact commands,
  * so an adapter upgrade that changes them asks again.
+ *
+ * EVERY BRANCH BELOW MAKES A DIFFERENT CLAIM, and they used to be one. The
+ * "installs nothing" line was the else-leg of a single ternary, so it also
+ * rendered for a request still in flight, a rejected IPC, a different harness
+ * being selected, and an adapter that threw while describing itself — the last
+ * of which shipped, and printed "This harness needs no setup step." directly
+ * under a paragraph describing the setup step. Keep the states apart.
  */
 import { useEffect, useState } from 'react';
 import type { HarnessBootstrapInfo } from '@shared/types';
 import { useSettingsStore } from '@/renderer/stores/useSettingsStore';
 import { ActionButton, Field, StackedField, Toggle } from '../controls';
+
+/** The harness this card describes. Never the globally-selected one. */
+const HARNESS_ID = 'claude-code';
+
+type LoadState = 'idle' | 'loading' | 'ready' | 'failed';
 
 export function ClaudeCodeControls() {
   const harness = useSettingsStore((s) => s.settings.agent.harness);
@@ -24,15 +36,31 @@ export function ClaudeCodeControls() {
     void update({ agent: { harness: { [key]: value } } });
 
   const [info, setInfo] = useState<HarnessBootstrapInfo | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [state, setState] = useState<LoadState>('idle');
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   const load = async (): Promise<void> => {
-    setLoading(true);
+    setState('loading');
+    setLoadError(null);
     try {
-      const next = await window.limboo?.agent?.harnessBootstrapPlan?.();
+      const call = window.limboo?.agent?.harnessBootstrapPlan;
+      if (!call) {
+        // No bridge (a plain browser preview, or a preload that failed to load).
+        // Emphatically not "this harness installs nothing".
+        setInfo(null);
+        setLoadError('The app bridge is unavailable, so the setup step cannot be read.');
+        setState('failed');
+        return;
+      }
+      const next = await call(HARNESS_ID);
       setInfo(next ?? null);
-    } finally {
-      setLoading(false);
+      setState('ready');
+    } catch (err) {
+      // Without this the rejection was unhandled AND the panel fell through to
+      // the "needs no setup step" line — the worst possible reading of a failure.
+      setInfo(null);
+      setLoadError(err instanceof Error ? err.message : String(err));
+      setState('failed');
     }
   };
 
@@ -42,14 +70,21 @@ export function ClaudeCodeControls() {
   useEffect(() => {
     if (harness.legacyClaudeSdk) {
       setInfo(null);
+      setState('idle');
+      setLoadError(null);
       return;
     }
     void load();
     // Re-reads when the stored ack changes so the state reflects an approval.
-  }, [harness.legacyClaudeSdk, harness.bootstrapAck, harness.id]);
+  }, [harness.legacyClaudeSdk, harness.bootstrapAck]);
 
   const plan = info?.plan ?? null;
   const needsAck = !!plan && !info?.acked;
+  const missing = (info?.prerequisites ?? []).filter((p) => !p.found);
+  const busy = state === 'loading';
+  // `planError` is the adapter failing to describe its setup; `error` is the
+  // adapter failing to load; `loadError` is the IPC itself failing.
+  const failure = info?.planError ?? (info && !info.available ? info.error : null) ?? loadError;
 
   return (
     <div className="flex flex-col gap-1">
@@ -69,17 +104,53 @@ export function ClaudeCodeControls() {
         <StackedField
           id="harnessBootstrap"
           label="One-time setup"
-          hint="Before its first session the harness installs the Claude Code CLI into its own directory beside your worktree — never into your repository. This reaches the npm registry from this machine, so it needs your approval once. Review the exact commands below."
+          // The hint renders unconditionally (see StackedField), so it must stay
+          // true in every state below. The sentence describing the npm install
+          // belongs to the plan branch, which is the only place that install is
+          // a fact — putting it here is what made the panel contradict itself.
+          hint="What this harness does once, before its first session — read from the adapter itself, never hardcoded here."
         >
-          {info && !info.available ? (
-            <p className="text-[12px] text-danger">
-              {info.error ?? 'The harness adapter could not be loaded.'}
-            </p>
+          {failure ? (
+            <div className="flex flex-col gap-2">
+              <p className="text-[12px] leading-relaxed text-danger">
+                {info?.planError
+                  ? 'This harness has a setup step but could not describe it, so runs are refused ' +
+                    'until it can. Approving commands Limboo cannot read is not something it will ' +
+                    'ask you to do.'
+                  : 'The harness adapter could not be loaded.'}
+              </p>
+              <p className="break-words font-mono text-[11px] leading-relaxed text-faint">
+                {failure}
+              </p>
+              <div>
+                <ActionButton label={busy ? 'Checking…' : 'Retry'} onClick={() => void load()} />
+              </div>
+            </div>
           ) : plan ? (
             <div className="flex flex-col gap-2">
+              <p className="text-[11px] leading-relaxed text-faint">
+                Before its first session the harness installs the Claude Code CLI into its own
+                directory beside your worktree — never into your repository. This reaches the npm
+                registry from this machine, so it needs your approval once. These are the exact
+                commands that will run.
+              </p>
               <pre className="overflow-x-auto whitespace-pre-wrap break-all rounded-md border border-line bg-surface-2 px-2 py-1.5 font-mono text-[11px] leading-relaxed text-fg">
                 {plan.commands.join('\n\n')}
               </pre>
+              {missing.length > 0 && (
+                <div className="flex flex-col gap-1 rounded-md border border-line bg-surface-2 px-2 py-1.5">
+                  {missing.map((p) => (
+                    <p key={p.tool} className="text-[11px] leading-relaxed text-warning">
+                      <span className="font-mono">{p.tool}</span> is not installed or not on PATH.{' '}
+                      <span className="text-faint">{p.hint}</span>
+                    </p>
+                  ))}
+                  <p className="text-[11px] leading-relaxed text-faint">
+                    You can still approve these commands — approval is consent, not capability —
+                    but the run will be refused until the tool is present.
+                  </p>
+                </div>
+              )}
               <div className="flex items-center gap-1.5">
                 {needsAck ? (
                   <ActionButton
@@ -93,7 +164,7 @@ export function ClaudeCodeControls() {
                     <ActionButton label="Revoke" danger onClick={() => set('bootstrapAck', '')} />
                   </>
                 )}
-                <ActionButton label={loading ? 'Checking…' : 'Recheck'} onClick={() => void load()} />
+                <ActionButton label={busy ? 'Checking…' : 'Recheck'} onClick={() => void load()} />
               </div>
               {needsAck && harness.bootstrapAck !== '' && (
                 <p className="text-[11px] text-warning">
@@ -103,7 +174,9 @@ export function ClaudeCodeControls() {
             </div>
           ) : (
             <p className="text-[12px] text-faint">
-              {loading ? 'Checking…' : 'This harness needs no setup step.'}
+              {state === 'ready'
+                ? 'This harness installs nothing — there is nothing to approve.'
+                : 'Reading the adapter’s setup step…'}
             </p>
           )}
         </StackedField>

--- a/src/renderer/features/workspace/WorkspaceRemoveDialog.tsx
+++ b/src/renderer/features/workspace/WorkspaceRemoveDialog.tsx
@@ -8,11 +8,12 @@
  * Matches the app modal idiom (centered overlay, `bg-elevated`, pop-in). Dark
  * only — no theme toggle, no gradients.
  */
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { AlertTriangle, X } from 'lucide-react';
 import type { Workspace } from '@shared/types';
 import { WorkspaceIconBadge } from './WorkspaceIconBadge';
 import { useWorkspaceStore } from '@/renderer/stores/useWorkspaceStore';
+import { useUIStore } from '@/renderer/stores/useUIStore';
 
 export function WorkspaceRemoveDialog({
   workspace,
@@ -22,25 +23,44 @@ export function WorkspaceRemoveDialog({
   onClose: () => void;
 }) {
   const remove = useWorkspaceStore((s) => s.remove);
+  const addToast = useUIStore((s) => s.addToast);
+  // Removal is genuinely slow now: it tears down each session's worktree,
+  // services and PTYs before touching the database. Without a pending state the
+  // dialog looks frozen and invites a second click on a destructive action.
+  const [removing, setRemoving] = useState(false);
 
-  // Close on Escape for keyboard parity with the rest of the app.
+  // Close on Escape for keyboard parity with the rest of the app — but not
+  // mid-removal, when there is nothing to cancel.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape' && !removing) onClose();
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [onClose]);
+  }, [onClose, removing]);
 
   const confirm = async () => {
-    await remove(workspace.id);
-    onClose();
+    if (removing) return;
+    setRemoving(true);
+    try {
+      await remove(workspace.id);
+      onClose();
+    } catch (err) {
+      setRemoving(false);
+      addToast({
+        title: 'Could not remove workspace',
+        description: err instanceof Error ? err.message : String(err),
+        tone: 'danger',
+      });
+    }
   };
 
   return (
     <div
       className="animate-fade-in fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-6"
-      onMouseDown={onClose}
+      onMouseDown={() => {
+        if (!removing) onClose();
+      }}
     >
       <div
         className="animate-pop-in flex w-full max-w-md flex-col overflow-hidden rounded-md border border-line-strong bg-elevated shadow-2xl"
@@ -84,16 +104,18 @@ export function WorkspaceRemoveDialog({
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md border border-line bg-surface-2 px-3 py-1.5 text-[12px] font-medium text-fg transition-colors hover:border-line-strong"
+            disabled={removing}
+            className="rounded-md border border-line bg-surface-2 px-3 py-1.5 text-[12px] font-medium text-fg transition-colors hover:border-line-strong disabled:opacity-40"
           >
             Cancel
           </button>
           <button
             type="button"
             onClick={confirm}
-            className="rounded-md bg-danger px-3 py-1.5 text-[12px] font-semibold text-base transition-opacity hover:opacity-90"
+            disabled={removing}
+            className="rounded-md bg-danger px-3 py-1.5 text-[12px] font-semibold text-base transition-opacity hover:opacity-90 disabled:opacity-60"
           >
-            Remove from Limboo
+            {removing ? 'Removing…' : 'Remove from Limboo'}
           </button>
         </div>
       </div>

--- a/src/renderer/features/workspace/WorkspaceSwitcher.tsx
+++ b/src/renderer/features/workspace/WorkspaceSwitcher.tsx
@@ -1,13 +1,32 @@
 /**
- * Workspace switcher in the title bar. Shows the active workspace (icon + name +
- * branch) and, on click, a dropdown to switch to another registered workspace or
- * open/create one. Replaces the old static session context pill.
+ * Workspace switcher in the title bar. Shows the active workspace (name +
+ * branch) and, on click, a dropdown to switch to another registered workspace,
+ * open/create one, or remove one. Replaces the old static session context pill.
+ *
+ * NO ICON BADGE ON THE TRIGGER. The title bar shows the workspace NAME; the
+ * initials chip in front of it said the same thing twice in less legible form.
+ * `WorkspaceIconBadge` still earns its place in the launcher and the remove
+ * dialog, where a workspace has to be picked out of a set at a glance.
+ *
+ * Removal lives here because it lived ONLY in `WorkspaceLauncher`, which renders
+ * only while no workspace is active — so once you opened one, there was no route
+ * to removing any workspace at all.
  */
 import { useEffect, useRef, useState } from 'react';
-import { ChevronDown, FolderOpen, FolderPlus, GitBranch, Boxes, Check, RefreshCw } from 'lucide-react';
+import {
+  ChevronDown,
+  FolderOpen,
+  FolderPlus,
+  GitBranch,
+  Boxes,
+  Check,
+  RefreshCw,
+  Trash2,
+} from 'lucide-react';
 import { useWorkspaceStore } from '@/renderer/stores/useWorkspaceStore';
 import { useUIStore } from '@/renderer/stores/useUIStore';
-import { WorkspaceIconBadge } from './WorkspaceIconBadge';
+import { IconButton } from '@/renderer/components/ui';
+import { WorkspaceRemoveDialog } from './WorkspaceRemoveDialog';
 import type { Workspace } from '@shared/types';
 
 export function WorkspaceSwitcher() {
@@ -22,6 +41,9 @@ export function WorkspaceSwitcher() {
 
   const active = workspaces.find((w) => w.id === activeId) ?? null;
   const [openMenu, setOpenMenu] = useState(false);
+  // Held ABOVE the `openMenu` conditional on purpose: the menu unmounts as soon
+  // as it closes, and the dialog has to outlive it.
+  const [pendingRemove, setPendingRemove] = useState<Workspace | null>(null);
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -29,9 +51,23 @@ export function WorkspaceSwitcher() {
     const onDown = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) setOpenMenu(false);
     };
+    // Escape closes the menu, matching SessionRowMenu — a menu you can only
+    // dismiss with the mouse is not dismissable from the keyboard at all.
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpenMenu(false);
+    };
     window.addEventListener('mousedown', onDown);
-    return () => window.removeEventListener('mousedown', onDown);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('mousedown', onDown);
+      window.removeEventListener('keydown', onKey);
+    };
   }, [openMenu]);
+
+  const requestRemove = (ws: Workspace) => {
+    setOpenMenu(false);
+    setPendingRemove(ws);
+  };
 
   const pickAnd = async (action: (path: string) => Promise<Workspace | null>) => {
     setOpenMenu(false);
@@ -71,7 +107,6 @@ export function WorkspaceSwitcher() {
       >
         {active ? (
           <>
-            <WorkspaceIconBadge icon={active.icon} size={16} />
             <span className="max-w-[12rem] truncate font-medium text-fg">{active.name}</span>
             {active.metadata.branch && (
               <>
@@ -95,19 +130,34 @@ export function WorkspaceSwitcher() {
           {workspaces.length > 0 ? (
             <ul className="max-h-72 overflow-y-auto">
               {workspaces.map((ws) => (
-                <li key={ws.id}>
+                // A row, not a button: the switch target and the remove control
+                // are siblings, because a <button> inside a <button> is invalid
+                // HTML and the nested one never receives the click.
+                <li
+                  key={ws.id}
+                  className="group flex items-center gap-1 rounded-md pr-1 transition-colors hover:bg-surface-2"
+                >
                   <button
                     type="button"
                     onClick={() => {
                       setOpenMenu(false);
                       if (ws.id !== activeId) void switchTo(ws.id);
                     }}
-                    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12px] text-muted transition-colors hover:bg-surface-2 hover:text-fg"
+                    className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12px] text-muted transition-colors hover:text-fg"
                   >
-                    <WorkspaceIconBadge icon={ws.icon} size={20} />
                     <span className="min-w-0 flex-1 truncate text-fg">{ws.name}</span>
                     {ws.id === activeId && <Check size={13} className="text-accent" />}
                   </button>
+                  {/* Revealed by hover AND focus — a control reachable only by
+                      mouse is not reachable. */}
+                  <IconButton
+                    size="sm"
+                    label={`Remove ${ws.name} from Limboo`}
+                    className="opacity-0 transition-opacity hover:text-danger focus-visible:opacity-100 group-hover:opacity-100"
+                    onClick={() => requestRemove(ws)}
+                  >
+                    <Trash2 size={13} />
+                  </IconButton>
                 </li>
               ))}
             </ul>
@@ -148,7 +198,28 @@ export function WorkspaceSwitcher() {
             <FolderPlus size={14} />
             Create workspace…
           </button>
+          {active && (
+            <>
+              <div className="my-1 border-t border-line" />
+              {/* The keyboard route to the same action as the per-row trash. */}
+              <button
+                type="button"
+                onClick={() => requestRemove(active)}
+                className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-[12px] text-danger transition-colors hover:bg-surface-2"
+              >
+                <Trash2 size={14} />
+                Remove {active.name}…
+              </button>
+            </>
+          )}
         </div>
+      )}
+
+      {pendingRemove && (
+        <WorkspaceRemoveDialog
+          workspace={pendingRemove}
+          onClose={() => setPendingRemove(null)}
+        />
       )}
     </div>
   );

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -66,7 +66,7 @@ export const AGENT_MODELS = [
   // Pi publishes no discoverable default model id, so rather than invent one
   // this selects "whatever the adapter picks" — see HARNESS_DEFAULT_MODEL_SUFFIX.
   { value: 'pi:default', label: 'Pi (default model)', provider: 'pi' },
-  // NO CODEX MODEL, deliberately. `@ai-sdk/harness-codex@1.0.67` declares
+  // NO CODEX MODEL, deliberately. `@ai-sdk/harness-codex@1.0.79` declares
   // `supportsBuiltinToolApprovals: false`, so its `bash` tool cannot be routed
   // through Limboo's permission gate and the harness is refused at preflight.
   // A picker entry that can only ever fail is worse than an absent one. The

--- a/src/shared/releaseManifest.generated.ts
+++ b/src/shared/releaseManifest.generated.ts
@@ -24,6 +24,91 @@ import type { ReleaseIndexEntry, ReleaseManifestEntry } from './release';
 /** Newest first. */
 export const RELEASE_MANIFESTS: ReleaseManifestEntry[] = [
   {
+    "version": "1.19.0",
+    "date": "2026-08-30",
+    "channel": "stable",
+    "codename": null,
+    "gitTag": "v1.19.0",
+    "commit": null,
+    "buildNumber": null,
+    "summary": "Limboo 1.19.0 repairs the agent harness, which could not install itself in any\npackaged build, and gives workspaces a way out of the app.",
+    "sections": [
+      {
+        "category": "fixed",
+        "title": "Fixed",
+        "items": [
+          {
+            "lead": "The harness could never complete its one-time setup",
+            "text": "Packaging stripped\n  every `pnpm-lock.yaml` in the tree — a rule meant for the project's own\n  lockfile that also removed one the harness adapter reads at runtime. Without\n  it the adapter could not describe its setup step, so runs died with\n  `ENOENT … not found in app.asar` and Settings reported the harness needed no\n  setup at all. The adapters' bridge assets now ship, and the project's own\n  lockfiles are still excluded."
+          },
+          {
+            "lead": "A harness that could not describe its setup ran anyway, ungated",
+            "text": "\"This\n  adapter installs nothing\" and \"this adapter could not say what it installs\"\n  were the same value internally, and the second silently skipped the approval\n  gate, the sandbox network check and the prerequisite check along with it. They\n  are now different states: the run is refused, and Settings says why instead of\n  claiming there is nothing to approve."
+          },
+          {
+            "lead": "The setup panel contradicted itself",
+            "text": "It described an install that needed\n  your approval and, immediately below, said no setup was needed. Five different\n  conditions — including a request still in flight and an outright failure —\n  collapsed into that one sentence. Each now reports itself, and a failed request\n  no longer reads as an absence of work."
+          },
+          {
+            "lead": "Removing a workspace left almost everything behind",
+            "text": "Only the workspace's\n  own record was deleted; its sessions, memories, search index, checkpoints,\n  work-graph nodes and MCP entries stayed in the database permanently, since a\n  re-added folder is issued a new id and can never reclaim them. Removal now\n  clears all of it in one transaction, after tearing down each session's\n  worktree, services and terminals — which is what the confirmation dialog had\n  been promising all along. Global, non-workspace data is untouched."
+          }
+        ],
+        "markdown": "- **The harness could never complete its one-time setup.** Packaging stripped\n  every `pnpm-lock.yaml` in the tree — a rule meant for the project's own\n  lockfile that also removed one the harness adapter reads at runtime. Without\n  it the adapter could not describe its setup step, so runs died with\n  `ENOENT … not found in app.asar` and Settings reported the harness needed no\n  setup at all. The adapters' bridge assets now ship, and the project's own\n  lockfiles are still excluded.\n- **A harness that could not describe its setup ran anyway, ungated.** \"This\n  adapter installs nothing\" and \"this adapter could not say what it installs\"\n  were the same value internally, and the second silently skipped the approval\n  gate, the sandbox network check and the prerequisite check along with it. They\n  are now different states: the run is refused, and Settings says why instead of\n  claiming there is nothing to approve.\n- **The setup panel contradicted itself.** It described an install that needed\n  your approval and, immediately below, said no setup was needed. Five different\n  conditions — including a request still in flight and an outright failure —\n  collapsed into that one sentence. Each now reports itself, and a failed request\n  no longer reads as an absence of work.\n- **Removing a workspace left almost everything behind.** Only the workspace's\n  own record was deleted; its sessions, memories, search index, checkpoints,\n  work-graph nodes and MCP entries stayed in the database permanently, since a\n  re-added folder is issued a new id and can never reclaim them. Removal now\n  clears all of it in one transaction, after tearing down each session's\n  worktree, services and terminals — which is what the confirmation dialog had\n  been promising all along. Global, non-workspace data is untouched."
+      },
+      {
+        "category": "added",
+        "title": "Added",
+        "items": [
+          {
+            "lead": "Workspaces can be removed from the title-bar switcher",
+            "text": "Removal existed only\n  in the launcher, which appears when no workspace is open — so once you opened\n  one there was no way to remove any. Each row in the dropdown now has a remove\n  control, with the same confirmation dialog and the same guarantee that your\n  project folder on disk is never touched."
+          },
+          {
+            "lead": "Missing setup prerequisites are named before you approve, not after a run\n  fails",
+            "text": "The check also stopped assuming pnpm: it reads whichever tools the\n  adapter's own commands invoke, so an adapter that bootstraps with yarn, bun or\n  corepack is checked just as precisely. Limboo still never substitutes one tool\n  for another — the commands you approve are the commands that run."
+          },
+          {
+            "lead": "Tools installed in a user directory are found again",
+            "text": "An app started from a\n  desktop launcher inherits a much smaller `PATH` than a shell, so an installed\n  pnpm, bun or nvm-managed Node could be reported missing. Setup now also looks\n  where those install themselves."
+          }
+        ],
+        "markdown": "- **Workspaces can be removed from the title-bar switcher.** Removal existed only\n  in the launcher, which appears when no workspace is open — so once you opened\n  one there was no way to remove any. Each row in the dropdown now has a remove\n  control, with the same confirmation dialog and the same guarantee that your\n  project folder on disk is never touched.\n- **Missing setup prerequisites are named before you approve, not after a run\n  fails.** The check also stopped assuming pnpm: it reads whichever tools the\n  adapter's own commands invoke, so an adapter that bootstraps with yarn, bun or\n  corepack is checked just as precisely. Limboo still never substitutes one tool\n  for another — the commands you approve are the commands that run.\n- **Tools installed in a user directory are found again.** An app started from a\n  desktop launcher inherits a much smaller `PATH` than a shell, so an installed\n  pnpm, bun or nvm-managed Node could be reported missing. Setup now also looks\n  where those install themselves."
+      },
+      {
+        "category": "changed",
+        "title": "Changed",
+        "items": [
+          {
+            "lead": "The title bar shows the workspace name alone",
+            "text": "The initials badge in front\n  of it repeated what the name already said. It remains in the launcher and the\n  remove dialog, where a workspace has to be picked out of a set at a glance."
+          }
+        ],
+        "markdown": "- **The title bar shows the workspace name alone.** The initials badge in front\n  of it repeated what the name already said. It remains in the launcher and the\n  remove dialog, where a workspace has to be picked out of a set at a glance."
+      }
+    ],
+    "contributors": [],
+    "pullRequests": [],
+    "mergedBranches": [],
+    "assets": [],
+    "signing": [],
+    "stats": {
+      "commits": null,
+      "filesChanged": null,
+      "additions": null,
+      "deletions": null
+    },
+    "links": {
+      "release": "https://github.com/limboo-ai/limboo/releases/tag/v1.19.0",
+      "compare": null,
+      "tag": "https://github.com/limboo-ai/limboo/releases/tag/v1.19.0",
+      "milestone": null
+    },
+    "checksumManifest": "SHA256SUMS",
+    "provenanceRepo": "limboo-ai/limboo",
+    "markdown": "Limboo 1.19.0 repairs the agent harness, which could not install itself in any\npackaged build, and gives workspaces a way out of the app.\n\n### Fixed\n\n- **The harness could never complete its one-time setup.** Packaging stripped\n  every `pnpm-lock.yaml` in the tree — a rule meant for the project's own\n  lockfile that also removed one the harness adapter reads at runtime. Without\n  it the adapter could not describe its setup step, so runs died with\n  `ENOENT … not found in app.asar` and Settings reported the harness needed no\n  setup at all. The adapters' bridge assets now ship, and the project's own\n  lockfiles are still excluded.\n- **A harness that could not describe its setup ran anyway, ungated.** \"This\n  adapter installs nothing\" and \"this adapter could not say what it installs\"\n  were the same value internally, and the second silently skipped the approval\n  gate, the sandbox network check and the prerequisite check along with it. They\n  are now different states: the run is refused, and Settings says why instead of\n  claiming there is nothing to approve.\n- **The setup panel contradicted itself.** It described an install that needed\n  your approval and, immediately below, said no setup was needed. Five different\n  conditions — including a request still in flight and an outright failure —\n  collapsed into that one sentence. Each now reports itself, and a failed request\n  no longer reads as an absence of work.\n- **Removing a workspace left almost everything behind.** Only the workspace's\n  own record was deleted; its sessions, memories, search index, checkpoints,\n  work-graph nodes and MCP entries stayed in the database permanently, since a\n  re-added folder is issued a new id and can never reclaim them. Removal now\n  clears all of it in one transaction, after tearing down each session's\n  worktree, services and terminals — which is what the confirmation dialog had\n  been promising all along. Global, non-workspace data is untouched.\n\n### Added\n\n- **Workspaces can be removed from the title-bar switcher.** Removal existed only\n  in the launcher, which appears when no workspace is open — so once you opened\n  one there was no way to remove any. Each row in the dropdown now has a remove\n  control, with the same confirmation dialog and the same guarantee that your\n  project folder on disk is never touched.\n- **Missing setup prerequisites are named before you approve, not after a run\n  fails.** The check also stopped assuming pnpm: it reads whichever tools the\n  adapter's own commands invoke, so an adapter that bootstraps with yarn, bun or\n  corepack is checked just as precisely. Limboo still never substitutes one tool\n  for another — the commands you approve are the commands that run.\n- **Tools installed in a user directory are found again.** An app started from a\n  desktop launcher inherits a much smaller `PATH` than a shell, so an installed\n  pnpm, bun or nvm-managed Node could be reported missing. Setup now also looks\n  where those install themselves.\n\n### Changed\n\n- **The title bar shows the workspace name alone.** The initials badge in front\n  of it repeated what the name already said. It remains in the launcher and the\n  remove dialog, where a workspace has to be picked out of a set at a glance."
+  },
+  {
     "version": "1.18.2",
     "date": "2026-08-13",
     "channel": "stable",
@@ -422,136 +507,18 @@ export const RELEASE_MANIFESTS: ReleaseManifestEntry[] = [
     "checksumManifest": "SHA256SUMS",
     "provenanceRepo": "limboo-ai/limboo",
     "markdown": "The first beta. Two bugs that made Cursor sessions unusable are fixed, agents can\nnow run through a swappable harness layer instead of one hardcoded integration,\nand Settings opens as a workspace tab. This build is published for testing ahead\nof a stable release — read the warning at the top of these notes before\ninstalling it over a working copy.\n\n### Fixed\n\n- **Cursor sessions denied every tool call.** The hook runner read the event name\n  from a single payload key that the CLI does not always send. With no event name\n  it could not identify what was being asked, so it failed closed — which is the\n  correct posture, but it meant every read, search, shell command and edit was\n  refused, and nothing on screen said why. The event name now travels in the\n  runner's own arguments, where Limboo writes it, with five payload spellings as\n  fallbacks, and a genuine failure now names the missing key in the timeline\n  instead of denying silently.\n- **Four more ways a Cursor run could stall.** The permission helper could boot as\n  a GUI process instead of a script and then hang for the full ten-minute hook\n  timeout on every single tool call; nothing timed out while it waited for input;\n  a successful approval could be truncated on its way out and be read as a\n  refusal; and the sandbox denied the helper access to its own communication\n  socket. Each is fixed, and each failure now reports what happened.\n- **\"Prompt me for everything\" meant \"deny everything\".** Tightening the approval\n  policy withdrew the rule that let Cursor read files at all. Because the only way\n  to ask for permission on that path is the hook bridge, a session with hooks\n  unavailable was left unable to read or to ask. Reads and inspection commands\n  now keep their floor regardless of the policy; the permission gate still runs\n  on top of it.\n- **A Cursor session could stream as Claude Code.** The model was checked for\n  character shape rather than for which provider serves it, and every Cursor\n  model id passes that check — so a mis-routed model was handed to the Claude\n  integration and ran there, with no error anywhere. Routing now has an explicit\n  \"unknown\" answer, dispatch is exhaustive, and a model nothing claims fails by\n  name instead of quietly running somewhere.\n- **Commit-message generation always used Claude.** A Cursor-only user pressing\n  the button started a Claude run and, with Claude not installed, was told to sign\n  in to a product they were not using. It now follows the agent you selected, and\n  the button is no longer disabled for Cursor users.\n- **Searching Settings missed several controls.** Some settings were never\n  registered in the search index, so typing their name found nothing. Fixed for\n  the Agent and Runtime categories, with a check that fails the build if it\n  happens again.\n- **Absolute paths inside your project were treated as escapes.** Cursor's CLI\n  writes full paths by default, and a full path to a file inside your own worktree\n  was classified as leaving it — so ordinary reads were refused during planning.\n\n### Added\n\n- **Agents can run through a harness layer.** Limboo now drives agents through\n  Vercel AI SDK 7's harness abstraction as well as its own integrations, so a new\n  agent runtime becomes an adapter rather than a new code path. Pi is available;\n  Claude Code runs through it behind an opt-in switch. Everything above the\n  adapter — the conversation, permissions, memory, search, the work graph, the\n  runtime panel — is unchanged, because they all sit on one seam.\n- **A sandbox that runs on your own worktree.** Every shipped sandbox for that\n  abstraction is either a cloud service or a private filesystem, and neither\n  fits: your repository must not leave the machine, and the agent has to edit the\n  actual files that git, the diff viewer and checkpoints are watching. Limboo has\n  its own, rooted at the session's worktree, with the same containment rules the\n  rest of the app enforces — nothing outside the worktree, and never the app's own\n  database, settings or secrets.\n- **Settings opens as a workspace tab.** An icon beside the close button promotes\n  the dialog into an editor tab, the way a diff opens. Both surfaces render the\n  same panels, so nothing drifts. The tab has no Cancel: settings apply as you\n  change them, exactly as they already did.\n- **An update channel you can choose.** Settings › Updates now offers Stable or\n  Beta. A beta is never downloaded in the background — you are shown its release\n  notes and decide.\n\n### Changed\n\n- **Settings panels are flat rows.** The Agent and MCP categories wrapped groups\n  of settings in bordered panels while every other category used plain labelled\n  rows, which made them look like a different application. The boxes are gone.\n  Every input, button and select now uses one corner radius.\n- **The Agent panel is reorganised.** Providers became Harnesses and now reads as\n  one list instead of two hand-built cards. Connection and reliability moved to\n  Runtime, where the rest of the supervision settings live. A section that\n  contained no settings at all was removed, and the remainder is ordered by the\n  decision you are making: which agent, which model, what it may do, what\n  contains it.\n- **The model hint stopped being wrong.** It named a default the app had not used\n  for several versions, because the text was typed by hand next to the value it\n  described. It is now derived from that value.\n\n### Security\n\n- **Built-in tools on the harness path are gated by Limboo.** The harness\n  abstraction has two separate approval surfaces, and the one Limboo had wired\n  covers only tools the host supplies — built-in file writes and shell commands\n  are governed by a different setting that defaults to allowing everything. On\n  that path an agent could have written files and run commands without Limboo's\n  permission gate. Every built-in tool call now suspends the turn and asks, using\n  the same authority, the same risk labels, the same dialogs and the same audit\n  trail as every other agent.\n- **A harness that cannot ask for permission is refused.** Rather than run it with\n  weaker enforcement, Limboo declines to start it and says so. This is not\n  theoretical: the Codex adapter reports that it cannot request approval for its\n  shell tool, so it is registered as unavailable with the reason shown rather than\n  offered and then failing.\n- **The harness setup step asks first.** Preparing a harness for its first run\n  downloads its agent CLI, which is the only time Limboo reaches the network\n  outside talking to your agent and fetching contributor avatars. The exact\n  commands are read from the adapter and shown to you for approval once, and the\n  approval is tied to those commands — if a later version changes them, you are\n  asked again. Without approval the run does not start.\n- **Credentials are passed through, never stored.** A harness receives an API key\n  only if your own environment already has one, from an explicitly named list.\n  Nothing is written to settings, accepted over the app's internal channels, put\n  on a command line, or logged. A gap in log redaction that could have printed\n  those variables is closed.\n- **Reads on the harness path cannot be gated, and the setting says so.** The\n  underlying runtime allows built-in file reads unconditionally, so\n  \"auto-approve reads\" has no effect there. Rather than leave a control that looks\n  like it works, the setting explains the limitation.\n\n### Known limitations\n\n- **Beta builds are not released builds.** Features may change or be removed\n  before release. Settings and session data move forward but not back, so a build\n  made after this one may not read data this one wrote. Keep a stable install for\n  work you cannot repeat.\n- **The harness path is off by default.** Claude Code and Cursor continue to run\n  through their own integrations. Turn the harness on in Settings › Agent ›\n  Harnesses if you want to try it; you will be asked to approve its setup step\n  first.\n- **A harness conversation does not resume.** Each message starts a fresh\n  conversation with the underlying runtime. The alternative failed on every second\n  message, so this is deliberate until the resume format is handled properly.\n- **Codex is unavailable.** Its adapter cannot ask for permission before running\n  shell commands. It is listed with that reason rather than hidden."
-  },
-  {
-    "version": "1.17.0",
-    "date": "2026-08-01",
-    "channel": "stable",
-    "codename": null,
-    "gitTag": "v1.17.0",
-    "commit": null,
-    "buildNumber": null,
-    "summary": "Plan Mode now stops. A plan waits for your decision instead of sliding into\nimplementation, and the plan you are shown is the plan the agent actually wrote —\nwhich, until this release, it very often was not. Git also becomes a platform\nservice in its own right, so repository work reads as part of the conversation\nrather than something that happened in a side panel.",
-    "sections": [
-      {
-        "category": "added",
-        "title": "Added",
-        "items": [
-          {
-            "lead": "Plan approval is a real stop, not a prompt",
-            "text": "When the agent presents a plan,\n  execution halts: no further model calls, no new prompts, no background work,\n  and every tool is refused until you decide. Approving continues the same turn\n  rather than starting a new one, so the agent keeps everything it had learned\n  while planning. Approve, Approve & accept edits, Keep planning, Reject and\n  Archive are the only things that move it forward."
-          },
-          {
-            "lead": "Keep planning now sends feedback",
-            "text": "Instead of discarding the plan and\n  starting over, it hands your notes to the agent, which revises and presents\n  again — same conversation, same context."
-          },
-          {
-            "lead": "Plans are versioned",
-            "text": "A session has one plan; refinements replace it and the\n  previous text moves into History. Two windows on the same session can no longer\n  approve different plans, and a plan that changed while you were reading it says\n  so rather than acting on the stale copy."
-          },
-          {
-            "lead": "A pending plan survives a restart",
-            "text": "Quit with a plan awaiting approval and it\n  is still there on relaunch, with its buttons live and implementation still\n  locked. Approving after a restart starts a fresh run carrying the plan text,\n  because the paused conversation cannot outlive the process."
-          },
-          {
-            "lead": "Git is a platform service",
-            "text": "Repository actions post structured entries into\n  the conversation carrying the paths, commit and checkpoint behind them, with\n  Open Diff, View Commit, Restore Checkpoint and Copy Command on each."
-          },
-          {
-            "lead": "Optional GitHub CLI integration",
-            "text": "If `gh` is installed and signed in, a\n  GitHub sub-tab lists pull requests and issues, and the agent can read them\n  through the tools it already has. Limboo stores no GitHub credential —\n  authentication stays the CLI's. Posting a comment is gated and shows the exact\n  body first."
-          },
-          {
-            "lead": "Contributor avatars in history",
-            "text": ", fetched in the main process and embedded so\n  no page ever requests a remote image. Behind `git.avatars.enabled`, which is\n  off-limits by default in the sense that turning it on is the thing that tells\n  GitHub which repository you are browsing — the setting says so."
-          }
-        ],
-        "markdown": "- **Plan approval is a real stop, not a prompt.** When the agent presents a plan,\n  execution halts: no further model calls, no new prompts, no background work,\n  and every tool is refused until you decide. Approving continues the same turn\n  rather than starting a new one, so the agent keeps everything it had learned\n  while planning. Approve, Approve & accept edits, Keep planning, Reject and\n  Archive are the only things that move it forward.\n- **Keep planning now sends feedback.** Instead of discarding the plan and\n  starting over, it hands your notes to the agent, which revises and presents\n  again — same conversation, same context.\n- **Plans are versioned.** A session has one plan; refinements replace it and the\n  previous text moves into History. Two windows on the same session can no longer\n  approve different plans, and a plan that changed while you were reading it says\n  so rather than acting on the stale copy.\n- **A pending plan survives a restart.** Quit with a plan awaiting approval and it\n  is still there on relaunch, with its buttons live and implementation still\n  locked. Approving after a restart starts a fresh run carrying the plan text,\n  because the paused conversation cannot outlive the process.\n- **Git is a platform service.** Repository actions post structured entries into\n  the conversation carrying the paths, commit and checkpoint behind them, with\n  Open Diff, View Commit, Restore Checkpoint and Copy Command on each.\n- **Optional GitHub CLI integration.** If `gh` is installed and signed in, a\n  GitHub sub-tab lists pull requests and issues, and the agent can read them\n  through the tools it already has. Limboo stores no GitHub credential —\n  authentication stays the CLI's. Posting a comment is gated and shows the exact\n  body first.\n- **Contributor avatars in history**, fetched in the main process and embedded so\n  no page ever requests a remote image. Behind `git.avatars.enabled`, which is\n  off-limits by default in the sense that turning it on is the thing that tells\n  GitHub which repository you are browsing — the setting says so."
-      },
-      {
-        "category": "changed",
-        "title": "Changed",
-        "items": [
-          {
-            "lead": "The integrated terminal is its own column",
-            "text": "between the conversation and the\n  drawer, instead of competing for the drawer with Files and Changes."
-          },
-          {
-            "lead": "The Activity and Hooks drawer panels are gone",
-            "text": "The Hook Engine, its audit\n  log and every hook setting are untouched — only the two panels and the IPC they\n  were the sole consumers of were removed."
-          },
-          {
-            "lead": "Switching sessions is now an ordered handover",
-            "text": "Worktree, file watcher, git\n  status, search index, memory scope, MCP and the agent are rebound in sequence,\n  and a thin ribbon says so while it happens. Switching quickly between sessions\n  cancels the stale work rather than letting it finish over the newer session."
-          }
-        ],
-        "markdown": "- **The integrated terminal is its own column** between the conversation and the\n  drawer, instead of competing for the drawer with Files and Changes.\n- **The Activity and Hooks drawer panels are gone.** The Hook Engine, its audit\n  log and every hook setting are untouched — only the two panels and the IPC they\n  were the sole consumers of were removed.\n- **Switching sessions is now an ordered handover.** Worktree, file watcher, git\n  status, search index, memory scope, MCP and the agent are rebound in sequence,\n  and a thin ribbon says so while it happens. Switching quickly between sessions\n  cancels the stale work rather than letting it finish over the newer session."
-      },
-      {
-        "category": "fixed",
-        "title": "Fixed",
-        "items": [
-          {
-            "lead": "The plan you approved was usually empty",
-            "text": "Current Claude releases write the\n  plan to a file and pass no plan text to the tool Limboo was reading, so almost\n  every captured plan was blank — and because the tool was blocked, no plan file\n  was produced either. Approving then sent an empty plan, the agent re-derived\n  the work from scratch, and the empty plan was filed as completed. Limboo now\n  tells the agent where to write its plan and reads it from there, with the\n  agent's own copy taking over once the plan is approved."
-          },
-          {
-            "lead": "Starting a new plan could silently destroy the one you were reviewing",
-            "text": "when\n  plan history was turned off. A pending plan is never discarded without being\n  filed first, and starting a second plan while one awaits approval is refused."
-          },
-          {
-            "lead": "A failed or cancelled planning run reported itself as \"rejected\"",
-            "text": ", which is\n  what the app says when a person declines a plan. Those now read as ended, with\n  the reason recorded, so declining and crashing no longer look identical."
-          },
-          {
-            "lead": "An unrelated prompt could mark a stalled plan complete",
-            "text": "Only the run that\n  was actually released to implement a plan can finish it."
-          },
-          {
-            "lead": "Live planning progress replayed the previous attempt's steps",
-            "text": "after asking\n  for a new plan, because it measured from when the plan first existed rather\n  than when the current attempt started."
-          },
-          {
-            "lead": "Deleting a session left its plan revisions behind",
-            "text": "in the database."
-          },
-          {
-            "lead": "A machine without git looked like a folder without a repository",
-            "text": ", and the app\n  offered to initialise one — an action that could never succeed. Limboo now\n  detects the missing binary and names the install command for your platform."
-          },
-          {
-            "lead": "Settings could be hand-edited into a dead drawer tab or an unbounded panel\n  width",
-            "text": "; both are now validated and clamped on load."
-          }
-        ],
-        "markdown": "- **The plan you approved was usually empty.** Current Claude releases write the\n  plan to a file and pass no plan text to the tool Limboo was reading, so almost\n  every captured plan was blank — and because the tool was blocked, no plan file\n  was produced either. Approving then sent an empty plan, the agent re-derived\n  the work from scratch, and the empty plan was filed as completed. Limboo now\n  tells the agent where to write its plan and reads it from there, with the\n  agent's own copy taking over once the plan is approved.\n- **Starting a new plan could silently destroy the one you were reviewing** when\n  plan history was turned off. A pending plan is never discarded without being\n  filed first, and starting a second plan while one awaits approval is refused.\n- **A failed or cancelled planning run reported itself as \"rejected\"**, which is\n  what the app says when a person declines a plan. Those now read as ended, with\n  the reason recorded, so declining and crashing no longer look identical.\n- **An unrelated prompt could mark a stalled plan complete.** Only the run that\n  was actually released to implement a plan can finish it.\n- **Live planning progress replayed the previous attempt's steps** after asking\n  for a new plan, because it measured from when the plan first existed rather\n  than when the current attempt started.\n- **Deleting a session left its plan revisions behind** in the database.\n- **A machine without git looked like a folder without a repository**, and the app\n  offered to initialise one — an action that could never succeed. Limboo now\n  detects the missing binary and names the install command for your platform.\n- **Settings could be hand-edited into a dead drawer tab or an unbounded panel\n  width**; both are now validated and clamped on load."
-      }
-    ],
-    "contributors": [],
-    "pullRequests": [],
-    "mergedBranches": [],
-    "assets": [],
-    "signing": [],
-    "stats": {
-      "commits": null,
-      "filesChanged": null,
-      "additions": null,
-      "deletions": null
-    },
-    "links": {
-      "release": "https://github.com/limboo-ai/limboo/releases/tag/v1.17.0",
-      "compare": null,
-      "tag": "https://github.com/limboo-ai/limboo/releases/tag/v1.17.0",
-      "milestone": null
-    },
-    "checksumManifest": "SHA256SUMS",
-    "provenanceRepo": "limboo-ai/limboo",
-    "markdown": "Plan Mode now stops. A plan waits for your decision instead of sliding into\nimplementation, and the plan you are shown is the plan the agent actually wrote —\nwhich, until this release, it very often was not. Git also becomes a platform\nservice in its own right, so repository work reads as part of the conversation\nrather than something that happened in a side panel.\n\n### Added\n\n- **Plan approval is a real stop, not a prompt.** When the agent presents a plan,\n  execution halts: no further model calls, no new prompts, no background work,\n  and every tool is refused until you decide. Approving continues the same turn\n  rather than starting a new one, so the agent keeps everything it had learned\n  while planning. Approve, Approve & accept edits, Keep planning, Reject and\n  Archive are the only things that move it forward.\n- **Keep planning now sends feedback.** Instead of discarding the plan and\n  starting over, it hands your notes to the agent, which revises and presents\n  again — same conversation, same context.\n- **Plans are versioned.** A session has one plan; refinements replace it and the\n  previous text moves into History. Two windows on the same session can no longer\n  approve different plans, and a plan that changed while you were reading it says\n  so rather than acting on the stale copy.\n- **A pending plan survives a restart.** Quit with a plan awaiting approval and it\n  is still there on relaunch, with its buttons live and implementation still\n  locked. Approving after a restart starts a fresh run carrying the plan text,\n  because the paused conversation cannot outlive the process.\n- **Git is a platform service.** Repository actions post structured entries into\n  the conversation carrying the paths, commit and checkpoint behind them, with\n  Open Diff, View Commit, Restore Checkpoint and Copy Command on each.\n- **Optional GitHub CLI integration.** If `gh` is installed and signed in, a\n  GitHub sub-tab lists pull requests and issues, and the agent can read them\n  through the tools it already has. Limboo stores no GitHub credential —\n  authentication stays the CLI's. Posting a comment is gated and shows the exact\n  body first.\n- **Contributor avatars in history**, fetched in the main process and embedded so\n  no page ever requests a remote image. Behind `git.avatars.enabled`, which is\n  off-limits by default in the sense that turning it on is the thing that tells\n  GitHub which repository you are browsing — the setting says so.\n\n### Changed\n\n- **The integrated terminal is its own column** between the conversation and the\n  drawer, instead of competing for the drawer with Files and Changes.\n- **The Activity and Hooks drawer panels are gone.** The Hook Engine, its audit\n  log and every hook setting are untouched — only the two panels and the IPC they\n  were the sole consumers of were removed.\n- **Switching sessions is now an ordered handover.** Worktree, file watcher, git\n  status, search index, memory scope, MCP and the agent are rebound in sequence,\n  and a thin ribbon says so while it happens. Switching quickly between sessions\n  cancels the stale work rather than letting it finish over the newer session.\n\n### Fixed\n\n- **The plan you approved was usually empty.** Current Claude releases write the\n  plan to a file and pass no plan text to the tool Limboo was reading, so almost\n  every captured plan was blank — and because the tool was blocked, no plan file\n  was produced either. Approving then sent an empty plan, the agent re-derived\n  the work from scratch, and the empty plan was filed as completed. Limboo now\n  tells the agent where to write its plan and reads it from there, with the\n  agent's own copy taking over once the plan is approved.\n- **Starting a new plan could silently destroy the one you were reviewing** when\n  plan history was turned off. A pending plan is never discarded without being\n  filed first, and starting a second plan while one awaits approval is refused.\n- **A failed or cancelled planning run reported itself as \"rejected\"**, which is\n  what the app says when a person declines a plan. Those now read as ended, with\n  the reason recorded, so declining and crashing no longer look identical.\n- **An unrelated prompt could mark a stalled plan complete.** Only the run that\n  was actually released to implement a plan can finish it.\n- **Live planning progress replayed the previous attempt's steps** after asking\n  for a new plan, because it measured from when the plan first existed rather\n  than when the current attempt started.\n- **Deleting a session left its plan revisions behind** in the database.\n- **A machine without git looked like a folder without a repository**, and the app\n  offered to initialise one — an action that could never succeed. Limboo now\n  detects the missing binary and names the install command for your platform.\n- **Settings could be hand-edited into a dead drawer tab or an unbounded panel\n  width**; both are now validated and clamped on load."
   }
 ];
 
 /** Every released version, newest first. */
 export const RELEASE_INDEX: ReleaseIndexEntry[] = [
+  {
+    "version": "1.19.0",
+    "date": "2026-08-30",
+    "channel": "stable",
+    "summary": "Limboo 1.19.0 repairs the agent harness, which could not install itself in any\npackaged build, and gives workspaces a way out of the app.",
+    "detailed": true
+  },
   {
     "version": "1.18.2",
     "date": "2026-08-13",
@@ -585,7 +552,7 @@ export const RELEASE_INDEX: ReleaseIndexEntry[] = [
     "date": "2026-08-01",
     "channel": "stable",
     "summary": "Plan Mode now stops. A plan waits for your decision instead of sliding into\nimplementation, and the plan you are shown is the plan the agent actually wrote —\nwhich, until this release, it very often was not. Git also becomes a platform\nservice in its own right, so repository work reads as part of the conversation\nrather than something that happened in a side panel.",
-    "detailed": true
+    "detailed": false
   },
   {
     "version": "1.16.0",

--- a/src/shared/releaseNotes.generated.ts
+++ b/src/shared/releaseNotes.generated.ts
@@ -22,6 +22,63 @@ export interface ReleaseNotesEntry {
 /** Newest first. */
 export const RELEASE_NOTES: ReleaseNotesEntry[] = [
   {
+    version: '1.19.0',
+    date: '2026-08-30',
+    markdown: `Limboo 1.19.0 repairs the agent harness, which could not install itself in any
+packaged build, and gives workspaces a way out of the app.
+
+### Fixed
+
+- **The harness could never complete its one-time setup.** Packaging stripped
+  every \`pnpm-lock.yaml\` in the tree — a rule meant for the project's own
+  lockfile that also removed one the harness adapter reads at runtime. Without
+  it the adapter could not describe its setup step, so runs died with
+  \`ENOENT … not found in app.asar\` and Settings reported the harness needed no
+  setup at all. The adapters' bridge assets now ship, and the project's own
+  lockfiles are still excluded.
+- **A harness that could not describe its setup ran anyway, ungated.** "This
+  adapter installs nothing" and "this adapter could not say what it installs"
+  were the same value internally, and the second silently skipped the approval
+  gate, the sandbox network check and the prerequisite check along with it. They
+  are now different states: the run is refused, and Settings says why instead of
+  claiming there is nothing to approve.
+- **The setup panel contradicted itself.** It described an install that needed
+  your approval and, immediately below, said no setup was needed. Five different
+  conditions — including a request still in flight and an outright failure —
+  collapsed into that one sentence. Each now reports itself, and a failed request
+  no longer reads as an absence of work.
+- **Removing a workspace left almost everything behind.** Only the workspace's
+  own record was deleted; its sessions, memories, search index, checkpoints,
+  work-graph nodes and MCP entries stayed in the database permanently, since a
+  re-added folder is issued a new id and can never reclaim them. Removal now
+  clears all of it in one transaction, after tearing down each session's
+  worktree, services and terminals — which is what the confirmation dialog had
+  been promising all along. Global, non-workspace data is untouched.
+
+### Added
+
+- **Workspaces can be removed from the title-bar switcher.** Removal existed only
+  in the launcher, which appears when no workspace is open — so once you opened
+  one there was no way to remove any. Each row in the dropdown now has a remove
+  control, with the same confirmation dialog and the same guarantee that your
+  project folder on disk is never touched.
+- **Missing setup prerequisites are named before you approve, not after a run
+  fails.** The check also stopped assuming pnpm: it reads whichever tools the
+  adapter's own commands invoke, so an adapter that bootstraps with yarn, bun or
+  corepack is checked just as precisely. Limboo still never substitutes one tool
+  for another — the commands you approve are the commands that run.
+- **Tools installed in a user directory are found again.** An app started from a
+  desktop launcher inherits a much smaller \`PATH\` than a shell, so an installed
+  pnpm, bun or nvm-managed Node could be reported missing. Setup now also looks
+  where those install themselves.
+
+### Changed
+
+- **The title bar shows the workspace name alone.** The initials badge in front
+  of it repeated what the name already said. It remains in the launcher and the
+  remove dialog, where a workspace has to be picked out of a set at a glance.`,
+  },
+  {
     version: '1.18.2',
     date: '2026-08-13',
     markdown: `### Fixed
@@ -305,86 +362,6 @@ installing it over a working copy.
   message, so this is deliberate until the resume format is handled properly.
 - **Codex is unavailable.** Its adapter cannot ask for permission before running
   shell commands. It is listed with that reason rather than hidden.`,
-  },
-  {
-    version: '1.17.0',
-    date: '2026-08-01',
-    markdown: `Plan Mode now stops. A plan waits for your decision instead of sliding into
-implementation, and the plan you are shown is the plan the agent actually wrote —
-which, until this release, it very often was not. Git also becomes a platform
-service in its own right, so repository work reads as part of the conversation
-rather than something that happened in a side panel.
-
-### Added
-
-- **Plan approval is a real stop, not a prompt.** When the agent presents a plan,
-  execution halts: no further model calls, no new prompts, no background work,
-  and every tool is refused until you decide. Approving continues the same turn
-  rather than starting a new one, so the agent keeps everything it had learned
-  while planning. Approve, Approve & accept edits, Keep planning, Reject and
-  Archive are the only things that move it forward.
-- **Keep planning now sends feedback.** Instead of discarding the plan and
-  starting over, it hands your notes to the agent, which revises and presents
-  again — same conversation, same context.
-- **Plans are versioned.** A session has one plan; refinements replace it and the
-  previous text moves into History. Two windows on the same session can no longer
-  approve different plans, and a plan that changed while you were reading it says
-  so rather than acting on the stale copy.
-- **A pending plan survives a restart.** Quit with a plan awaiting approval and it
-  is still there on relaunch, with its buttons live and implementation still
-  locked. Approving after a restart starts a fresh run carrying the plan text,
-  because the paused conversation cannot outlive the process.
-- **Git is a platform service.** Repository actions post structured entries into
-  the conversation carrying the paths, commit and checkpoint behind them, with
-  Open Diff, View Commit, Restore Checkpoint and Copy Command on each.
-- **Optional GitHub CLI integration.** If \`gh\` is installed and signed in, a
-  GitHub sub-tab lists pull requests and issues, and the agent can read them
-  through the tools it already has. Limboo stores no GitHub credential —
-  authentication stays the CLI's. Posting a comment is gated and shows the exact
-  body first.
-- **Contributor avatars in history**, fetched in the main process and embedded so
-  no page ever requests a remote image. Behind \`git.avatars.enabled\`, which is
-  off-limits by default in the sense that turning it on is the thing that tells
-  GitHub which repository you are browsing — the setting says so.
-
-### Changed
-
-- **The integrated terminal is its own column** between the conversation and the
-  drawer, instead of competing for the drawer with Files and Changes.
-- **The Activity and Hooks drawer panels are gone.** The Hook Engine, its audit
-  log and every hook setting are untouched — only the two panels and the IPC they
-  were the sole consumers of were removed.
-- **Switching sessions is now an ordered handover.** Worktree, file watcher, git
-  status, search index, memory scope, MCP and the agent are rebound in sequence,
-  and a thin ribbon says so while it happens. Switching quickly between sessions
-  cancels the stale work rather than letting it finish over the newer session.
-
-### Fixed
-
-- **The plan you approved was usually empty.** Current Claude releases write the
-  plan to a file and pass no plan text to the tool Limboo was reading, so almost
-  every captured plan was blank — and because the tool was blocked, no plan file
-  was produced either. Approving then sent an empty plan, the agent re-derived
-  the work from scratch, and the empty plan was filed as completed. Limboo now
-  tells the agent where to write its plan and reads it from there, with the
-  agent's own copy taking over once the plan is approved.
-- **Starting a new plan could silently destroy the one you were reviewing** when
-  plan history was turned off. A pending plan is never discarded without being
-  filed first, and starting a second plan while one awaits approval is refused.
-- **A failed or cancelled planning run reported itself as "rejected"**, which is
-  what the app says when a person declines a plan. Those now read as ended, with
-  the reason recorded, so declining and crashing no longer look identical.
-- **An unrelated prompt could mark a stalled plan complete.** Only the run that
-  was actually released to implement a plan can finish it.
-- **Live planning progress replayed the previous attempt's steps** after asking
-  for a new plan, because it measured from when the plan first existed rather
-  than when the current attempt started.
-- **Deleting a session left its plan revisions behind** in the database.
-- **A machine without git looked like a folder without a repository**, and the app
-  offered to initialise one — an action that could never succeed. Limboo now
-  detects the missing binary and names the install command for your platform.
-- **Settings could be hand-edited into a dead drawer tab or an unbounded panel
-  width**; both are now validated and clamped on load.`,
   },
 ];
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -61,6 +61,21 @@ export interface HarnessBootstrapInfo {
   plan: { commands: string[]; files: string[]; fingerprint: string } | null;
   /** True when the current plan's fingerprint matches the stored approval. */
   acked: boolean;
+  /**
+   * Set when the adapter HAS a setup step but could not describe it.
+   *
+   * A different claim from `plan: null`, and deliberately its own field: the two
+   * used to be the same value, so a broken adapter rendered as "this harness
+   * needs no setup step" while runs silently lost the consent gate.
+   */
+  planError?: string;
+  /**
+   * Per-tool prerequisite status for this plan's commands, in invocation order.
+   *
+   * Tool names and code-supplied remedies only — never a resolved path, which
+   * would leak the home directory into the renderer.
+   */
+  prerequisites?: { tool: string; found: boolean; hint: string }[];
   error?: string;
 }
 


### PR DESCRIPTION
## The bug

Packaging stripped **every** `pnpm-lock.yaml` in the tree. The rule came from electron-packager's `DEFAULT_IGNORES`, where it means *"drop this project's own lockfile"*, but as an unanchored suffix match it also removed `node_modules/@ai-sdk/harness-*/dist/bridge/pnpm-lock.yaml` — a required runtime asset the adapter reads in `getBootstrap()`.

Confirmed in the shipped build: `asar list /opt/Limboo/resources/app.asar | grep pnpm-lock` returns nothing, and the installed app's log carries the consequence:

```
[ERROR] Agent run failed ENOENT,
  node_modules/@ai-sdk/harness-claude-code/bridge/pnpm-lock.yaml
  not found in /opt/Limboo/resources/app.asar
```

## Why it was invisible

`readBootstrapPlan` swallowed the throw and returned `null` — the same value that means *"this adapter installs nothing"*. The `if (plan)` in `HarnessRuntime` then skipped the consent gate, the sandbox network check and the prerequisite probe **together**, so a broken adapter ran with every guard the consent copy promises silently disabled, while Settings reported the harness needed no setup step.

The read is now a three-state outcome (`none` / `plan` / `unreadable`), and `unreadable` refuses the run.

## Also here

- **Prerequisites are derived, not hardcoded.** The old two-entry pnpm+npm table matched by string prefix missed `node` (invoked past a shell conditional) and assumed one package manager. `toolchain.ts` reads the executables out of the plan's own commands. Commands are still never rewritten — the approved string is the executed string, so a missing tool is reported, not worked around.
- **PATH discovery.** A desktop-launched Electron process inherits a much smaller `PATH` than a shell, so an installed pnpm/bun/nvm-node read as missing. Widened for both the probe and the bootstrap child. Discovery only — nothing is installed.
- **Workspace removal** reached the title-bar switcher (it existed only in the launcher, which shows when no workspace is open — so once you opened one, removal was unreachable), and `WorkspaceManager.remove` now actually cascades. It deleted one row and orphaned sessions/memories/search-index/checkpoints permanently, which is what the confirmation dialog had been claiming it cleaned up.

## Verification

- Real `ignore` predicate extracted and evaluated over 14 cases: root lockfiles still stripped, both harness bridge lockfiles now kept.
- Cold-process reproduction of the ENOENT: returns `unreadable`, run refused. Restored: returns `plan`.
- Consent/network/tool assertions each confirmed to refuse and to allow correctly.
- Cascade exercised on a copy of a real 66 MB database: 8,142 orphaned rows cleared for one workspace, other workspaces untouched, global NULL-scope rows preserved, `PRAGMA integrity_check` ok.
- Re-verified against `@ai-sdk/harness-claude-code@1.0.80` / `harness-codex@1.0.79` (node_modules was 13 patches behind the manifest): `BOOTSTRAP_DIR`, the bridge's single `0.0.0.0` bind site and both `supportsBuiltinToolApprovals` flags unchanged. The bootstrap commands themselves changed, which the fingerprint ack correctly re-prompts for.
- `npm run lint`, renderer Vite build, main esbuild bundle, `gen:notes --check` all clean.

**Not verified:** `npm run package` produces no output on this machine — it exits 0 at "Finalizing package" and writes nothing. Reproduced identically with the original `forge.config.ts`, so it predates this change, but it means a freshly built asar was not inspected directly.