### PR TITLE
fix(harness): make the harness path runnable end to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ All notable changes to Limboo are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.20.0] - 2026-08-31
+
+Limboo 1.20.0 makes the agent harness actually run. 1.19.0 repaired its
+packaging; this release fixes the three separate reasons a run still could not
+start, gives harness conversations memory between prompts, and moves the
+harness runtime somewhere it belongs.
+
+### Fixed
+
+- **The harness could not start a run at all — for three independent reasons.**
+  Its one-time setup was refused by Limboo's own path guard on its very first
+  command, so the install could never begin. No network port was ever handed to
+  the agent bridge, which the harness requires and refuses to start without. And
+  the method the adapter uses to reach that bridge was missing, so a run that got
+  past the first two failed the moment the bridge came up. Each of these was
+  enough on its own; all three are fixed, and the setup now completes.
+- **Setup failures were retried forever instead of being reported.** A refusal
+  that mentioned the network — such as the sandbox network policy blocking the
+  download — was mistaken for a dropped connection and retried, though the same
+  setting would produce it again immediately. Refusals are now recognised for
+  what they are and reported once, with the reason.
+- **A failed setup command said nothing useful.** If one of the approved commands
+  ran and failed — a large download timing out is enough — it surfaced as a
+  generic failed run. It now reports what failed and what the tool itself said to
+  do about it, and is not retried: the package manager records the install as
+  complete even when part of it failed, so re-running it fails identically.
+- **Every prompt started a new conversation, and left a process behind.** Each
+  turn opened a fresh harness session without ending the previous one, so the
+  agent forgot the turn before and one background process accumulated per prompt.
+- **Non-Anthropic harnesses could never authenticate.** They were handed
+  Anthropic's credential variable names instead of their own, because the
+  credential lookup read the configured harness rather than the one the selected
+  model actually runs on.
+
+### Changed
+
+- **The harness keeps its runtime inside Limboo's own data directory.** It used
+  to be placed next to your worktree, which is Limboo-owned for a session with a
+  worktree — but a session without one is rooted at your repository, so its
+  runtime landed beside your project folder. It now always lives under Limboo's
+  application data, never in your repository and never next to it. Existing
+  installs will re-run the one-time setup once, in the new location.
+- **The setup panel says where the commands run.** It listed the two commands and
+  nothing else, so copying them into a terminal was the obvious thing to try —
+  and it fails, because the lockfile they install from is written into the setup
+  directory first. The panel now names that directory and the files placed in it.
+  Your existing approval still stands: the commands themselves have not changed.
+- **The agent harness packages were updated** (`@ai-sdk/harness` 1.0.91,
+  `@ai-sdk/harness-claude-code` 1.0.94). Every assumption Limboo makes about
+  their internals — where the runtime is installed, how the bridge binds, which
+  harnesses can be permission-gated — was re-checked against the new versions.
+
 ## [1.19.0] - 2026-08-30
 
 Limboo 1.19.0 repairs the agent harness, which could not install itself in any

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,24 @@ added without amending this paragraph:
    The harness path (`settings.agent.harness`, off behind `legacyClaudeSdk`)
    drives a third-party adapter whose first session bootstraps its own runtime:
    `@ai-sdk/harness-claude-code` writes a `package.json` + lockfile into
-   `.harness-bootstrap/` — a **sibling of the worktree, never inside the
-   repository** — and runs `pnpm install --frozen-lockfile` plus the CLI's own
-   installer there. The adapter hardcodes this; there is no offline mode.
+   `.harness-bootstrap/claude-code/` and runs `pnpm install --frozen-lockfile`
+   plus `./node_modules/.bin/claude --version` **in that directory**. The
+   adapter hardcodes this; there is no offline mode. The directory resolves
+   under the sandbox's `defaultWorkingDirectory`, which
+   `LocalWorktreeSandbox` reports as a Limboo-owned state root —
+   `{userData}/harness-state/<bucket>/`, holding a link to the execution root
+   — so the runtime lands **inside userData, never in the repository and never
+   beside it**. (It used to be the worktree's plain PARENT. That is Limboo-owned
+   for a worktree-backed session, but `resolveSessionRoot` falls back to the
+   workspace path for a plain one, and the parent is then the user's own
+   projects directory. See `harness/sandbox/stateRoot.ts`.)
+
+   **Where the commands run is part of what the consent surface must say.** They
+   only work in that directory — it is where the adapter just wrote the lockfile
+   they install from — so a user who copies them into a shell gets
+   `ERR_PNPM_NO_LOCKFILE` and reads it as a Limboo bug. `BootstrapPlan.dir`
+   carries it through to the panel; it is deliberately **not** part of the
+   consent fingerprint, which covers what executes.
 
    Four things keep it inside this paragraph's spirit rather than merely
    permitted by it:
@@ -71,11 +86,23 @@ added without amending this paragraph:
    - **It is refused, with a reason, when it cannot succeed.** A sandbox network
      policy of `off` (or an allowlist without the registry), or a missing
      `pnpm`, is detected before the run instead of surfacing as a bootstrap that
-     times out inside the sandbox (`assertBootstrapPossible`).
+     times out inside the sandbox (`assertBootstrapPossible`). What cannot be
+     predicted is reported: a command that runs and exits non-zero becomes
+     `HarnessBootstrapFailedError`, carrying the adapter's own stderr, and is
+     **never retried** — pnpm records an install as complete even when an
+     OPTIONAL dependency failed to download, so the re-run says "Already up to
+     date" and fails identically. Every harness refusal is classified by error
+     CLASS (`classifyHarnessRefusal`), never by message text: the
+     network-allowlist refusal's own wording contains "network", which the
+     transient-transport regex matched, so a standing policy decision was being
+     retried as though it were a dropped socket.
    - **It reaches nothing but the registry**, and it installs into the sandbox
      state dir, which is the ONLY path outside the worktree the local sandbox
-     provider permits (two literal dot-prefixed segments; see
-     `LocalWorktreeSandbox.resolvePath`).
+     provider permits for file I/O (two literal dot-prefixed segments; see
+     `LocalWorktreeSandbox.resolvePath`). The state root ITSELF is additionally
+     allowed as a working directory — and only that — because the framework
+     runs the bootstrap's `mkdir` there; see `resolveCwd`, which is kept
+     separate from `resolvePath` so file I/O goes on refusing it.
    - **It is not the agent's network.** The agent's own provider traffic is item
      1; this is a package install, and no agent tool can trigger it.
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -42,7 +42,8 @@ import { AttachmentManager } from './managers/attachments/AttachmentManager';
 import { SecretStore } from './secrets/SecretStore';
 import { CursorAuthManager } from './managers/cursor/CursorAuthManager';
 import { CursorRuntime } from './managers/cursor/CursorRuntime';
-import { harnessById } from './managers/agent/harnessRegistry';
+import { harnessById, harnessIdForRun } from './managers/agent/harnessRegistry';
+import { worktreeRootDir } from './managers/worktree/paths';
 import { HarnessRuntime } from './managers/harness/HarnessRuntime';
 import { LocalWorktreeSandboxProvider } from './managers/harness/sandbox/LocalWorktreeSandbox';
 import { resolveSandboxConfig } from './managers/sandbox/policy';
@@ -411,9 +412,14 @@ function bootstrap(): void {
           attachmentsDir: sessionAttachmentsDir(sessionId),
         }),
       attachmentsDirFor: (sessionId) => sessionAttachmentsDir(sessionId),
-      // Credential var NAMES the active harness reads. Forwarded only when the
+      // Credential var NAMES the harness that will actually run reads. Resolved
+      // through `harnessIdForRun` — the harness follows the MODEL — so a Codex
+      // or Pi run gets its own keys instead of Claude's. Forwarded only when the
       // user's own environment already has them; Limboo stores none.
-      envKeysFor: () => harnessById(settings.getAll().agent.harness.id)?.envKeys ?? [],
+      envKeysFor: () => harnessById(harnessIdForRun(settings.getAll().agent))?.envKeys ?? [],
+      // Only consulted to decide whether a session may fall back to the
+      // worktree's parent when the private state root cannot be prepared.
+      worktreeRoot: () => worktreeRootDir(settings.getAll()),
       diag: (severity, label, detail) => {
         if (severity === 'error') logger.error(`[harness] ${label}`, detail ?? '');
         else logger.info(`[harness] ${label}`, detail ?? '');

--- a/src/main/managers/AgentManager.ts
+++ b/src/main/managers/AgentManager.ts
@@ -98,7 +98,6 @@ import {
   SEARCH_LIMITS,
   clamp,
   cursorModelSet,
-  PROVIDER_HARNESS,
   providerForModel,
   resolveModelRouting,
 } from '@shared/constants';
@@ -156,9 +155,10 @@ import type { HarnessRuntime, HarnessRunHandle } from './harness/HarnessRuntime'
 import type { LocalWorktreeSandboxProvider } from './harness/sandbox/LocalWorktreeSandbox';
 import { buildToolApprovalMap } from './harness/approval';
 import { readBootstrapPlan } from './harness/bootstrap';
+import { classifyHarnessRefusal } from './harness/errors';
 import { resolveTools } from './harness/toolchain';
 import { loadHarness } from './harness';
-import { harnessById } from './agent/harnessRegistry';
+import { harnessById, harnessIdForRun } from './agent/harnessRegistry';
 import { isSubagentTool } from '@shared/subagents';
 import { IpcEvents } from '@shared/ipc-channels';
 import { getDb } from '../db/database';
@@ -2005,6 +2005,11 @@ export class AgentManager {
     // In-memory runtime state (tool rows, tasks, live changes) belongs to the
     // truncated turns; dropping it lets the next snapshot rebuild cleanly.
     this.runtimes.delete(sessionId);
+    // The truncate above dropped every `agent_provider_sessions` row, including
+    // the harness resume — so a parked bridge now holds a conversation the
+    // repository no longer matches, and nothing will reattach to it. Tear it
+    // down, or the next prompt respawns onto the port it is still bound to.
+    void this.discardHarnessSandbox(sessionId);
 
     const detail =
       `${restore.filesReverted} file${restore.filesReverted === 1 ? '' : 's'} restored` +
@@ -2033,6 +2038,10 @@ export class AgentManager {
   /** Forget a session entirely (transcript, activity, runtime state). */
   clearSession(sessionId: string): void {
     this.stop(sessionId);
+    // A harness session parks its bridge on `detach()` so the next turn can
+    // reattach. There is no next turn now, so the process and its loopback port
+    // would otherwise survive until the app quit.
+    void this.discardHarnessSandbox(sessionId);
     // Governance bus: the session's execution context is ending. Emit before the
     // rows are deleted (the audit trail for this session is cleared with them).
     this.emitHook(sessionId, 'session-end', { summary: 'Session cleared' });
@@ -2684,7 +2693,10 @@ export class AgentManager {
         // / transport shapes that never appear as a terminal_reason. Resolved
         // BEFORE the retry-fresh check so a Cursor verdict — which carries its
         // own `retryFresh` — gets the same remedy as a Claude one.
+        // A harness refusal is checked FIRST and by error class, because its
+        // own prose defeats the text classifiers — see `classifyHarnessRefusal`.
         const cls =
+          classifyHarnessRefusal(err) ??
           structured ??
           (provider === 'cursor' ? classifyCursorError(redact(raw)) : classifyAgentError(redact(raw)));
         // These two are optional across the three classifier shapes — only the
@@ -2839,10 +2851,10 @@ export class AgentManager {
     // The harness follows the MODEL, not the settings field. `agent.harness.id`
     // is the choice for Anthropic models — where a harness and the direct SDK
     // both exist — but a Codex or Pi model can only run on its own harness, and
-    // reading the stored id there would try to run it on Claude Code.
-    const modelProvider = providerForModel(agent.model);
-    const harnessId =
-      modelProvider === 'anthropic' ? agent.harness.id : PROVIDER_HARNESS[modelProvider];
+    // reading the stored id there would try to run it on Claude Code. Shared
+    // with the sandbox provider's credential-env resolver, which read the
+    // stored id directly and so handed those runs the wrong key names.
+    const harnessId = harnessIdForRun(agent);
     const descriptor = harnessById(harnessId);
     if (!descriptor) throw new Error(`Unknown harness "${harnessId}".`);
 
@@ -2945,6 +2957,10 @@ export class AgentManager {
     }
 
     const canUseTool = this.makeCanUseTool(sessionId, cwd, permMode);
+    // Resolved BEFORE the runtime starts, because a rejected or absent resume
+    // also tears down the cached sandbox session, and that has to finish before
+    // `createSession` hands out a port a parked bridge is still bound to.
+    const resumeFrom = await this.resolveHarnessResume(sessionId, harnessId);
     // The approval callback needs the handle in order to interrupt the turn,
     // but the handle only exists once the run has started — hence the cell.
     const handleRef: { current: HarnessRunHandle | null } = { current: null };
@@ -2999,12 +3015,14 @@ export class AgentManager {
         },
         sandbox,
         mcpServers,
-        // No resume yet. `createSession({resumeFrom})` requires a structured
-        // `{type:'resume-session', specificationVersion, harnessId, data}` and
-        // THROWS on anything else, so passing the legacy row's opaque string
-        // failed every second prompt. A fresh conversation per run is a
-        // degradation; an error on every second prompt is a broken feature.
-        resumeFrom: undefined,
+        // Multi-turn continuity. `createSession({resumeFrom})` requires a
+        // structured `{type:'resume-session', specificationVersion, harnessId,
+        // data}` and THROWS on anything else — which is why the legacy row's
+        // opaque string could never be passed here, and why this was pinned to
+        // `undefined` (a fresh conversation per prompt) until there was a real
+        // one to pass. `resolveHarnessResume` produces exactly that shape or
+        // nothing, validating the row before it can reach the framework.
+        resumeFrom,
         workDir,
         debug: agent.harness.debug,
         abort,
@@ -3015,7 +3033,12 @@ export class AgentManager {
     if (run) run.query = { close: handle.close };
     this.setLifecycle('streaming');
     this.setRequest(sessionId, { phase: 'streaming' });
-    await handle.done;
+    const outcome = await handle.done;
+    // Store what the parked session handed back so the NEXT prompt continues
+    // this conversation instead of opening a new one. `undefined` clears the
+    // row — an un-parked session has no resume, and a stale one would be worse
+    // than none.
+    await this.rememberHarnessResume(sessionId, harnessId, outcome.resumeState);
     } finally {
       // The pipe is per-run: closing it is what stops a stale bridge from
       // outliving the run that authorized it.
@@ -6947,6 +6970,116 @@ export class AgentManager {
     getDb()
       .prepare('DELETE FROM agent_provider_sessions WHERE session_id = ? AND provider = ?')
       .run(sessionId, provider);
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Harness resume state                                                */
+  /* ------------------------------------------------------------------ */
+  /**
+   * A harness's resume state rides the SAME `agent_provider_sessions` table
+   * under its own key, `harness:<harnessId>`.
+   *
+   * The key must not be a bare `AgentProvider`. `claude-code` and Limboo's
+   * direct Claude Agent SDK path are both `anthropic`, and they store entirely
+   * different things — the SDK path stores a session id string, the harness
+   * path a structured lifecycle object. Sharing the `anthropic` row would have
+   * each path overwrite the other's resume with something it cannot parse.
+   * That is the collision the `onInit: () => undefined` note in `runHarnessOnce`
+   * was written to avoid, closed properly here.
+   *
+   * The typed `AgentProvider` helpers above are deliberately left alone rather
+   * than widened to `string`: their signature is what keeps a provider key from
+   * being invented at a call site.
+   */
+  private harnessResumeKey(harnessId: string): string {
+    return `harness:${harnessId}`;
+  }
+
+  /**
+   * Resolve a stored harness resume state for the next run, or `undefined`.
+   *
+   * VALIDATES before returning. `HarnessAgent.createSession` throws when the
+   * resume state was not produced by the same adapter, so a stale row from a
+   * different harness (or a truncated write) must never reach it — that would
+   * turn a recoverable "start fresh" into a failed run on every prompt. A row
+   * that does not parse, or names another harness, is dropped and forgotten:
+   * the same posture `CURSOR_RESUME_ID_RE` takes with an invalid chat id.
+   *
+   * ASYNC because dropping a resume also has to tear down the sandbox session —
+   * see {@link discardHarnessSandbox} — and that must complete BEFORE the next
+   * `createSession`, or the respawned bridge races the parked one for the port.
+   */
+  private async resolveHarnessResume(sessionId: string, harnessId: string): Promise<unknown> {
+    const key = this.harnessResumeKey(harnessId);
+    const raw = this.loadProviderSession(sessionId, key as AgentProvider);
+    if (!raw) {
+      // No resume, but a sandbox session may still be cached from a run whose
+      // bridge is parked and listening. Starting fresh on top of it is the
+      // port collision described below.
+      await this.discardHarnessSandbox(sessionId);
+      return undefined;
+    }
+    try {
+      const parsed = JSON.parse(raw) as { type?: unknown; harnessId?: unknown };
+      if (parsed?.type === 'resume-session' && parsed?.harnessId === harnessId) return parsed;
+    } catch {
+      /* fall through to the drop below */
+    }
+    this.forgetProviderSession(sessionId, key as AgentProvider);
+    this.diag(
+      'lifecycle',
+      'warning',
+      'Dropped an unusable harness resume state',
+      `harness ${harnessId} — the next prompt starts a fresh conversation.`,
+      sessionId,
+    );
+    await this.discardHarnessSandbox(sessionId);
+    return undefined;
+  }
+
+  /** Persist (or clear) a harness resume state after a run parks its session. */
+  private async rememberHarnessResume(
+    sessionId: string,
+    harnessId: string,
+    state: unknown,
+  ): Promise<void> {
+    const key = this.harnessResumeKey(harnessId) as AgentProvider;
+    if (state == null) {
+      this.forgetProviderSession(sessionId, key);
+      // The turn did not park, so there is no bridge to reattach to — but the
+      // process may still be alive on the reserved port. Tear it down now
+      // rather than leaving the next prompt to collide with it.
+      await this.discardHarnessSandbox(sessionId);
+      return;
+    }
+    try {
+      this.rememberProviderSession(sessionId, key, JSON.stringify(state));
+    } catch {
+      // Unserialisable state is a lost resume, never a failed run.
+      this.forgetProviderSession(sessionId, key);
+      await this.discardHarnessSandbox(sessionId);
+    }
+  }
+
+  /**
+   * Drop a session's cached sandbox: kill its parked bridge, release its port.
+   *
+   * Required whenever the conversation will NOT be resumed. `detach()` leaves
+   * the bridge listening on purpose — that is what lets the next turn reattach
+   * instead of reinstalling — but a run that starts FRESH spawns a new bridge
+   * on the port the sandbox session still exposes, and the parked one is still
+   * bound to it. Without this the second prompt after any lost resume dies with
+   * EADDRINUSE, and the cause would look like a port bug rather than a
+   * lifecycle one.
+   *
+   * Best-effort: teardown must never fail a run.
+   */
+  private async discardHarnessSandbox(sessionId: string): Promise<void> {
+    try {
+      await this.harnessSandbox?.release(sessionId);
+    } catch {
+      /* the provider deletes nothing; a failure here costs only the cache */
+    }
   }
 
   /**

--- a/src/main/managers/agent/harnessRegistry.ts
+++ b/src/main/managers/agent/harnessRegistry.ts
@@ -16,7 +16,7 @@
  * runtime behind the same {@link ProviderRunBridge} seam rather than being
  * migrated or dropped.
  */
-import type { AgentProvider } from '@shared/constants';
+import { PROVIDER_HARNESS, providerForModel, type AgentProvider } from '@shared/constants';
 import type { HarnessSettingsShape } from '../harness/adapterSettings';
 
 /** How a harness executes, which decides what infrastructure it needs. */
@@ -232,4 +232,24 @@ export function harnessesForProvider(provider: AgentProvider): HarnessDescriptor
 export function harnessForProvider(provider: AgentProvider | null): HarnessDescriptor | undefined {
   if (!provider) return undefined;
   return HARNESSES.find((h) => h.provider === provider);
+}
+
+/**
+ * The harness that a run WILL use, resolved the way `AgentManager.runHarnessOnce`
+ * resolves it.
+ *
+ * The harness follows the MODEL, not `settings.agent.harness.id`. That field is
+ * only the choice for Anthropic models — the one provider where a harness and
+ * Limboo's direct Claude Agent SDK path both exist; a Codex or Pi model can run
+ * on nothing but its own harness. Reading the stored id for those would try to
+ * run them on Claude Code.
+ *
+ * Extracted so every caller that needs "which harness is this run" agrees. The
+ * sandbox provider's credential-env-key resolver read the stored id directly and
+ * therefore handed a Codex or Pi run Claude's `ANTHROPIC_*` names and none of
+ * its own — a run that could not authenticate, for a reason nothing surfaced.
+ */
+export function harnessIdForRun(agent: { model: string; harness: { id: string } }): string {
+  const provider = providerForModel(agent.model);
+  return provider === 'anthropic' ? agent.harness.id : PROVIDER_HARNESS[provider];
 }

--- a/src/main/managers/harness/HarnessRuntime.ts
+++ b/src/main/managers/harness/HarnessRuntime.ts
@@ -28,7 +28,7 @@ import {
   assertBootstrapPossible,
   readBootstrapPlan,
 } from './bootstrap';
-import { HarnessBootstrapUnreadableError, HarnessUngatedError } from './errors';
+import { asBootstrapFailure, HarnessBootstrapUnreadableError, HarnessUngatedError } from './errors';
 import { harnessPermissionMode } from './permissions';
 import { newTranslateContext, translatePart, type HarnessApprovalRequest } from './translate';
 import type { HarnessAdapterFlags, HarnessSession, HarnessToolApproval } from './types';
@@ -95,6 +95,15 @@ export interface HarnessRunSpec {
 export interface HarnessRunOutcome {
   /** Provider session id captured from the stream, for resume storage. */
   sessionToken?: string;
+  /**
+   * Opaque resume state from `session.detach()`, for the NEXT turn.
+   *
+   * Structured (`{ type: 'resume-session', specificationVersion, harnessId,
+   * data }`) and produced only by the lifecycle methods — nothing in the stream
+   * carries it, which is why the `onInit` bridge callback is inert on this path.
+   * The caller persists it verbatim and hands it back as `resumeFrom`.
+   */
+  resumeState?: unknown;
   result?: { ok: boolean; text: string };
 }
 
@@ -223,11 +232,21 @@ export class HarnessRuntime {
       onLog: (line) => bridge.diag('stream', 'debug', 'harness', safeLine(line)),
     });
 
-    const session = await agent.createSession(
-      spec.resumeFrom != null
-        ? { sessionId: spec.sessionId, resumeFrom: spec.resumeFrom }
-        : { sessionId: spec.sessionId },
-    );
+    // `createSession` is where the framework applies the bootstrap recipe — it
+    // writes the adapter's files and runs the approved commands, throwing an
+    // anonymous Error if one exits non-zero. Rename it here, at the only seam
+    // that knows which harness this is, so the failure is reported with its own
+    // stderr and is never retried as though it were a dropped connection.
+    let session: HarnessSession;
+    try {
+      session = await agent.createSession(
+        spec.resumeFrom != null
+          ? { sessionId: spec.sessionId, resumeFrom: spec.resumeFrom }
+          : { sessionId: spec.sessionId },
+      );
+    } catch (err) {
+      throw asBootstrapFailure(err, label) ?? err;
+    }
     this.live.add(session);
     bridge.onSandboxStatus?.('ready', 'Workspace boundary established.');
 
@@ -303,7 +322,38 @@ export class HarnessRuntime {
           bridge.finishStreaming();
           bridge.onResult(true, ctx.text);
         }
-        return { result: { ok: ctx.ok, text: ctx.text } };
+        // PARK THE TURN. Nothing did this before, on any path but abort, and
+        // both consequences were real: the adapter's bridge child kept running
+        // until the app quit (one more `node bridge.mjs` per prompt, since each
+        // run opens its own session), and with no resume state stored the next
+        // prompt started a brand-new conversation.
+        //
+        // `detach()` rather than `stop()`: it parks the runtime while leaving
+        // the bridge listening, which is precisely what the adapter's attach
+        // path is built for — the next turn reopens the existing socket instead
+        // of respawning and re-checking the bootstrap marker. `stop()` remains
+        // the right call when the SESSION ends, and `dispose()` still makes it.
+        //
+        // Best-effort by design: a failure here costs the resume, and a run
+        // that produced real work must not be reported as failed because its
+        // bookkeeping did not settle.
+        //
+        // Skipped on abort: `close()` already called `suspendTurn()` there,
+        // which is the stronger claim (it preserves the UNFINISHED turn so the
+        // next send continues it — what makes plan-approve-then-implement
+        // work), and detaching on top of it would fight that.
+        let resumeState: unknown;
+        try {
+          if (!spec.abort.signal.aborted) resumeState = await session.detach?.();
+        } catch (err) {
+          bridge.diag(
+            'lifecycle',
+            'warning',
+            'Could not park the harness session; the next prompt will start a fresh conversation',
+            err instanceof Error ? err.message.slice(0, 300) : undefined,
+          );
+        }
+        return { resumeState, result: { ok: ctx.ok, text: ctx.text } };
       } finally {
         this.live.delete(session);
         spec.abort.signal.removeEventListener('abort', close);

--- a/src/main/managers/harness/bootstrap.ts
+++ b/src/main/managers/harness/bootstrap.ts
@@ -31,6 +31,22 @@ export interface BootstrapPlan {
   commands: string[];
   /** Files written into the state dir (names only — contents can be large). */
   files: string[];
+  /**
+   * The directory, relative to the sandbox root, that the files are written
+   * into and the commands are RUN IN.
+   *
+   * Not decoration. `applyBootstrapRecipe` passes it as `workingDirectory` for
+   * every command, so `pnpm install --frozen-lockfile` only makes sense there —
+   * that is where the adapter just wrote `pnpm-lock.yaml`. A consent surface
+   * that shows the commands without the directory invites the user to paste
+   * them into their shell, where they fail with `ERR_PNPM_NO_LOCKFILE` and look
+   * like a Limboo bug.
+   *
+   * Deliberately NOT part of the fingerprint. Consent is over what EXECUTES;
+   * folding the directory in would void every existing approval for a string
+   * that changes nothing about the commands.
+   */
+  dir?: string;
   /** Stable id of THIS command set; the unit of consent. */
   fingerprint: string;
 }
@@ -39,6 +55,7 @@ export interface BootstrapPlan {
 interface RawBootstrap {
   commands?: readonly { command?: unknown }[];
   files?: readonly { path?: unknown }[];
+  bootstrapDir?: unknown;
 }
 
 /**
@@ -98,11 +115,18 @@ export async function readBootstrapPlan(adapter: unknown): Promise<BootstrapRead
   const files = (raw?.files ?? [])
     .map((f) => (typeof f?.path === 'string' ? f.path : ''))
     .filter((f) => f.length > 0);
+  // Relative by contract (`applyBootstrapRecipe` resolves it against the
+  // sandbox root), and it must STAY relative on the way to the renderer: an
+  // absolute one would carry the user's home directory into the UI, which is
+  // the same reason `prerequisites` reports tool names and never resolved paths.
+  const rawDir = typeof raw?.bootstrapDir === 'string' ? raw.bootstrapDir.trim() : '';
+  const dir = rawDir && !rawDir.startsWith('/') && !/^[A-Za-z]:/.test(rawDir) ? rawDir : undefined;
   return {
     kind: 'plan',
     plan: {
       commands,
       files,
+      ...(dir ? { dir } : {}),
       // Only the COMMANDS are fingerprinted. File contents change on every
       // adapter patch release; what the user is consenting to is what executes.
       fingerprint: crypto

--- a/src/main/managers/harness/errors.ts
+++ b/src/main/managers/harness/errors.ts
@@ -3,6 +3,100 @@
  */
 
 /**
+ * A bootstrap command the user approved ran, and exited non-zero.
+ *
+ * The framework throws a plain `Error` for this, so it arrived as anonymous
+ * prose and was classified by regex like any other run failure — which is how a
+ * setup step that cannot succeed got retried, and how a setup step that failed
+ * for a nameable reason got reported as "the run failed".
+ *
+ * The adapter's own stderr is the most useful thing in the box and is carried
+ * verbatim (bounded): the claude-code plan's second command is
+ * `./node_modules/.bin/claude --version`, and when the CLI's large
+ * platform-native optional dependency did not download — a slow link plus
+ * pnpm's per-request fetch timeout is enough — it exits 1 and prints exactly
+ * what to do. Swallowing that in favour of a generic message would throw away
+ * the answer.
+ *
+ * Non-retryable on purpose. pnpm records the install as complete even when an
+ * OPTIONAL dependency failed, so a re-run reports "Already up to date" and the
+ * second command fails identically, forever. Retrying that is a loop, not a
+ * recovery; the marker file is never written either way, so the user re-running
+ * it deliberately after fixing the cause still gets a full, correct install.
+ */
+export class HarnessBootstrapFailedError extends Error {
+  readonly name = 'HarnessBootstrapFailedError';
+
+  constructor(label: string, detail: string) {
+    super(
+      `${label}'s one-time setup did not complete. Limboo ran the commands you ` +
+        'approved and one of them failed, so no agent was started. The setup ' +
+        `step reported:\n\n${detail}`,
+    );
+  }
+}
+
+/** The framework's own prefix when a recipe command exits non-zero. */
+const FRAMEWORK_BOOTSTRAP_FAILURE = /^Bootstrap command failed for harness/;
+
+/**
+ * Recognise a framework bootstrap failure so it can be renamed and reported.
+ *
+ * A string match against a third-party message, so it FAILS OPEN: an
+ * unrecognised error is left exactly as it was and travels the ordinary path.
+ * The cost of a miss is a less specific message, never a swallowed failure —
+ * the opposite trade-off from `patchBridge.ts`, where a miss means a security
+ * claim can no longer be proved and the run must stop.
+ */
+export function asBootstrapFailure(err: unknown, label: string): Error | null {
+  const message = err instanceof Error ? err.message : '';
+  if (!FRAMEWORK_BOOTSTRAP_FAILURE.test(message)) return null;
+  return new HarnessBootstrapFailedError(label, message.slice(0, 1_200));
+}
+
+/**
+ * Every error name below is a DECISION, not a failure.
+ *
+ * `HarnessCapabilityUnsupportedError` is the framework's own and is included
+ * for the same reason: an adapter that cannot do a thing will not start doing
+ * it on the second attempt.
+ */
+const REFUSAL_NAMES = new Set([
+  'HarnessUngatedError',
+  'HarnessConsentRequiredError',
+  'HarnessBootstrapBlockedError',
+  'HarnessBootstrapUnreadableError',
+  'HarnessBootstrapFailedError',
+  'HarnessCapabilityUnsupportedError',
+]);
+
+/**
+ * Classify a harness refusal, or return `null` to let the ordinary classifiers
+ * run.
+ *
+ * WHY THIS EXISTS, and why it matches on the error NAME rather than its text:
+ * `classifyAgentError` decides recoverability with a regex over the message,
+ * and `HarnessBootstrapBlockedError`'s message necessarily says *"it downloads
+ * the agent CLI from the npm registry, which is not in the sandbox **network**
+ * allowlist"*. That `network` matched the transient-transport branch, so a
+ * standing policy decision — one the same settings will produce again the next
+ * millisecond — was retried as though it were a dropped socket. A refusal whose
+ * own wording makes it look retryable is exactly the failure mode a text
+ * classifier cannot be trusted with, so this one reads the class instead.
+ *
+ * Deliberately non-recoverable and lifecycle-neutral: nothing about the agent's
+ * health changed, the request was declined, and the message already tells the
+ * user what to do about it.
+ */
+export function classifyHarnessRefusal(
+  err: unknown,
+): { outcome: 'failed'; recoverable: false } | null {
+  const name = (err as { name?: unknown } | null)?.name;
+  if (typeof name !== 'string' || !REFUSAL_NAMES.has(name)) return null;
+  return { outcome: 'failed', recoverable: false };
+}
+
+/**
  * The adapter cannot ask Limboo for permission before a built-in tool edits a
  * file or runs a command.
  *

--- a/src/main/managers/harness/sandbox/LocalWorktreeSandbox.ts
+++ b/src/main/managers/harness/sandbox/LocalWorktreeSandbox.ts
@@ -21,11 +21,14 @@
  * would therefore put the agent in `<worktree>/claude-code-<id>/` — an empty
  * folder inside the repo, not the repo.
  *
- * Hence `defaultWorkingDirectory` is the worktree's PARENT and the caller
- * passes `workDir = basename(worktree)`, so the join lands exactly on the
- * worktree root. A pleasant side effect: the adapter's bootstrap directory is
- * placed under the parent, i.e. a SIBLING of the worktree, so the bridge's
- * own files never appear in `git status`.
+ * Hence `defaultWorkingDirectory` is a Limboo-owned STATE ROOT under userData
+ * and the caller passes `workDir = basename(worktree)`, which that root holds
+ * as a link to the real worktree — so the join lands exactly on the worktree
+ * while the adapter's own `.harness-bootstrap` / `.agent-runs` directories
+ * stay inside userData and never appear in `git status`. See `stateRoot.ts`
+ * for why the link has to be real on disk and why the worktree's plain PARENT
+ * is not good enough (a non-worktree session's parent is the user's own
+ * projects directory).
  *
  * ── What is guarded, and why each guard exists ───────────────────────────
  *  - Every path resolves through {@link resolvePath}: canonicalized, confined
@@ -50,6 +53,7 @@ import { augmentedPath } from '../toolchain';
 import { resolveJail } from './jail';
 import { patchBootstrapFile } from './patchBridge';
 import { assertLoopbackOnly, reserveLoopbackPort, type PortReservation } from './ports';
+import { canFallBackToParent, prepareStateRoot } from './stateRoot';
 
 /** Everything the provider needs, injected — never a manager reference. */
 export interface LocalSandboxDeps {
@@ -60,14 +64,29 @@ export interface LocalSandboxDeps {
   /** This session's attachment staging dir, mounted read-only when present. */
   attachmentsDirFor?(sessionId: string): string | undefined;
   /**
-   * Credential env var NAMES the active harness needs (never values).
+   * Credential env var NAMES the harness that will actually run needs (never
+   * values).
    *
    * Each is forwarded to the child only when already present in the host
    * environment. Limboo stores no provider credential — this exists so a user
    * whose shell has `ANTHROPIC_API_KEY` can authenticate, without the app ever
    * holding, echoing or persisting the value.
+   *
+   * Takes the SESSION, because the harness follows the MODEL rather than
+   * `settings.agent.harness.id` — that field is only the choice for Anthropic
+   * models, where a harness and the direct SDK path both exist. Reading it
+   * unconditionally handed a Codex or Pi run Claude's key names and none of
+   * its own, so those runs could never authenticate.
    */
-  envKeysFor?(): readonly string[];
+  envKeysFor?(sessionId: string): readonly string[];
+  /**
+   * Limboo's worktree root (`{userData}/worktrees` by default).
+   *
+   * Consulted only to decide whether a session may fall back to
+   * `path.dirname(root)` when the state-root link cannot be created — see
+   * `stateRoot.ts` `canFallBackToParent`.
+   */
+  worktreeRoot(): string;
   /** Structured diagnostics (already-redacted detail only). */
   diag?(severity: 'debug' | 'info' | 'warning' | 'error', label: string, detail?: string): void;
 }
@@ -75,7 +94,7 @@ export interface LocalSandboxDeps {
 /**
  * The adapter state directories permitted as SIBLINGS of the worktree.
  *
- * Third-party constants, verified in @ai-sdk/harness-claude-code@1.0.80:
+ * Third-party constants, re-verified in @ai-sdk/harness-claude-code@1.0.94:
  * `BOOTSTRAP_DIR = ".harness-bootstrap/claude-code"` and the per-session
  * `.agent-runs/<sessionId>/bridge`, both resolved against the sandbox's
  * `defaultWorkingDirectory`. Kept as literals rather than a prefix rule so a
@@ -211,7 +230,7 @@ class LocalSandboxSession {
     // worktree (slugs come from `sanitizeBranchName`, which cannot emit a
     // leading dot). The crown-jewel loop above already ran unconditionally, so
     // nothing here can reach a protected file. Both names are third-party
-    // constants verified in @ai-sdk/harness-claude-code@1.0.80 — an upgrade
+    // constants re-verified in @ai-sdk/harness-claude-code@1.0.94 — an upgrade
     // that renames them fails loudly at the first write rather than silently
     // writing somewhere else.
     const realState = realpathNearest(this.defaultWorkingDirectory);
@@ -233,6 +252,39 @@ class LocalSandboxSession {
       }
     }
     throw new Error('Refused: path is outside the session workspace.');
+  }
+
+  /**
+   * Resolve a WORKING DIRECTORY for a spawned command.
+   *
+   * Everything {@link resolvePath} permits, plus the state root itself. That
+   * one addition is what makes the harness bootstrap possible at all: the
+   * framework's `applyBootstrapRecipe` runs `mkdir -p "$BOOTSTRAP_DIR"` with
+   * `workingDirectory` set to `defaultWorkingDirectory`, and `resolvePath`
+   * refused it — its state-dir carve-out admits `<state>/.harness-bootstrap/…`
+   * but not `<state>`, because `path.relative(state, state)` is `''` and an
+   * empty first segment is in no allow-list. So the very first command of the
+   * one-time setup failed, every time, with "path is outside the session
+   * workspace" — which is how a harness that had been "installed" for months
+   * had never once completed its install.
+   *
+   * Kept SEPARATE from `resolvePath` rather than widening it: file I/O must go
+   * on refusing this directory, so the harness cannot read or write the state
+   * root's own entries (a sibling session's `.agent-runs`, say) through the
+   * file API.
+   *
+   * It grants no reach that did not already exist. A cwd is not file access,
+   * and these guards cover the file-I/O API rather than shell commands — a
+   * command already launched with `cwd = worktree` can `cd ..` on its own. The
+   * layer that would contain a shell command is the OS jail, which `jail.ts`
+   * documents as a deliberate no-op today.
+   */
+  private resolveCwd(p: string): string {
+    const abs = path.isAbsolute(p) ? path.resolve(p) : path.resolve(this.worktree, p);
+    if (realpathNearest(abs) === realpathNearest(this.defaultWorkingDirectory)) {
+      return this.defaultWorkingDirectory;
+    }
+    return this.resolvePath(p, false);
   }
 
   /* ---------------------------------------------------------------- */
@@ -320,7 +372,17 @@ class LocalSandboxSession {
     workingDirectory?: string;
     env?: Record<string, string>;
   }): ReturnType<typeof spawn> {
-    const cwd = o.workingDirectory ? this.resolvePath(o.workingDirectory, false) : this.worktree;
+    const cwd = o.workingDirectory ? this.resolveCwd(o.workingDirectory) : this.worktree;
+    // Hand the reserved bridge port over to whatever is about to run.
+    //
+    // `reserveLoopbackPort` HOLDS its listener open on purpose — that is what
+    // closes the probe-then-race window a plain "find a free port" helper
+    // leaves. But the harness bridge binds that same port itself, so the hold
+    // has to end before any child starts or the bridge dies with EADDRINUSE
+    // (see the third rejected option in patchBridge.ts's header). Releasing
+    // here, at the last instant before `spawn`, keeps the window as narrow as
+    // it can be while still letting the bridge bind.
+    this.releasePortReservations();
     const [shellCmd, shellFlag] =
       process.platform === 'win32' ? [process.env.COMSPEC || 'cmd.exe', '/d/s/c'] : ['/bin/sh', '-c'];
     const argv = [...this.jail.argv, shellCmd, shellFlag, o.command];
@@ -390,18 +452,55 @@ class LocalSandboxSession {
   /* Ports / lifecycle                                                 */
   /* ---------------------------------------------------------------- */
 
-  readonly getPortUrl = async (o: {
-    port: number;
-    protocol?: 'http' | 'https' | 'ws';
-  }): Promise<string> => {
-    // ALWAYS loopback. This is the URL the adapter opens its control channel
-    // on, so it is also the last place a non-local host could sneak in.
+  /**
+   * ALWAYS loopback. This is the URL the adapter opens its control channel on,
+   * so it is also the last place a non-local host could sneak in — hence the
+   * exposure check AND the runtime `assertLoopbackOnly` assertion, both of
+   * which every port accessor shares by going through here.
+   *
+   * `https` deliberately resolves to `http`: there is no certificate for
+   * 127.0.0.1 and nothing to protect in transit on a loopback socket the
+   * bridge token already authenticates.
+   */
+  private async loopbackUrl(o: { port: number; protocol?: 'http' | 'https' | 'ws' }): Promise<string> {
     if (!this.ports.includes(o.port)) {
       throw new Error(`Port ${o.port} is not exposed by this sandbox.`);
     }
     await assertLoopbackOnly(o.port);
-    return `${o.protocol === 'ws' ? 'ws' : o.protocol === 'https' ? 'http' : 'http'}://127.0.0.1:${o.port}`;
-  };
+    return `${o.protocol === 'ws' ? 'ws' : 'http'}://127.0.0.1:${o.port}`;
+  }
+
+  /**
+   * The port accessor the adapter actually calls.
+   *
+   * The adapter reaches for `getPortEndpoint` — not the deprecated
+   * `getPortUrl` — at both its attach and its fresh-spawn paths. At 1.0.80 it
+   * called it UNCONDITIONALLY and had no fallback, so implementing only
+   * `getPortUrl` meant every claude-code run died with a TypeError the moment
+   * its bridge came up. 1.0.94 feature-detects instead
+   * (`'getPortEndpoint' in sandboxSession`), which turns that crash into a
+   * silent downgrade to the deprecated path — so this is still the method that
+   * decides which branch a run takes, and it is now the one that keeps the
+   * provider on the supported side of a deprecation.
+   *
+   * Both stay: the interface still declares `getPortUrl`, and a future adapter
+   * may call either.
+   *
+   * `headers` is deliberately absent. It exists on the interface for providers
+   * that gate a public tunnel with an auth header; a loopback socket has
+   * nothing to add, and inventing one would be a claim about a protection that
+   * is not there.
+   */
+  readonly getPortEndpoint = async (o: {
+    port: number;
+    protocol?: 'http' | 'https' | 'ws';
+  }): Promise<{ url: string }> => ({ url: await this.loopbackUrl(o) });
+
+  /** @deprecated by the framework; kept because the interface still declares it. */
+  readonly getPortUrl = async (o: {
+    port: number;
+    protocol?: 'http' | 'https' | 'ws';
+  }): Promise<string> => this.loopbackUrl(o);
 
   readonly setPorts = async (ports: readonly number[]): Promise<void> => {
     // Full-replacement semantics per the interface contract.
@@ -424,12 +523,33 @@ class LocalSandboxSession {
     }
   };
 
-  /** Reserve a loopback port for the bridge and expose it. */
+  /**
+   * Reserve a loopback port for the bridge and EXPOSE it.
+   *
+   * The exposure half is the point. A bridge-backed adapter reads
+   * `sandboxSession.ports[0]` to decide where its bridge should listen, and
+   * refuses the whole run when the array is empty
+   * (`HarnessCapabilityUnsupportedError: "The claude-code harness needs a TCP
+   * port exposed by the sandbox."`). This method existed and had no caller, so
+   * `ports` was always `[]` and no bridge-backed harness could ever start.
+   */
   async allocatePort(): Promise<PortReservation> {
     const res = await reserveLoopbackPort();
     this.reservations.set(res.port, res);
     this.ports.push(res.port);
     return res;
+  }
+
+  /**
+   * Drop the holding listeners while KEEPING the ports exposed.
+   *
+   * `ports` is what the adapter reads; `reservations` is only how we held them
+   * against the rest of the machine until something was ready to bind. See the
+   * call site in {@link launch}.
+   */
+  private releasePortReservations(): void {
+    for (const res of this.reservations.values()) res.release();
+    this.reservations.clear();
   }
 
   readonly setNetworkPolicy = async (policy: unknown): Promise<void> => {
@@ -465,8 +585,7 @@ class LocalSandboxSession {
     this.stopped = true;
     for (const child of this.children) killTree(child, KILL_GRACE_MS);
     this.children.clear();
-    for (const res of this.reservations.values()) res.release();
-    this.reservations.clear();
+    this.releasePortReservations();
     this.ports.length = 0;
   };
 
@@ -519,18 +638,57 @@ export class LocalWorktreeSandboxProvider {
 
     const session = new LocalSandboxSession(
       sessionId,
-      // The worktree's PARENT — the framework appends a subdirectory. See the
-      // working-directory note in the module header.
-      path.dirname(root),
+      // A Limboo-owned state root under userData that holds a link to the
+      // worktree — the framework appends a subdirectory to this. See the
+      // working-directory note in the module header and `stateRoot.ts`.
+      this.stateRootFor(root),
       root,
       this.deps.resolveSandbox(sessionId, root),
       this.deps.attachmentsDirFor?.(sessionId),
-      this.deps.envKeysFor?.() ?? [],
+      this.deps.envKeysFor?.(sessionId) ?? [],
       this.deps.diag ?? ((): void => undefined),
     );
+    // Expose a loopback port BEFORE the adapter reads `ports`. A bridge-backed
+    // harness refuses the run outright when the array is empty, so this is not
+    // an optimisation — it is what makes such a harness startable at all.
+    await session.allocatePort();
     this.sessions.set(sessionId, session);
     return session;
   };
+
+  /**
+   * The directory this provider reports as `defaultWorkingDirectory`.
+   *
+   * Normally `{userData}/harness-state/<bucket>`, with a link to the execution
+   * root inside it (see `stateRoot.ts`). If the link cannot be created, fall
+   * back to the worktree's parent ONLY when that parent is already inside
+   * Limboo's worktree root — which is what shipped before and is still under
+   * userData. For a plain session the parent is the user's own projects
+   * directory, so writing adapter state there is refused instead: littering
+   * `.harness-bootstrap/` beside somebody's repository is not a degraded mode,
+   * it is the failure this whole arrangement exists to prevent.
+   */
+  private stateRootFor(root: string): string {
+    try {
+      return prepareStateRoot(root).stateRoot;
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      if (canFallBackToParent(root, this.deps.worktreeRoot())) {
+        this.deps.diag?.(
+          'warning',
+          'Harness state root unavailable; using the worktree parent',
+          detail,
+        );
+        return path.dirname(root);
+      }
+      throw new Error(
+        'Limboo could not prepare a private directory for the agent harness, and ' +
+          'this session is not worktree-backed — so the harness would have to write ' +
+          'its runtime beside your repository. Create a worktree for this session, ' +
+          `or fix the state directory. Reason: ${detail}`,
+      );
+    }
+  }
 
   readonly resumeSession = async (options: { sessionId: string }): Promise<LocalSandboxSession> => {
     const found = this.sessions.get(options.sessionId);

--- a/src/main/managers/harness/sandbox/patchBridge.ts
+++ b/src/main/managers/harness/sandbox/patchBridge.ts
@@ -31,7 +31,7 @@
  * either one into a warning.
  */
 
-/** The exact literal the adapter ships. Verified in 1.0.80 (exactly one site). */
+/** The exact literal the adapter ships. Re-verified in 1.0.94 (exactly one site). */
 const BIND_ALL = /host:\s*(["'])0\.0\.0\.0\1/g;
 const LOOPBACK = 'host: "127.0.0.1"';
 

--- a/src/main/managers/harness/sandbox/stateRoot.ts
+++ b/src/main/managers/harness/sandbox/stateRoot.ts
@@ -1,0 +1,155 @@
+/**
+ * Where a harness session's adapter state lives, and how the framework's
+ * working-directory arithmetic is made to land on the real worktree anyway.
+ *
+ * ── THE CONSTRAINT ───────────────────────────────────────────────────────
+ * The AI SDK framework composes a session's cwd as
+ * `posix.join(defaultWorkingDirectory, workDir)` and rejects `workDir: '.'`,
+ * so the session always lands in a SUBDIRECTORY of whatever the provider
+ * reports as its default. The adapter then resolves its own state against that
+ * same default:
+ *
+ *   <default>/.harness-bootstrap/claude-code/   (installed CLI + bridge)
+ *   <default>/.agent-runs/<sessionId>/bridge/   (per-run bridge state)
+ *
+ * So "where the state goes" and "where the agent works" are ONE value, and the
+ * provider only gets to pick one of them.
+ *
+ * ── WHY NOT `path.dirname(worktree)` ─────────────────────────────────────
+ * That was the original answer, and it is right exactly when the session is
+ * worktree-backed: the parent is `{userData}/worktrees/<bucket>`, already
+ * Limboo-owned. But `WorktreeManager.resolveSessionRoot` FALLS BACK to the
+ * workspace path for a plain session, and then the parent is wherever the user
+ * keeps their code — so a first run would create `~/Desktop/.harness-bootstrap/`
+ * and `~/Desktop/.agent-runs/` beside their repository, and the provider's own
+ * state carve-out would grant the harness read+write to those trees at an
+ * arbitrary location on disk.
+ *
+ * ── THE ANSWER ───────────────────────────────────────────────────────────
+ * Report a Limboo-owned directory as `defaultWorkingDirectory` for EVERY
+ * session — worktree-backed or not — and make `<stateRoot>/<basename(root)>` a
+ * real on-disk link to the execution root:
+ *
+ *   {userData}/harness-state/<sha1(realpath(root)).slice(0,12)>/
+ *     ├── .harness-bootstrap/…        adapter state, always under userData
+ *     ├── .agent-runs/…               adapter state, always under userData
+ *     └── <basename(root)>  ─────────▶ the real worktree (symlink/junction)
+ *
+ * The link must be REAL rather than an in-process alias: the adapter spawns
+ * `node bridge.mjs --workdir <stateRoot>/<name>`, and that child `cd`s there
+ * itself. A path this process rewrites but the filesystem does not have would
+ * fail in the child, where nothing can translate it back.
+ *
+ * Containment is unchanged by the link. `LocalSandboxSession.resolvePath`
+ * canonicalizes with `realpathNearest` BEFORE confining, so
+ * `<stateRoot>/<name>/foo` resolves to `<worktree>/foo` and is admitted by the
+ * ordinary worktree check — not by a new carve-out. The crown-jewel refusal
+ * still runs first and unconditionally.
+ *
+ * The bucket hash follows `worktree/paths.ts` (`repoBucket`) so both features
+ * derive a directory name from a path the same way.
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { app } from 'electron';
+
+/** Root of every harness session's state. Always inside userData. */
+export function harnessStateRootDir(): string {
+  return path.join(app.getPath('userData'), 'harness-state');
+}
+
+/** Short, stable per-execution-root bucket. The `repoBucket` idiom. */
+function bucketFor(root: string): string {
+  let real = root;
+  try {
+    real = fs.realpathSync.native(root);
+  } catch {
+    /* keep the normalized path when realpath fails (e.g. a transient share) */
+  }
+  return crypto
+    .createHash('sha1')
+    .update(path.normalize(real).toLowerCase())
+    .digest('hex')
+    .slice(0, 12);
+}
+
+export interface HarnessStateLayout {
+  /** What the provider reports as `defaultWorkingDirectory`. */
+  stateRoot: string;
+  /** The `workDir` a caller passes so the framework's join lands on `root`. */
+  workDir: string;
+  /** `<stateRoot>/<workDir>` — the path the harness and its child actually use. */
+  linkPath: string;
+}
+
+/**
+ * Prepare the state root for one execution root, creating the link.
+ *
+ * Idempotent: an existing link pointing at the same target is left alone, and a
+ * stale one (the worktree was recreated at a different real path) is replaced.
+ *
+ * @throws when the link cannot be created and the caller must not fall back —
+ * see {@link canFallBackToParent}.
+ */
+export function prepareStateRoot(root: string): HarnessStateLayout {
+  const stateRoot = path.join(harnessStateRootDir(), bucketFor(root));
+  const workDir = path.basename(root);
+  const linkPath = path.join(stateRoot, workDir);
+
+  fs.mkdirSync(stateRoot, { recursive: true });
+
+  const target = path.resolve(root);
+  let existing: string | null = null;
+  try {
+    existing = fs.readlinkSync(linkPath);
+  } catch {
+    existing = null;
+  }
+  if (existing !== null) {
+    // Compare canonically: a junction reads back as an extended-length path on
+    // Windows, and the worktree may itself sit behind a symlinked home.
+    if (samePath(existing, target)) return { stateRoot, workDir, linkPath };
+    fs.rmSync(linkPath, { force: true });
+  } else if (fs.existsSync(linkPath)) {
+    // Something that is NOT a link occupies the slot. Refuse rather than delete:
+    // this is inside userData, but it is still not ours to remove blind.
+    throw new Error(
+      `Harness state path ${workDir} exists and is not a link to the session workspace.`,
+    );
+  }
+
+  // 'junction' on win32: directory junctions need no elevation and no Developer
+  // Mode, unlike a real symlink. Elsewhere 'dir' is the portable choice.
+  fs.symlinkSync(target, linkPath, process.platform === 'win32' ? 'junction' : 'dir');
+  return { stateRoot, workDir, linkPath };
+}
+
+/**
+ * May a session fall back to `path.dirname(root)` when the link cannot be made?
+ *
+ * ONLY when the parent is already inside Limboo's own worktree root — i.e. the
+ * session is worktree-backed and the fallback writes into
+ * `{userData}/worktrees/<bucket>`, which is exactly what shipped before. For a
+ * plain session the parent is the user's own projects directory, and writing
+ * adapter state there is the thing this module exists to prevent, so the caller
+ * must refuse the session instead.
+ */
+export function canFallBackToParent(root: string, worktreeRoot: string): boolean {
+  const parent = path.resolve(path.dirname(root));
+  const wt = path.resolve(worktreeRoot);
+  return parent === wt || parent.startsWith(wt + path.sep);
+}
+
+function samePath(a: string, b: string): boolean {
+  const norm = (p: string): string => {
+    let out = path.resolve(p);
+    try {
+      out = fs.realpathSync.native(out);
+    } catch {
+      /* not present — compare the resolved form */
+    }
+    return process.platform === 'win32' ? out.toLowerCase() : out;
+  };
+  return norm(a) === norm(b);
+}

--- a/src/main/managers/harness/toolchain.ts
+++ b/src/main/managers/harness/toolchain.ts
@@ -94,9 +94,12 @@ function hintFor(tool: string): string {
  * Splits on the shell operators that open a new command position (`&&`, `||`,
  * `;`, `|`, and the `(`/`{` group openers), then walks each segment left to
  * right for the first real executable. Walking rather than just taking word[0]
- * matters: the claude-code plan's second command is
- * `… ; then node node_modules/…/install.cjs ; fi && …`, where `then` holds the
- * first position and `node` — an actual prerequisite — is the second.
+ * matters because a bootstrap command may be a whole pipeline: in a form like
+ * `if … ; then node node_modules/…/install.cjs ; fi && …`, `then` holds the
+ * first position and `node` — an actual prerequisite — is the second. (The
+ * claude-code plan at 1.0.94 is simpler than that — two flat
+ * commands — but the walk is what keeps this version-independent, and the
+ * shape above is one adapters have shipped.)
  *
  * Deliberately conservative. This decides what to PROBE, and a false positive
  * becomes a prerequisite the user is told to install for no reason, so the walk

--- a/src/renderer/features/settings/panels/ClaudeCodeControls.tsx
+++ b/src/renderer/features/settings/panels/ClaudeCodeControls.tsx
@@ -130,10 +130,27 @@ export function ClaudeCodeControls() {
             <div className="flex flex-col gap-2">
               <p className="text-[11px] leading-relaxed text-faint">
                 Before its first session the harness installs the Claude Code CLI into its own
-                directory beside your worktree — never into your repository. This reaches the npm
-                registry from this machine, so it needs your approval once. These are the exact
-                commands that will run.
+                private directory — never into your repository, and never beside it. This reaches
+                the npm registry from this machine, so it needs your approval once. These are the
+                exact commands that will run.
               </p>
+              {plan.dir && (
+                // WHERE these run is load-bearing, not context. Limboo executes
+                // them with the working directory set to this folder, and the
+                // adapter writes the lockfile they install from into it first —
+                // so the same commands pasted into a shell fail with
+                // ERR_PNPM_NO_LOCKFILE and read as a Limboo bug. The panel used
+                // to show the commands alone, and that is exactly what happened.
+                <p className="text-[11px] leading-relaxed text-faint">
+                  Limboo runs them in{' '}
+                  <span className="font-mono text-muted">{plan.dir}</span>, after writing{' '}
+                  <span className="font-mono text-muted">
+                    {plan.files.map((f) => f.split('/').pop()).join(', ')}
+                  </span>{' '}
+                  there. Run somewhere else — a terminal, your home directory — they will fail:
+                  the lockfile they install from lives in that folder.
+                </p>
+              )}
               <pre className="overflow-x-auto whitespace-pre-wrap break-all rounded-md border border-line bg-surface-2 px-2 py-1.5 font-mono text-[11px] leading-relaxed text-fg">
                 {plan.commands.join('\n\n')}
               </pre>

--- a/src/shared/releaseManifest.generated.ts
+++ b/src/shared/releaseManifest.generated.ts
@@ -24,6 +24,84 @@ import type { ReleaseIndexEntry, ReleaseManifestEntry } from './release';
 /** Newest first. */
 export const RELEASE_MANIFESTS: ReleaseManifestEntry[] = [
   {
+    "version": "1.20.0",
+    "date": "2026-08-31",
+    "channel": "stable",
+    "codename": null,
+    "gitTag": "v1.20.0",
+    "commit": null,
+    "buildNumber": null,
+    "summary": "Limboo 1.20.0 makes the agent harness actually run. 1.19.0 repaired its\npackaging; this release fixes the three separate reasons a run still could not\nstart, gives harness conversations memory between prompts, and moves the\nharness runtime somewhere it belongs.",
+    "sections": [
+      {
+        "category": "fixed",
+        "title": "Fixed",
+        "items": [
+          {
+            "lead": "The harness could not start a run at all — for three independent reasons",
+            "text": "Its one-time setup was refused by Limboo's own path guard on its very first\n  command, so the install could never begin. No network port was ever handed to\n  the agent bridge, which the harness requires and refuses to start without. And\n  the method the adapter uses to reach that bridge was missing, so a run that got\n  past the first two failed the moment the bridge came up. Each of these was\n  enough on its own; all three are fixed, and the setup now completes."
+          },
+          {
+            "lead": "Setup failures were retried forever instead of being reported",
+            "text": "A refusal\n  that mentioned the network — such as the sandbox network policy blocking the\n  download — was mistaken for a dropped connection and retried, though the same\n  setting would produce it again immediately. Refusals are now recognised for\n  what they are and reported once, with the reason."
+          },
+          {
+            "lead": "A failed setup command said nothing useful",
+            "text": "If one of the approved commands\n  ran and failed — a large download timing out is enough — it surfaced as a\n  generic failed run. It now reports what failed and what the tool itself said to\n  do about it, and is not retried: the package manager records the install as\n  complete even when part of it failed, so re-running it fails identically."
+          },
+          {
+            "lead": "Every prompt started a new conversation, and left a process behind",
+            "text": "Each\n  turn opened a fresh harness session without ending the previous one, so the\n  agent forgot the turn before and one background process accumulated per prompt."
+          },
+          {
+            "lead": "Non-Anthropic harnesses could never authenticate",
+            "text": "They were handed\n  Anthropic's credential variable names instead of their own, because the\n  credential lookup read the configured harness rather than the one the selected\n  model actually runs on."
+          }
+        ],
+        "markdown": "- **The harness could not start a run at all — for three independent reasons.**\n  Its one-time setup was refused by Limboo's own path guard on its very first\n  command, so the install could never begin. No network port was ever handed to\n  the agent bridge, which the harness requires and refuses to start without. And\n  the method the adapter uses to reach that bridge was missing, so a run that got\n  past the first two failed the moment the bridge came up. Each of these was\n  enough on its own; all three are fixed, and the setup now completes.\n- **Setup failures were retried forever instead of being reported.** A refusal\n  that mentioned the network — such as the sandbox network policy blocking the\n  download — was mistaken for a dropped connection and retried, though the same\n  setting would produce it again immediately. Refusals are now recognised for\n  what they are and reported once, with the reason.\n- **A failed setup command said nothing useful.** If one of the approved commands\n  ran and failed — a large download timing out is enough — it surfaced as a\n  generic failed run. It now reports what failed and what the tool itself said to\n  do about it, and is not retried: the package manager records the install as\n  complete even when part of it failed, so re-running it fails identically.\n- **Every prompt started a new conversation, and left a process behind.** Each\n  turn opened a fresh harness session without ending the previous one, so the\n  agent forgot the turn before and one background process accumulated per prompt.\n- **Non-Anthropic harnesses could never authenticate.** They were handed\n  Anthropic's credential variable names instead of their own, because the\n  credential lookup read the configured harness rather than the one the selected\n  model actually runs on."
+      },
+      {
+        "category": "changed",
+        "title": "Changed",
+        "items": [
+          {
+            "lead": "The harness keeps its runtime inside Limboo's own data directory",
+            "text": "It used\n  to be placed next to your worktree, which is Limboo-owned for a session with a\n  worktree — but a session without one is rooted at your repository, so its\n  runtime landed beside your project folder. It now always lives under Limboo's\n  application data, never in your repository and never next to it. Existing\n  installs will re-run the one-time setup once, in the new location."
+          },
+          {
+            "lead": "The setup panel says where the commands run",
+            "text": "It listed the two commands and\n  nothing else, so copying them into a terminal was the obvious thing to try —\n  and it fails, because the lockfile they install from is written into the setup\n  directory first. The panel now names that directory and the files placed in it.\n  Your existing approval still stands: the commands themselves have not changed."
+          },
+          {
+            "lead": "The agent harness packages were updated",
+            "text": "(`@ai-sdk/harness` 1.0.91,\n  `@ai-sdk/harness-claude-code` 1.0.94). Every assumption Limboo makes about\n  their internals — where the runtime is installed, how the bridge binds, which\n  harnesses can be permission-gated — was re-checked against the new versions."
+          }
+        ],
+        "markdown": "- **The harness keeps its runtime inside Limboo's own data directory.** It used\n  to be placed next to your worktree, which is Limboo-owned for a session with a\n  worktree — but a session without one is rooted at your repository, so its\n  runtime landed beside your project folder. It now always lives under Limboo's\n  application data, never in your repository and never next to it. Existing\n  installs will re-run the one-time setup once, in the new location.\n- **The setup panel says where the commands run.** It listed the two commands and\n  nothing else, so copying them into a terminal was the obvious thing to try —\n  and it fails, because the lockfile they install from is written into the setup\n  directory first. The panel now names that directory and the files placed in it.\n  Your existing approval still stands: the commands themselves have not changed.\n- **The agent harness packages were updated** (`@ai-sdk/harness` 1.0.91,\n  `@ai-sdk/harness-claude-code` 1.0.94). Every assumption Limboo makes about\n  their internals — where the runtime is installed, how the bridge binds, which\n  harnesses can be permission-gated — was re-checked against the new versions."
+      }
+    ],
+    "contributors": [],
+    "pullRequests": [],
+    "mergedBranches": [],
+    "assets": [],
+    "signing": [],
+    "stats": {
+      "commits": null,
+      "filesChanged": null,
+      "additions": null,
+      "deletions": null
+    },
+    "links": {
+      "release": "https://github.com/limboo-ai/limboo/releases/tag/v1.20.0",
+      "compare": null,
+      "tag": "https://github.com/limboo-ai/limboo/releases/tag/v1.20.0",
+      "milestone": null
+    },
+    "checksumManifest": "SHA256SUMS",
+    "provenanceRepo": "limboo-ai/limboo",
+    "markdown": "Limboo 1.20.0 makes the agent harness actually run. 1.19.0 repaired its\npackaging; this release fixes the three separate reasons a run still could not\nstart, gives harness conversations memory between prompts, and moves the\nharness runtime somewhere it belongs.\n\n### Fixed\n\n- **The harness could not start a run at all — for three independent reasons.**\n  Its one-time setup was refused by Limboo's own path guard on its very first\n  command, so the install could never begin. No network port was ever handed to\n  the agent bridge, which the harness requires and refuses to start without. And\n  the method the adapter uses to reach that bridge was missing, so a run that got\n  past the first two failed the moment the bridge came up. Each of these was\n  enough on its own; all three are fixed, and the setup now completes.\n- **Setup failures were retried forever instead of being reported.** A refusal\n  that mentioned the network — such as the sandbox network policy blocking the\n  download — was mistaken for a dropped connection and retried, though the same\n  setting would produce it again immediately. Refusals are now recognised for\n  what they are and reported once, with the reason.\n- **A failed setup command said nothing useful.** If one of the approved commands\n  ran and failed — a large download timing out is enough — it surfaced as a\n  generic failed run. It now reports what failed and what the tool itself said to\n  do about it, and is not retried: the package manager records the install as\n  complete even when part of it failed, so re-running it fails identically.\n- **Every prompt started a new conversation, and left a process behind.** Each\n  turn opened a fresh harness session without ending the previous one, so the\n  agent forgot the turn before and one background process accumulated per prompt.\n- **Non-Anthropic harnesses could never authenticate.** They were handed\n  Anthropic's credential variable names instead of their own, because the\n  credential lookup read the configured harness rather than the one the selected\n  model actually runs on.\n\n### Changed\n\n- **The harness keeps its runtime inside Limboo's own data directory.** It used\n  to be placed next to your worktree, which is Limboo-owned for a session with a\n  worktree — but a session without one is rooted at your repository, so its\n  runtime landed beside your project folder. It now always lives under Limboo's\n  application data, never in your repository and never next to it. Existing\n  installs will re-run the one-time setup once, in the new location.\n- **The setup panel says where the commands run.** It listed the two commands and\n  nothing else, so copying them into a terminal was the obvious thing to try —\n  and it fails, because the lockfile they install from is written into the setup\n  directory first. The panel now names that directory and the files placed in it.\n  Your existing approval still stands: the commands themselves have not changed.\n- **The agent harness packages were updated** (`@ai-sdk/harness` 1.0.91,\n  `@ai-sdk/harness-claude-code` 1.0.94). Every assumption Limboo makes about\n  their internals — where the runtime is installed, how the bridge binds, which\n  harnesses can be permission-gated — was re-checked against the new versions."
+  },
+  {
     "version": "1.19.0",
     "date": "2026-08-30",
     "channel": "stable",
@@ -348,170 +426,18 @@ export const RELEASE_MANIFESTS: ReleaseManifestEntry[] = [
     "checksumManifest": "SHA256SUMS",
     "provenanceRepo": "limboo-ai/limboo",
     "markdown": "Limboo 1.18.0 stabilizes the Cursor fixes from the beta, adds the swappable\nharness layer, opens Settings as a workspace tab, and ships the beta update\nchannel as an opt-in path for future prereleases.\n\n### Fixed\n\n- **Cursor sessions denied every tool call.** The hook runner read the event name\n  from a single payload key that the CLI does not always send. With no event name\n  it could not identify what was being asked, so it failed closed — which is the\n  correct posture, but it meant every read, search, shell command and edit was\n  refused, and nothing on screen said why. The event name now travels in the\n  runner's own arguments, where Limboo writes it, with five payload spellings as\n  fallbacks, and a genuine failure now names the missing key in the timeline\n  instead of denying silently.\n- **Four more ways a Cursor run could stall.** The permission helper could boot as\n  a GUI process instead of a script and then hang for the full ten-minute hook\n  timeout on every single tool call; nothing timed out while it waited for input;\n  a successful approval could be truncated on its way out and be read as a\n  refusal; and the sandbox denied the helper access to its own communication\n  socket. Each is fixed, and each failure now reports what happened.\n- **\"Prompt me for everything\" meant \"deny everything\".** Tightening the approval\n  policy withdrew the rule that let Cursor read files at all. Because the only way\n  to ask for permission on that path is the hook bridge, a session with hooks\n  unavailable was left unable to read or to ask. Reads and inspection commands\n  now keep their floor regardless of the policy; the permission gate still runs\n  on top of it.\n- **A Cursor session could stream as Claude Code.** The model was checked for\n  character shape rather than for which provider serves it, and every Cursor\n  model id passes that check — so a mis-routed model was handed to the Claude\n  integration and ran there, with no error anywhere. Routing now has an explicit\n  \"unknown\" answer, dispatch is exhaustive, and a model nothing claims fails by\n  name instead of quietly running somewhere.\n- **Commit-message generation always used Claude.** A Cursor-only user pressing\n  the button started a Claude run and, with Claude not installed, was told to sign\n  in to a product they were not using. It now follows the agent you selected, and\n  the button is no longer disabled for Cursor users.\n- **Searching Settings missed several controls.** Some settings were never\n  registered in the search index, so typing their name found nothing. Fixed for\n  the Agent and Runtime categories, with a check that fails the build if it\n  happens again.\n- **Absolute paths inside your project were treated as escapes.** Cursor's CLI\n  writes full paths by default, and a full path to a file inside your own worktree\n  was classified as leaving it — so ordinary reads were refused during planning.\n\n### Added\n\n- **Agents can run through a harness layer.** Limboo now drives agents through\n  Vercel AI SDK 7's harness abstraction as well as its own integrations, so a new\n  agent runtime becomes an adapter rather than a new code path. Pi is available;\n  Claude Code runs through it behind an opt-in switch. Everything above the\n  adapter — the conversation, permissions, memory, search, the work graph, the\n  runtime panel — is unchanged, because they all sit on one seam.\n- **A sandbox that runs on your own worktree.** Every shipped sandbox for that\n  abstraction is either a cloud service or a private filesystem, and neither\n  fits: your repository must not leave the machine, and the agent has to edit the\n  actual files that git, the diff viewer and checkpoints are watching. Limboo has\n  its own, rooted at the session's worktree, with the same containment rules the\n  rest of the app enforces — nothing outside the worktree, and never the app's own\n  database, settings or secrets.\n- **Settings opens as a workspace tab.** An icon beside the close button promotes\n  the dialog into an editor tab, the way a diff opens. Both surfaces render the\n  same panels, so nothing drifts. The tab has no Cancel: settings apply as you\n  change them, exactly as they already did.\n- **An update channel you can choose.** Settings › Updates now offers Stable or\n  Beta. A beta is never downloaded in the background — you are shown its release\n  notes and decide.\n\n### Changed\n\n- **Settings panels are flat rows.** The Agent and MCP categories wrapped groups\n  of settings in bordered panels while every other category used plain labelled\n  rows, which made them look like a different application. The boxes are gone.\n  Every input, button and select now uses one corner radius.\n- **The Agent panel is reorganised.** Providers became Harnesses and now reads as\n  one list instead of two hand-built cards. Connection and reliability moved to\n  Runtime, where the rest of the supervision settings live. A section that\n  contained no settings at all was removed, and the remainder is ordered by the\n  decision you are making: which agent, which model, what it may do, what\n  contains it.\n- **The model hint stopped being wrong.** It named a default the app had not used\n  for several versions, because the text was typed by hand next to the value it\n  described. It is now derived from that value.\n\n### Security\n\n- **Built-in tools on the harness path are gated by Limboo.** The harness\n  abstraction has two separate approval surfaces, and the one Limboo had wired\n  covers only tools the host supplies — built-in file writes and shell commands\n  are governed by a different setting that defaults to allowing everything. On\n  that path an agent could have written files and run commands without Limboo's\n  permission gate. Every built-in tool call now suspends the turn and asks, using\n  the same authority, the same risk labels, the same dialogs and the same audit\n  trail as every other agent.\n- **A harness that cannot ask for permission is refused.** Rather than run it with\n  weaker enforcement, Limboo declines to start it and says so. This is not\n  theoretical: the Codex adapter reports that it cannot request approval for its\n  shell tool, so it is registered as unavailable with the reason shown rather than\n  offered and then failing.\n- **The harness setup step asks first.** Preparing a harness for its first run\n  downloads its agent CLI, which is the only time Limboo reaches the network\n  outside talking to your agent and fetching contributor avatars. The exact\n  commands are read from the adapter and shown to you for approval once, and the\n  approval is tied to those commands — if a later version changes them, you are\n  asked again. Without approval the run does not start.\n- **Credentials are passed through, never stored.** A harness receives an API key\n  only if your own environment already has one, from an explicitly named list.\n  Nothing is written to settings, accepted over the app's internal channels, put\n  on a command line, or logged. A gap in log redaction that could have printed\n  those variables is closed.\n- **Reads on the harness path cannot be gated, and the setting says so.** The\n  underlying runtime allows built-in file reads unconditionally, so\n  \"auto-approve reads\" has no effect there. Rather than leave a control that looks\n  like it works, the setting explains the limitation.\n\n### Known limitations\n\n- **The harness path is off by default.** Claude Code and Cursor continue to run\n  through their own integrations. Turn the harness on in Settings › Agent ›\n  Harnesses if you want to try it; you will be asked to approve its setup step\n  first.\n- **A harness conversation does not resume.** Each message starts a fresh\n  conversation with the underlying runtime. The alternative failed on every second\n  message, so this is deliberate until the resume format is handled properly.\n- **Codex is unavailable.** Its adapter cannot ask for permission before running\n  shell commands. It is listed with that reason rather than hidden."
-  },
-  {
-    "version": "1.18.0-beta.2",
-    "date": "2026-08-12",
-    "channel": "beta",
-    "codename": null,
-    "gitTag": "v1.18.0-beta.2",
-    "commit": null,
-    "buildNumber": null,
-    "summary": "The first beta. Two bugs that made Cursor sessions unusable are fixed, agents can\nnow run through a swappable harness layer instead of one hardcoded integration,\nand Settings opens as a workspace tab. This build is published for testing ahead\nof a stable release — read the warning at the top of these notes before\ninstalling it over a working copy.",
-    "sections": [
-      {
-        "category": "fixed",
-        "title": "Fixed",
-        "items": [
-          {
-            "lead": "Cursor sessions denied every tool call",
-            "text": "The hook runner read the event name\n  from a single payload key that the CLI does not always send. With no event name\n  it could not identify what was being asked, so it failed closed — which is the\n  correct posture, but it meant every read, search, shell command and edit was\n  refused, and nothing on screen said why. The event name now travels in the\n  runner's own arguments, where Limboo writes it, with five payload spellings as\n  fallbacks, and a genuine failure now names the missing key in the timeline\n  instead of denying silently."
-          },
-          {
-            "lead": "Four more ways a Cursor run could stall",
-            "text": "The permission helper could boot as\n  a GUI process instead of a script and then hang for the full ten-minute hook\n  timeout on every single tool call; nothing timed out while it waited for input;\n  a successful approval could be truncated on its way out and be read as a\n  refusal; and the sandbox denied the helper access to its own communication\n  socket. Each is fixed, and each failure now reports what happened."
-          },
-          {
-            "lead": "\"Prompt me for everything\" meant \"deny everything\"",
-            "text": "Tightening the approval\n  policy withdrew the rule that let Cursor read files at all. Because the only way\n  to ask for permission on that path is the hook bridge, a session with hooks\n  unavailable was left unable to read or to ask. Reads and inspection commands\n  now keep their floor regardless of the policy; the permission gate still runs\n  on top of it."
-          },
-          {
-            "lead": "A Cursor session could stream as Claude Code",
-            "text": "The model was checked for\n  character shape rather than for which provider serves it, and every Cursor\n  model id passes that check — so a mis-routed model was handed to the Claude\n  integration and ran there, with no error anywhere. Routing now has an explicit\n  \"unknown\" answer, dispatch is exhaustive, and a model nothing claims fails by\n  name instead of quietly running somewhere."
-          },
-          {
-            "lead": "Commit-message generation always used Claude",
-            "text": "A Cursor-only user pressing\n  the button started a Claude run and, with Claude not installed, was told to sign\n  in to a product they were not using. It now follows the agent you selected, and\n  the button is no longer disabled for Cursor users."
-          },
-          {
-            "lead": "Searching Settings missed several controls",
-            "text": "Some settings were never\n  registered in the search index, so typing their name found nothing. Fixed for\n  the Agent and Runtime categories, with a check that fails the build if it\n  happens again."
-          },
-          {
-            "lead": "Absolute paths inside your project were treated as escapes",
-            "text": "Cursor's CLI\n  writes full paths by default, and a full path to a file inside your own worktree\n  was classified as leaving it — so ordinary reads were refused during planning."
-          }
-        ],
-        "markdown": "- **Cursor sessions denied every tool call.** The hook runner read the event name\n  from a single payload key that the CLI does not always send. With no event name\n  it could not identify what was being asked, so it failed closed — which is the\n  correct posture, but it meant every read, search, shell command and edit was\n  refused, and nothing on screen said why. The event name now travels in the\n  runner's own arguments, where Limboo writes it, with five payload spellings as\n  fallbacks, and a genuine failure now names the missing key in the timeline\n  instead of denying silently.\n- **Four more ways a Cursor run could stall.** The permission helper could boot as\n  a GUI process instead of a script and then hang for the full ten-minute hook\n  timeout on every single tool call; nothing timed out while it waited for input;\n  a successful approval could be truncated on its way out and be read as a\n  refusal; and the sandbox denied the helper access to its own communication\n  socket. Each is fixed, and each failure now reports what happened.\n- **\"Prompt me for everything\" meant \"deny everything\".** Tightening the approval\n  policy withdrew the rule that let Cursor read files at all. Because the only way\n  to ask for permission on that path is the hook bridge, a session with hooks\n  unavailable was left unable to read or to ask. Reads and inspection commands\n  now keep their floor regardless of the policy; the permission gate still runs\n  on top of it.\n- **A Cursor session could stream as Claude Code.** The model was checked for\n  character shape rather than for which provider serves it, and every Cursor\n  model id passes that check — so a mis-routed model was handed to the Claude\n  integration and ran there, with no error anywhere. Routing now has an explicit\n  \"unknown\" answer, dispatch is exhaustive, and a model nothing claims fails by\n  name instead of quietly running somewhere.\n- **Commit-message generation always used Claude.** A Cursor-only user pressing\n  the button started a Claude run and, with Claude not installed, was told to sign\n  in to a product they were not using. It now follows the agent you selected, and\n  the button is no longer disabled for Cursor users.\n- **Searching Settings missed several controls.** Some settings were never\n  registered in the search index, so typing their name found nothing. Fixed for\n  the Agent and Runtime categories, with a check that fails the build if it\n  happens again.\n- **Absolute paths inside your project were treated as escapes.** Cursor's CLI\n  writes full paths by default, and a full path to a file inside your own worktree\n  was classified as leaving it — so ordinary reads were refused during planning."
-      },
-      {
-        "category": "added",
-        "title": "Added",
-        "items": [
-          {
-            "lead": "Agents can run through a harness layer",
-            "text": "Limboo now drives agents through\n  Vercel AI SDK 7's harness abstraction as well as its own integrations, so a new\n  agent runtime becomes an adapter rather than a new code path. Pi is available;\n  Claude Code runs through it behind an opt-in switch. Everything above the\n  adapter — the conversation, permissions, memory, search, the work graph, the\n  runtime panel — is unchanged, because they all sit on one seam."
-          },
-          {
-            "lead": "A sandbox that runs on your own worktree",
-            "text": "Every shipped sandbox for that\n  abstraction is either a cloud service or a private filesystem, and neither\n  fits: your repository must not leave the machine, and the agent has to edit the\n  actual files that git, the diff viewer and checkpoints are watching. Limboo has\n  its own, rooted at the session's worktree, with the same containment rules the\n  rest of the app enforces — nothing outside the worktree, and never the app's own\n  database, settings or secrets."
-          },
-          {
-            "lead": "Settings opens as a workspace tab",
-            "text": "An icon beside the close button promotes\n  the dialog into an editor tab, the way a diff opens. Both surfaces render the\n  same panels, so nothing drifts. The tab has no Cancel: settings apply as you\n  change them, exactly as they already did."
-          },
-          {
-            "lead": "An update channel you can choose",
-            "text": "Settings › Updates now offers Stable or\n  Beta. A beta is never downloaded in the background — you are shown its release\n  notes and decide."
-          }
-        ],
-        "markdown": "- **Agents can run through a harness layer.** Limboo now drives agents through\n  Vercel AI SDK 7's harness abstraction as well as its own integrations, so a new\n  agent runtime becomes an adapter rather than a new code path. Pi is available;\n  Claude Code runs through it behind an opt-in switch. Everything above the\n  adapter — the conversation, permissions, memory, search, the work graph, the\n  runtime panel — is unchanged, because they all sit on one seam.\n- **A sandbox that runs on your own worktree.** Every shipped sandbox for that\n  abstraction is either a cloud service or a private filesystem, and neither\n  fits: your repository must not leave the machine, and the agent has to edit the\n  actual files that git, the diff viewer and checkpoints are watching. Limboo has\n  its own, rooted at the session's worktree, with the same containment rules the\n  rest of the app enforces — nothing outside the worktree, and never the app's own\n  database, settings or secrets.\n- **Settings opens as a workspace tab.** An icon beside the close button promotes\n  the dialog into an editor tab, the way a diff opens. Both surfaces render the\n  same panels, so nothing drifts. The tab has no Cancel: settings apply as you\n  change them, exactly as they already did.\n- **An update channel you can choose.** Settings › Updates now offers Stable or\n  Beta. A beta is never downloaded in the background — you are shown its release\n  notes and decide."
-      },
-      {
-        "category": "changed",
-        "title": "Changed",
-        "items": [
-          {
-            "lead": "Settings panels are flat rows",
-            "text": "The Agent and MCP categories wrapped groups\n  of settings in bordered panels while every other category used plain labelled\n  rows, which made them look like a different application. The boxes are gone.\n  Every input, button and select now uses one corner radius."
-          },
-          {
-            "lead": "The Agent panel is reorganised",
-            "text": "Providers became Harnesses and now reads as\n  one list instead of two hand-built cards. Connection and reliability moved to\n  Runtime, where the rest of the supervision settings live. A section that\n  contained no settings at all was removed, and the remainder is ordered by the\n  decision you are making: which agent, which model, what it may do, what\n  contains it."
-          },
-          {
-            "lead": "The model hint stopped being wrong",
-            "text": "It named a default the app had not used\n  for several versions, because the text was typed by hand next to the value it\n  described. It is now derived from that value."
-          }
-        ],
-        "markdown": "- **Settings panels are flat rows.** The Agent and MCP categories wrapped groups\n  of settings in bordered panels while every other category used plain labelled\n  rows, which made them look like a different application. The boxes are gone.\n  Every input, button and select now uses one corner radius.\n- **The Agent panel is reorganised.** Providers became Harnesses and now reads as\n  one list instead of two hand-built cards. Connection and reliability moved to\n  Runtime, where the rest of the supervision settings live. A section that\n  contained no settings at all was removed, and the remainder is ordered by the\n  decision you are making: which agent, which model, what it may do, what\n  contains it.\n- **The model hint stopped being wrong.** It named a default the app had not used\n  for several versions, because the text was typed by hand next to the value it\n  described. It is now derived from that value."
-      },
-      {
-        "category": "security",
-        "title": "Security",
-        "items": [
-          {
-            "lead": "Built-in tools on the harness path are gated by Limboo",
-            "text": "The harness\n  abstraction has two separate approval surfaces, and the one Limboo had wired\n  covers only tools the host supplies — built-in file writes and shell commands\n  are governed by a different setting that defaults to allowing everything. On\n  that path an agent could have written files and run commands without Limboo's\n  permission gate. Every built-in tool call now suspends the turn and asks, using\n  the same authority, the same risk labels, the same dialogs and the same audit\n  trail as every other agent."
-          },
-          {
-            "lead": "A harness that cannot ask for permission is refused",
-            "text": "Rather than run it with\n  weaker enforcement, Limboo declines to start it and says so. This is not\n  theoretical: the Codex adapter reports that it cannot request approval for its\n  shell tool, so it is registered as unavailable with the reason shown rather than\n  offered and then failing."
-          },
-          {
-            "lead": "The harness setup step asks first",
-            "text": "Preparing a harness for its first run\n  downloads its agent CLI, which is the only time Limboo reaches the network\n  outside talking to your agent and fetching contributor avatars. The exact\n  commands are read from the adapter and shown to you for approval once, and the\n  approval is tied to those commands — if a later version changes them, you are\n  asked again. Without approval the run does not start."
-          },
-          {
-            "lead": "Credentials are passed through, never stored",
-            "text": "A harness receives an API key\n  only if your own environment already has one, from an explicitly named list.\n  Nothing is written to settings, accepted over the app's internal channels, put\n  on a command line, or logged. A gap in log redaction that could have printed\n  those variables is closed."
-          },
-          {
-            "lead": "Reads on the harness path cannot be gated, and the setting says so",
-            "text": "The\n  underlying runtime allows built-in file reads unconditionally, so\n  \"auto-approve reads\" has no effect there. Rather than leave a control that looks\n  like it works, the setting explains the limitation."
-          }
-        ],
-        "markdown": "- **Built-in tools on the harness path are gated by Limboo.** The harness\n  abstraction has two separate approval surfaces, and the one Limboo had wired\n  covers only tools the host supplies — built-in file writes and shell commands\n  are governed by a different setting that defaults to allowing everything. On\n  that path an agent could have written files and run commands without Limboo's\n  permission gate. Every built-in tool call now suspends the turn and asks, using\n  the same authority, the same risk labels, the same dialogs and the same audit\n  trail as every other agent.\n- **A harness that cannot ask for permission is refused.** Rather than run it with\n  weaker enforcement, Limboo declines to start it and says so. This is not\n  theoretical: the Codex adapter reports that it cannot request approval for its\n  shell tool, so it is registered as unavailable with the reason shown rather than\n  offered and then failing.\n- **The harness setup step asks first.** Preparing a harness for its first run\n  downloads its agent CLI, which is the only time Limboo reaches the network\n  outside talking to your agent and fetching contributor avatars. The exact\n  commands are read from the adapter and shown to you for approval once, and the\n  approval is tied to those commands — if a later version changes them, you are\n  asked again. Without approval the run does not start.\n- **Credentials are passed through, never stored.** A harness receives an API key\n  only if your own environment already has one, from an explicitly named list.\n  Nothing is written to settings, accepted over the app's internal channels, put\n  on a command line, or logged. A gap in log redaction that could have printed\n  those variables is closed.\n- **Reads on the harness path cannot be gated, and the setting says so.** The\n  underlying runtime allows built-in file reads unconditionally, so\n  \"auto-approve reads\" has no effect there. Rather than leave a control that looks\n  like it works, the setting explains the limitation."
-      },
-      {
-        "category": "known-issues",
-        "title": "Known limitations",
-        "items": [
-          {
-            "lead": "Beta builds are not released builds",
-            "text": "Features may change or be removed\n  before release. Settings and session data move forward but not back, so a build\n  made after this one may not read data this one wrote. Keep a stable install for\n  work you cannot repeat."
-          },
-          {
-            "lead": "The harness path is off by default",
-            "text": "Claude Code and Cursor continue to run\n  through their own integrations. Turn the harness on in Settings › Agent ›\n  Harnesses if you want to try it; you will be asked to approve its setup step\n  first."
-          },
-          {
-            "lead": "A harness conversation does not resume",
-            "text": "Each message starts a fresh\n  conversation with the underlying runtime. The alternative failed on every second\n  message, so this is deliberate until the resume format is handled properly."
-          },
-          {
-            "lead": "Codex is unavailable",
-            "text": "Its adapter cannot ask for permission before running\n  shell commands. It is listed with that reason rather than hidden."
-          }
-        ],
-        "markdown": "- **Beta builds are not released builds.** Features may change or be removed\n  before release. Settings and session data move forward but not back, so a build\n  made after this one may not read data this one wrote. Keep a stable install for\n  work you cannot repeat.\n- **The harness path is off by default.** Claude Code and Cursor continue to run\n  through their own integrations. Turn the harness on in Settings › Agent ›\n  Harnesses if you want to try it; you will be asked to approve its setup step\n  first.\n- **A harness conversation does not resume.** Each message starts a fresh\n  conversation with the underlying runtime. The alternative failed on every second\n  message, so this is deliberate until the resume format is handled properly.\n- **Codex is unavailable.** Its adapter cannot ask for permission before running\n  shell commands. It is listed with that reason rather than hidden."
-      }
-    ],
-    "contributors": [],
-    "pullRequests": [],
-    "mergedBranches": [],
-    "assets": [],
-    "signing": [],
-    "stats": {
-      "commits": null,
-      "filesChanged": null,
-      "additions": null,
-      "deletions": null
-    },
-    "links": {
-      "release": "https://github.com/limboo-ai/limboo/releases/tag/v1.18.0-beta.2",
-      "compare": null,
-      "tag": "https://github.com/limboo-ai/limboo/releases/tag/v1.18.0-beta.2",
-      "milestone": null
-    },
-    "checksumManifest": "SHA256SUMS",
-    "provenanceRepo": "limboo-ai/limboo",
-    "markdown": "The first beta. Two bugs that made Cursor sessions unusable are fixed, agents can\nnow run through a swappable harness layer instead of one hardcoded integration,\nand Settings opens as a workspace tab. This build is published for testing ahead\nof a stable release — read the warning at the top of these notes before\ninstalling it over a working copy.\n\n### Fixed\n\n- **Cursor sessions denied every tool call.** The hook runner read the event name\n  from a single payload key that the CLI does not always send. With no event name\n  it could not identify what was being asked, so it failed closed — which is the\n  correct posture, but it meant every read, search, shell command and edit was\n  refused, and nothing on screen said why. The event name now travels in the\n  runner's own arguments, where Limboo writes it, with five payload spellings as\n  fallbacks, and a genuine failure now names the missing key in the timeline\n  instead of denying silently.\n- **Four more ways a Cursor run could stall.** The permission helper could boot as\n  a GUI process instead of a script and then hang for the full ten-minute hook\n  timeout on every single tool call; nothing timed out while it waited for input;\n  a successful approval could be truncated on its way out and be read as a\n  refusal; and the sandbox denied the helper access to its own communication\n  socket. Each is fixed, and each failure now reports what happened.\n- **\"Prompt me for everything\" meant \"deny everything\".** Tightening the approval\n  policy withdrew the rule that let Cursor read files at all. Because the only way\n  to ask for permission on that path is the hook bridge, a session with hooks\n  unavailable was left unable to read or to ask. Reads and inspection commands\n  now keep their floor regardless of the policy; the permission gate still runs\n  on top of it.\n- **A Cursor session could stream as Claude Code.** The model was checked for\n  character shape rather than for which provider serves it, and every Cursor\n  model id passes that check — so a mis-routed model was handed to the Claude\n  integration and ran there, with no error anywhere. Routing now has an explicit\n  \"unknown\" answer, dispatch is exhaustive, and a model nothing claims fails by\n  name instead of quietly running somewhere.\n- **Commit-message generation always used Claude.** A Cursor-only user pressing\n  the button started a Claude run and, with Claude not installed, was told to sign\n  in to a product they were not using. It now follows the agent you selected, and\n  the button is no longer disabled for Cursor users.\n- **Searching Settings missed several controls.** Some settings were never\n  registered in the search index, so typing their name found nothing. Fixed for\n  the Agent and Runtime categories, with a check that fails the build if it\n  happens again.\n- **Absolute paths inside your project were treated as escapes.** Cursor's CLI\n  writes full paths by default, and a full path to a file inside your own worktree\n  was classified as leaving it — so ordinary reads were refused during planning.\n\n### Added\n\n- **Agents can run through a harness layer.** Limboo now drives agents through\n  Vercel AI SDK 7's harness abstraction as well as its own integrations, so a new\n  agent runtime becomes an adapter rather than a new code path. Pi is available;\n  Claude Code runs through it behind an opt-in switch. Everything above the\n  adapter — the conversation, permissions, memory, search, the work graph, the\n  runtime panel — is unchanged, because they all sit on one seam.\n- **A sandbox that runs on your own worktree.** Every shipped sandbox for that\n  abstraction is either a cloud service or a private filesystem, and neither\n  fits: your repository must not leave the machine, and the agent has to edit the\n  actual files that git, the diff viewer and checkpoints are watching. Limboo has\n  its own, rooted at the session's worktree, with the same containment rules the\n  rest of the app enforces — nothing outside the worktree, and never the app's own\n  database, settings or secrets.\n- **Settings opens as a workspace tab.** An icon beside the close button promotes\n  the dialog into an editor tab, the way a diff opens. Both surfaces render the\n  same panels, so nothing drifts. The tab has no Cancel: settings apply as you\n  change them, exactly as they already did.\n- **An update channel you can choose.** Settings › Updates now offers Stable or\n  Beta. A beta is never downloaded in the background — you are shown its release\n  notes and decide.\n\n### Changed\n\n- **Settings panels are flat rows.** The Agent and MCP categories wrapped groups\n  of settings in bordered panels while every other category used plain labelled\n  rows, which made them look like a different application. The boxes are gone.\n  Every input, button and select now uses one corner radius.\n- **The Agent panel is reorganised.** Providers became Harnesses and now reads as\n  one list instead of two hand-built cards. Connection and reliability moved to\n  Runtime, where the rest of the supervision settings live. A section that\n  contained no settings at all was removed, and the remainder is ordered by the\n  decision you are making: which agent, which model, what it may do, what\n  contains it.\n- **The model hint stopped being wrong.** It named a default the app had not used\n  for several versions, because the text was typed by hand next to the value it\n  described. It is now derived from that value.\n\n### Security\n\n- **Built-in tools on the harness path are gated by Limboo.** The harness\n  abstraction has two separate approval surfaces, and the one Limboo had wired\n  covers only tools the host supplies — built-in file writes and shell commands\n  are governed by a different setting that defaults to allowing everything. On\n  that path an agent could have written files and run commands without Limboo's\n  permission gate. Every built-in tool call now suspends the turn and asks, using\n  the same authority, the same risk labels, the same dialogs and the same audit\n  trail as every other agent.\n- **A harness that cannot ask for permission is refused.** Rather than run it with\n  weaker enforcement, Limboo declines to start it and says so. This is not\n  theoretical: the Codex adapter reports that it cannot request approval for its\n  shell tool, so it is registered as unavailable with the reason shown rather than\n  offered and then failing.\n- **The harness setup step asks first.** Preparing a harness for its first run\n  downloads its agent CLI, which is the only time Limboo reaches the network\n  outside talking to your agent and fetching contributor avatars. The exact\n  commands are read from the adapter and shown to you for approval once, and the\n  approval is tied to those commands — if a later version changes them, you are\n  asked again. Without approval the run does not start.\n- **Credentials are passed through, never stored.** A harness receives an API key\n  only if your own environment already has one, from an explicitly named list.\n  Nothing is written to settings, accepted over the app's internal channels, put\n  on a command line, or logged. A gap in log redaction that could have printed\n  those variables is closed.\n- **Reads on the harness path cannot be gated, and the setting says so.** The\n  underlying runtime allows built-in file reads unconditionally, so\n  \"auto-approve reads\" has no effect there. Rather than leave a control that looks\n  like it works, the setting explains the limitation.\n\n### Known limitations\n\n- **Beta builds are not released builds.** Features may change or be removed\n  before release. Settings and session data move forward but not back, so a build\n  made after this one may not read data this one wrote. Keep a stable install for\n  work you cannot repeat.\n- **The harness path is off by default.** Claude Code and Cursor continue to run\n  through their own integrations. Turn the harness on in Settings › Agent ›\n  Harnesses if you want to try it; you will be asked to approve its setup step\n  first.\n- **A harness conversation does not resume.** Each message starts a fresh\n  conversation with the underlying runtime. The alternative failed on every second\n  message, so this is deliberate until the resume format is handled properly.\n- **Codex is unavailable.** Its adapter cannot ask for permission before running\n  shell commands. It is listed with that reason rather than hidden."
   }
 ];
 
 /** Every released version, newest first. */
 export const RELEASE_INDEX: ReleaseIndexEntry[] = [
+  {
+    "version": "1.20.0",
+    "date": "2026-08-31",
+    "channel": "stable",
+    "summary": "Limboo 1.20.0 makes the agent harness actually run. 1.19.0 repaired its\npackaging; this release fixes the three separate reasons a run still could not\nstart, gives harness conversations memory between prompts, and moves the\nharness runtime somewhere it belongs.",
+    "detailed": true
+  },
   {
     "version": "1.19.0",
     "date": "2026-08-30",
@@ -545,7 +471,7 @@ export const RELEASE_INDEX: ReleaseIndexEntry[] = [
     "date": "2026-08-12",
     "channel": "beta",
     "summary": "The first beta. Two bugs that made Cursor sessions unusable are fixed, agents can\nnow run through a swappable harness layer instead of one hardcoded integration,\nand Settings opens as a workspace tab. This build is published for testing ahead\nof a stable release — read the warning at the top of these notes before\ninstalling it over a working copy.",
-    "detailed": true
+    "detailed": false
   },
   {
     "version": "1.17.0",

--- a/src/shared/releaseNotes.generated.ts
+++ b/src/shared/releaseNotes.generated.ts
@@ -22,6 +22,59 @@ export interface ReleaseNotesEntry {
 /** Newest first. */
 export const RELEASE_NOTES: ReleaseNotesEntry[] = [
   {
+    version: '1.20.0',
+    date: '2026-08-31',
+    markdown: `Limboo 1.20.0 makes the agent harness actually run. 1.19.0 repaired its
+packaging; this release fixes the three separate reasons a run still could not
+start, gives harness conversations memory between prompts, and moves the
+harness runtime somewhere it belongs.
+
+### Fixed
+
+- **The harness could not start a run at all — for three independent reasons.**
+  Its one-time setup was refused by Limboo's own path guard on its very first
+  command, so the install could never begin. No network port was ever handed to
+  the agent bridge, which the harness requires and refuses to start without. And
+  the method the adapter uses to reach that bridge was missing, so a run that got
+  past the first two failed the moment the bridge came up. Each of these was
+  enough on its own; all three are fixed, and the setup now completes.
+- **Setup failures were retried forever instead of being reported.** A refusal
+  that mentioned the network — such as the sandbox network policy blocking the
+  download — was mistaken for a dropped connection and retried, though the same
+  setting would produce it again immediately. Refusals are now recognised for
+  what they are and reported once, with the reason.
+- **A failed setup command said nothing useful.** If one of the approved commands
+  ran and failed — a large download timing out is enough — it surfaced as a
+  generic failed run. It now reports what failed and what the tool itself said to
+  do about it, and is not retried: the package manager records the install as
+  complete even when part of it failed, so re-running it fails identically.
+- **Every prompt started a new conversation, and left a process behind.** Each
+  turn opened a fresh harness session without ending the previous one, so the
+  agent forgot the turn before and one background process accumulated per prompt.
+- **Non-Anthropic harnesses could never authenticate.** They were handed
+  Anthropic's credential variable names instead of their own, because the
+  credential lookup read the configured harness rather than the one the selected
+  model actually runs on.
+
+### Changed
+
+- **The harness keeps its runtime inside Limboo's own data directory.** It used
+  to be placed next to your worktree, which is Limboo-owned for a session with a
+  worktree — but a session without one is rooted at your repository, so its
+  runtime landed beside your project folder. It now always lives under Limboo's
+  application data, never in your repository and never next to it. Existing
+  installs will re-run the one-time setup once, in the new location.
+- **The setup panel says where the commands run.** It listed the two commands and
+  nothing else, so copying them into a terminal was the obvious thing to try —
+  and it fails, because the lockfile they install from is written into the setup
+  directory first. The panel now names that directory and the files placed in it.
+  Your existing approval still stands: the commands themselves have not changed.
+- **The agent harness packages were updated** (\`@ai-sdk/harness\` 1.0.91,
+  \`@ai-sdk/harness-claude-code\` 1.0.94). Every assumption Limboo makes about
+  their internals — where the runtime is installed, how the bridge binds, which
+  harnesses can be permission-gated — was re-checked against the new versions.`,
+  },
+  {
     version: '1.19.0',
     date: '2026-08-30',
     markdown: `Limboo 1.19.0 repairs the agent harness, which could not install itself in any
@@ -218,141 +271,6 @@ channel as an opt-in path for future prereleases.
 
 ### Known limitations
 
-- **The harness path is off by default.** Claude Code and Cursor continue to run
-  through their own integrations. Turn the harness on in Settings › Agent ›
-  Harnesses if you want to try it; you will be asked to approve its setup step
-  first.
-- **A harness conversation does not resume.** Each message starts a fresh
-  conversation with the underlying runtime. The alternative failed on every second
-  message, so this is deliberate until the resume format is handled properly.
-- **Codex is unavailable.** Its adapter cannot ask for permission before running
-  shell commands. It is listed with that reason rather than hidden.`,
-  },
-  {
-    version: '1.18.0-beta.2',
-    date: '2026-08-12',
-    markdown: `The first beta. Two bugs that made Cursor sessions unusable are fixed, agents can
-now run through a swappable harness layer instead of one hardcoded integration,
-and Settings opens as a workspace tab. This build is published for testing ahead
-of a stable release — read the warning at the top of these notes before
-installing it over a working copy.
-
-### Fixed
-
-- **Cursor sessions denied every tool call.** The hook runner read the event name
-  from a single payload key that the CLI does not always send. With no event name
-  it could not identify what was being asked, so it failed closed — which is the
-  correct posture, but it meant every read, search, shell command and edit was
-  refused, and nothing on screen said why. The event name now travels in the
-  runner's own arguments, where Limboo writes it, with five payload spellings as
-  fallbacks, and a genuine failure now names the missing key in the timeline
-  instead of denying silently.
-- **Four more ways a Cursor run could stall.** The permission helper could boot as
-  a GUI process instead of a script and then hang for the full ten-minute hook
-  timeout on every single tool call; nothing timed out while it waited for input;
-  a successful approval could be truncated on its way out and be read as a
-  refusal; and the sandbox denied the helper access to its own communication
-  socket. Each is fixed, and each failure now reports what happened.
-- **"Prompt me for everything" meant "deny everything".** Tightening the approval
-  policy withdrew the rule that let Cursor read files at all. Because the only way
-  to ask for permission on that path is the hook bridge, a session with hooks
-  unavailable was left unable to read or to ask. Reads and inspection commands
-  now keep their floor regardless of the policy; the permission gate still runs
-  on top of it.
-- **A Cursor session could stream as Claude Code.** The model was checked for
-  character shape rather than for which provider serves it, and every Cursor
-  model id passes that check — so a mis-routed model was handed to the Claude
-  integration and ran there, with no error anywhere. Routing now has an explicit
-  "unknown" answer, dispatch is exhaustive, and a model nothing claims fails by
-  name instead of quietly running somewhere.
-- **Commit-message generation always used Claude.** A Cursor-only user pressing
-  the button started a Claude run and, with Claude not installed, was told to sign
-  in to a product they were not using. It now follows the agent you selected, and
-  the button is no longer disabled for Cursor users.
-- **Searching Settings missed several controls.** Some settings were never
-  registered in the search index, so typing their name found nothing. Fixed for
-  the Agent and Runtime categories, with a check that fails the build if it
-  happens again.
-- **Absolute paths inside your project were treated as escapes.** Cursor's CLI
-  writes full paths by default, and a full path to a file inside your own worktree
-  was classified as leaving it — so ordinary reads were refused during planning.
-
-### Added
-
-- **Agents can run through a harness layer.** Limboo now drives agents through
-  Vercel AI SDK 7's harness abstraction as well as its own integrations, so a new
-  agent runtime becomes an adapter rather than a new code path. Pi is available;
-  Claude Code runs through it behind an opt-in switch. Everything above the
-  adapter — the conversation, permissions, memory, search, the work graph, the
-  runtime panel — is unchanged, because they all sit on one seam.
-- **A sandbox that runs on your own worktree.** Every shipped sandbox for that
-  abstraction is either a cloud service or a private filesystem, and neither
-  fits: your repository must not leave the machine, and the agent has to edit the
-  actual files that git, the diff viewer and checkpoints are watching. Limboo has
-  its own, rooted at the session's worktree, with the same containment rules the
-  rest of the app enforces — nothing outside the worktree, and never the app's own
-  database, settings or secrets.
-- **Settings opens as a workspace tab.** An icon beside the close button promotes
-  the dialog into an editor tab, the way a diff opens. Both surfaces render the
-  same panels, so nothing drifts. The tab has no Cancel: settings apply as you
-  change them, exactly as they already did.
-- **An update channel you can choose.** Settings › Updates now offers Stable or
-  Beta. A beta is never downloaded in the background — you are shown its release
-  notes and decide.
-
-### Changed
-
-- **Settings panels are flat rows.** The Agent and MCP categories wrapped groups
-  of settings in bordered panels while every other category used plain labelled
-  rows, which made them look like a different application. The boxes are gone.
-  Every input, button and select now uses one corner radius.
-- **The Agent panel is reorganised.** Providers became Harnesses and now reads as
-  one list instead of two hand-built cards. Connection and reliability moved to
-  Runtime, where the rest of the supervision settings live. A section that
-  contained no settings at all was removed, and the remainder is ordered by the
-  decision you are making: which agent, which model, what it may do, what
-  contains it.
-- **The model hint stopped being wrong.** It named a default the app had not used
-  for several versions, because the text was typed by hand next to the value it
-  described. It is now derived from that value.
-
-### Security
-
-- **Built-in tools on the harness path are gated by Limboo.** The harness
-  abstraction has two separate approval surfaces, and the one Limboo had wired
-  covers only tools the host supplies — built-in file writes and shell commands
-  are governed by a different setting that defaults to allowing everything. On
-  that path an agent could have written files and run commands without Limboo's
-  permission gate. Every built-in tool call now suspends the turn and asks, using
-  the same authority, the same risk labels, the same dialogs and the same audit
-  trail as every other agent.
-- **A harness that cannot ask for permission is refused.** Rather than run it with
-  weaker enforcement, Limboo declines to start it and says so. This is not
-  theoretical: the Codex adapter reports that it cannot request approval for its
-  shell tool, so it is registered as unavailable with the reason shown rather than
-  offered and then failing.
-- **The harness setup step asks first.** Preparing a harness for its first run
-  downloads its agent CLI, which is the only time Limboo reaches the network
-  outside talking to your agent and fetching contributor avatars. The exact
-  commands are read from the adapter and shown to you for approval once, and the
-  approval is tied to those commands — if a later version changes them, you are
-  asked again. Without approval the run does not start.
-- **Credentials are passed through, never stored.** A harness receives an API key
-  only if your own environment already has one, from an explicitly named list.
-  Nothing is written to settings, accepted over the app's internal channels, put
-  on a command line, or logged. A gap in log redaction that could have printed
-  those variables is closed.
-- **Reads on the harness path cannot be gated, and the setting says so.** The
-  underlying runtime allows built-in file reads unconditionally, so
-  "auto-approve reads" has no effect there. Rather than leave a control that looks
-  like it works, the setting explains the limitation.
-
-### Known limitations
-
-- **Beta builds are not released builds.** Features may change or be removed
-  before release. Settings and session data move forward but not back, so a build
-  made after this one may not read data this one wrote. Keep a stable install for
-  work you cannot repeat.
 - **The harness path is off by default.** Claude Code and Cursor continue to run
   through their own integrations. Turn the harness on in Settings › Agent ›
   Harnesses if you want to try it; you will be asked to approve its setup step

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -57,8 +57,21 @@ export interface HarnessBootstrapInfo {
   /** False when the adapter could not be loaded at all. */
   available: boolean;
   harnessId: string;
-  /** `null` when this harness installs nothing — there is nothing to approve. */
-  plan: { commands: string[]; files: string[]; fingerprint: string } | null;
+  /**
+   * `null` when this harness installs nothing — there is nothing to approve.
+   *
+   * `dir` is where the files are written and the commands are RUN — relative to
+   * the sandbox root, never absolute (an absolute one would carry the home
+   * directory into the renderer). Showing it is not decoration: the commands
+   * only work in that directory, because that is where the adapter just wrote
+   * the lockfile they install from.
+   */
+  plan: {
+    commands: string[];
+    files: string[];
+    dir?: string;
+    fingerprint: string;
+  } | null;
   /** True when the current plan's fingerprint matches the stored approval. */
   acked: boolean;
   /**


### PR DESCRIPTION
The AI SDK harness path could not complete a single run. Three independent blockers, each fatal on its own, plus five correctness gaps behind them.

## The three blockers

1. **The bootstrap's first command was refused by our own path guard.** `applyBootstrapRecipe` runs `mkdir -p "$BOOTSTRAP_DIR"` with the cwd set to `defaultWorkingDirectory`. `resolvePath`'s state-dir carve-out admits `<state>/.harness-bootstrap/…` but not `<state>` itself — `path.relative` of a path against itself is `''`, and an empty first segment matches no allow-list. Adds `resolveCwd`, kept separate from `resolvePath` so file I/O goes on refusing that directory.
2. **No port was ever exposed.** `allocatePort()` had no caller, so `ports` stayed empty and the adapter refused the run outright. Now allocated in `createSession`, with the holding listener released immediately before a spawn so the bridge can bind it.
3. **`getPortEndpoint` was missing.** The adapter reaches for it at both its attach and fresh-spawn paths. 1.0.80 called it unconditionally (a TypeError once the bridge came up); 1.0.94 feature-detects, which downgrades silently to the deprecated `getPortUrl`. Both are now implemented over one loopback resolver that keeps the exposure check and the `assertLoopbackOnly` assertion.

## Also fixed

- **Refusals were retried forever.** `HarnessBootstrapBlockedError` has to say the download is blocked by the sandbox *network* allowlist, and that word matched `classifyAgentError`'s transient-transport regex — so a standing policy decision was retried as a dropped socket. Refusals are now classified by error **class**, never by message text.
- **A failed bootstrap command said nothing useful.** It becomes `HarnessBootstrapFailedError`, carrying the adapter's own stderr and remedy, and is not retried: pnpm records an install as complete even when an optional dependency failed, so the re-run reports "Already up to date" and fails identically.
- **Every prompt opened a fresh conversation and leaked a bridge process** — the session was never parked and `resumeFrom` was pinned to `undefined`. Runs now `detach()` and persist the structured resume state under a `harness:<id>` key in `agent_provider_sessions` (its own key: the direct Claude SDK path already owns `anthropic` and stores a different shape). The cached sandbox is torn down whenever a resume is lost, or the respawned bridge races the parked one for the port.
- **Non-Anthropic harnesses could never authenticate.** `envKeysFor` read `settings.agent.harness.id`, but the harness follows the MODEL. Both call sites now share `harnessIdForRun`.

## Harness state leaves the user's project directory

It was placed in the worktree's parent — Limboo-owned for a worktree-backed session, but `resolveSessionRoot` falls back to the workspace path for a plain one, so `.harness-bootstrap/` and `.agent-runs/` landed **beside the user's repository** and the provider's carve-out granted access there. `stateRoot.ts` anchors every session at `{userData}/harness-state/<bucket>/`, holding a real link to the execution root (junction on win32) so the framework's `join` still lands on the worktree. Containment is unchanged: `realpathNearest` canonicalizes through the link before confinement, so the ordinary worktree check admits it — not a new carve-out.

## The consent surface

It showed two bare commands and nothing else, which invites pasting them into a shell — where they fail with `ERR_PNPM_NO_LOCKFILE`, because the lockfile they install from is written into the setup directory first. The panel now names that directory and the files placed in it. `bootstrapDir` is deliberately kept **out** of the consent fingerprint, which covers what executes — verified unchanged at `7bf0abe567fbfa55`, so existing approvals survive.

## Verification

Against the versions this tree ships (`@ai-sdk/harness` 1.0.91, `@ai-sdk/harness-claude-code` 1.0.94 — bumped by #123 while this was in progress), re-checking every hardcoded third-party literal: the bridge's `host: "0.0.0.0"` bind site (still exactly one, so `patchBridge` neither misses nor over-matches), `.harness-bootstrap` / `.agent-runs`, the bootstrap commands, `resolveBridgePort` still reading `ports`, and each adapter's `supportsBuiltinToolApprovals`.

- All three blockers **reproduce** against the pre-fix provider built from `HEAD`, and pass after.
- 19 provider checks against a real worktree, driving the exact call sequence `applyBootstrapRecipe` makes — including that nothing is written inside or beside the worktree, that crown jewels and out-of-workspace paths are still refused, and that file I/O into the state root is still refused.
- The adapter's real bootstrap commands were executed in a seeded directory and the install completes.
- `npm run lint` (0 errors), renderer build, main bundle, `check:unions`, `gen:notes --check` all pass.

`legacyClaudeSdk` still defaults to `true` — the harness stays opt-in. No persisted setting changed and `SETTINGS_VERSION` is not bumped.