### PR TITLE
ci: pin Windows builds to windows-2022 (VS2026 breaks node-gyp)

### DIFF
--- a/.github/workflows/_package.yml
+++ b/.github/workflows/_package.yml
@@ -24,10 +24,28 @@ on:
         # tag-triggered supplement (release-supplement.yml) passes the labels
         # GitLab's SaaS runners cannot provide — Intel macOS and arm64 Linux /
         # Windows — so one reusable build definition serves both paths.
+        #
+        # Windows is PINNED to windows-2022, not windows-latest. `windows-latest`
+        # now resolves to the `win25-vs2026` image, and `@electron/node-gyp@10.2.0`
+        # cannot detect Visual Studio 2026 — it reports `unknown version
+        # "undefined"` and then "could not find a version of Visual Studio 2017 or
+        # newer", so every native build fails outright.
+        #
+        # It became fatal when better-sqlite3 went 12 -> 13: v12 declared
+        # `install: prebuild-install || node-gyp rebuild`, which used the prebuilt
+        # and only compiled as a fallback. v13 declares NO install script but still
+        # ships a `binding.gyp`, so npm applies its documented default of compiling
+        # with node-gyp — unconditionally, even though v13 ships a perfectly good
+        # `prebuilds/win32-x64.node`.
+        #
+        # Unpin once @electron/node-gyp can find VS2026. The better fix is to stop
+        # source-building better-sqlite3 at all (it is a Node-API prebuilt, exactly
+        # like node-pty and sherpa-onnx, which forge.config.ts already excludes from
+        # @electron/rebuild) — that is a separate change and is not this one.
         description: JSON array of runner labels to build on
         type: string
         required: false
-        default: '["ubuntu-latest", "macos-latest", "windows-latest"]'
+        default: '["ubuntu-latest", "macos-latest", "windows-2022"]'
 
 permissions:
   contents: read
@@ -133,7 +151,7 @@ jobs:
         # platform-specific installer. Generate it on the primary matrix only;
         # supplementary architecture jobs still publish installers and checksums,
         # while release.yml/release-supplement.yml keep a single release SBOM.
-        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' || matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' || matrix.os == 'windows-2022' }}
         uses: anchore/sbom-action@v0
         with:
           path: .
@@ -169,7 +187,7 @@ jobs:
             dist/**/*.zip
 
       - name: Attest SBOM
-        if: ${{ inputs.attest && (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' || matrix.os == 'windows-latest') }}
+        if: ${{ inputs.attest && (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' || matrix.os == 'windows-2022') }}
         uses: actions/attest-sbom@v1
         with:
           subject-path: dist/SHA256SUMS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2022]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       # cannot build (Intel macOS, arm64 Linux, arm64 Windows).
       runners: >-
         ["ubuntu-latest", "ubuntu-24.04-arm", "macos-latest", "macos-15-intel",
-         "windows-latest", "windows-11-arm"]
+         "windows-2022", "windows-11-arm"]
 
   publish:
     name: Publish GitHub Release

--- a/package-lock.json
+++ b/package-lock.json
@@ -8184,6 +8184,7 @@
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
       "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.0.0"


### PR DESCRIPTION
Fixes the `Package (windows-latest)` failure blocking the v1.19.0 release, and the same failure in `ci.yml` on main.

## Correcting the record first

#120 claimed a `hasInstallScript` lockfile line caused this. **That was wrong** — npm re-derives the flag from `binding.gyp`, so removing it changed nothing and the rerun failed identically. This PR reverts that commit and restores the line.

## What actually broke

Windows packaging has been broken on main since #112 bumped better-sqlite3 12.11.1 → 13.0.3. It surfaced now only because this is the first release cut since; the last green release (v1.18.2, 2026-08-13) predates the bump.

Two things had to line up:

| | better-sqlite3 **12.11.1** | **13.0.3** |
|---|---|---|
| `install` script | `prebuild-install \|\| node-gyp rebuild --release` | **none** |
| `binding.gyp` | present | present |
| Effect | uses the prebuilt; compiles only as fallback | npm's documented default applies — *"if there is a binding.gyp and no install script, npm defaults to compiling with node-gyp"* — so it **always** compiles |

...and `windows-latest` moved to the `win25-vs2026` image, where `@electron/node-gyp@10.2.0` cannot detect Visual Studio 2026:

```
gyp verb find VS unknown version "undefined" found at
  "C:\Program Files\Microsoft Visual Studio\18\Enterprise"
gyp ERR! find VS could not find a version of Visual Studio 2017 or newer to use
```

Either alone is survivable. Together, every Windows x64 job dies in `npm ci` before any Limboo code runs. `windows-11-arm` is unaffected — its image still has a VS node-gyp recognises — which is why exactly one leg of the matrix broke.

The irony: better-sqlite3 13 ships Node-API prebuilts for all eight platforms, `win32-x64.node` included. It is compiling something it never needed to compile.

## This change

Pins Windows to `windows-2022`, which has a detectable toolchain. The label is threaded through both `matrix.os` conditionals gating the SBOM and attestation steps, so those keep running on the primary matrix instead of silently skipping. The artifact name becomes `limboo-windows-2022`; the release job globs `artifacts/*/` and picks it up unchanged. `ci.yml` is pinned too — same `npm ci`, same failure.

## Follow-up worth doing separately

The durable fix is to stop source-building better-sqlite3 at all, the way `node-pty` and `sherpa-onnx-node` are already excluded from `@electron/rebuild` in `forge.config.ts`. Deliberately not bundled into a release fix.