### PR TITLE
fix(ci): stop npm ci from source-building better-sqlite3 on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8184,7 +8184,6 @@
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
       "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.0.0"


### PR DESCRIPTION
Fixes the `Package (windows-latest)` failure in the v1.19.0 release run ([33303821610](https://github.com/limboo-ai/limboo/actions/runs/33303821610)), which failed twice — the rerun was deterministic, not a flake.

## Cause

My previous commit's `npm install` restored `hasInstallScript: true` on the `better-sqlite3` lockfile entry. Dependabot had dropped that field when it bumped 12.11.1 → 13.0.3 (#112), and its absence is the only reason `npm ci` had been skipping the package's `install: node-gyp rebuild`.

With the field back, `npm ci` runs node-gyp, and node-gyp fails on the current `windows-latest` image:

```
gyp verb find VS unknown version "undefined" found at
  "C:\Program Files\Microsoft Visual Studio\18\Enterprise"
gyp ERR! find VS could not find a version of Visual Studio 2017 or newer to use
```

The runner ships **Visual Studio 18**, which `@electron/node-gyp@10.2.0` doesn't recognise, so it reports no usable toolchain at all. `windows-11-arm` and all non-Windows legs pass, which is why exactly one job broke.

## This change

Reverts that one lockfile line, restoring the dependency state main already built from. It was an unintended side effect of reinstalling to match the manifest, not part of the change it rode in on.

## Known trap, deliberately left standing

The field is *accurate* — better-sqlite3 really does have an install script — so the next `npm install` anyone runs will re-add it and break Windows again. The durable fix is for packaging to stop needing a compiler for better-sqlite3 (it ships prebuilds), the way node-pty is already excluded from `@electron/rebuild` in `forge.config.ts`. That's a CI change worth making on its own rather than inside a release.